### PR TITLE
fix(colors): tailwind.config como fonte única de cores (ADR-006)

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,22 +1,14 @@
 /** @type {import('tailwindcss').Config} */
+const { Colors } = require("./constants/Colors");
+
 module.exports = {
   content: ["app/**/*.*", "components/**/*.*"],
   presets: [require("nativewind/preset")],
   theme: {
     extend: {
       colors: {
-        light: {
-          background: "#F8F9FA",
-          text: "#333333",
-          outerText: "#F8F9FA",
-          backgroundCard: "rgba(255, 255, 255, 0.15)",
-        },
-        dark: {
-          background: "#333333",
-          text: "#F8F9FA",
-          outerText: "#333333",
-          backgroundCard: "rgba(255, 255, 255, 0d.15)",
-        },
+        light: Colors.light,
+        dark: Colors.dark,
       },
     },
   },


### PR DESCRIPTION
## O quê
Faz o `tailwind.config.js` **importar as cores de `constants/Colors.js`** em vez de duplicá-las inline, cumprindo a parte da fonte única do ADR-006 (issue #49).

## Por quê
- As cores estavam **duplicadas** entre `constants/Colors.js` e `tailwind.config.js` — mudar um azul exigia editar dois lugares.
- O tema `dark` tinha um **bug de digitação**: `backgroundCard: "rgba(255, 255, 255, 0d.15)"` (o `0d`), que produzia uma cor inválida. Agora o valor vem da fonte única, já correto (`0.15`).

## Como
```js
const { Colors } = require("./constants/Colors");
// ...
colors: { light: Colors.light, dark: Colors.dark }
```

## Validação
- Config carregado via **jiti** (o loader que o Tailwind 3.4 usa) + `resolveConfig` → cores resolvem corretamente e `dark.backgroundCard` volta a ser `rgba(255, 255, 255, 0.15)`.
- `prettier --check` passa; ESLint ignora arquivos de config (esperado).

## Escopo
Fecha a pendência de fonte única da #49. As outras duas partes da #49 (`Colors.js` consolidado e `shadow` como objeto RN nativo) já estavam prontas em commits anteriores.

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)