### PR TITLE
fix(style): shadow nativo do RN e correção de CSS-web (ADR-006, #50)

### DIFF
--- a/app/index.jsx
+++ b/app/index.jsx
@@ -7,7 +7,7 @@ import MyView from "@/components/MyView";
 
 import { useThemedStyles } from "@/hook/useThemedStyle";
 
-import { Colors } from "@/constants/Colors";
+import { shadow } from "@/constants/Colors";
 import MyHeader from "@/components/MyHeader";
 //#endregion
 
@@ -21,7 +21,6 @@ export default function Home() {
     card: {
       width: "50%",
       height: "50%",
-      boxShadow: Colors.shadow,
     },
     button: {
       backgroundColor: theme.background,
@@ -30,7 +29,7 @@ export default function Home() {
   return (
     <MyView style={styles.container}>
       <MyHeader />
-      <Card mode="contained" style={styles.card}>
+      <Card mode="contained" style={[styles.card, shadow]}>
         <Card.Title
           title="Olá, mundo!"
           subtitle="Esse pedaço de tecnologia está em construção!"

--- a/components/MyButton.jsx
+++ b/components/MyButton.jsx
@@ -1,4 +1,4 @@
-import { Colors } from "@/constants/Colors";
+import { Colors, shadow } from "@/constants/Colors";
 import { useState } from "react";
 import { Text, useColorScheme } from "react-native";
 import { Button } from "react-native-paper";
@@ -39,13 +39,16 @@ export function MyIconButton({
 
   return (
     <Button
-      style={{
-        border: isSelected ? "none" : "solid 1px #333",
-        borderRadius: "100%",
-        padding: 3,
-        boxShadow: Colors.shadow,
-        overflow: "hidden",
-      }}
+      style={[
+        {
+          borderWidth: isSelected ? 0 : 1,
+          borderColor: "#333",
+          borderRadius: 9999,
+          padding: 3,
+          overflow: "hidden",
+        },
+        shadow,
+      ]}
       buttonColor={isSelected ? Colors.secondary : "transparent"}
       textColor={theme.text}
       mode="outlined"

--- a/components/MyHistory.jsx
+++ b/components/MyHistory.jsx
@@ -6,7 +6,7 @@ import { StyleSheet, Text, useColorScheme, View } from "react-native";
 import MyView from "./MyView";
 import { getCategoryInfo } from "./categoryUtils";
 
-import { Colors } from "@/constants/Colors";
+import { Colors, shadow } from "@/constants/Colors";
 
 import { get, getByMonth } from "@/infra/database";
 import Checkbox from "expo-checkbox";
@@ -20,53 +20,38 @@ export default function MyHistory({ cardStyle, tableName, reload }) {
   const { displayName, unity } = getCategoryInfo(tableName);
 
   const styles = StyleSheet.create({
-    container: {
-      display: "flex",
-      alignItems: "center",
-      width: "100%",
-      gap: 10,
-    },
+    container: { alignItems: "center", width: "100%", gap: 10 },
     card: {
-      display: "flex",
       width: "100%",
-      maxWidth: 40,
+      maxWidth: 640,
       gap: 10,
       backgroundColor: theme.backgroundCard,
       borderRadius: 6,
       padding: 1,
       paddingTop: 1,
       paddingBottom: 1,
-      boxShadow: Colors.shadow,
     },
-    text: {
-      width: "fit",
-      color: theme.text,
-      fontWeight: "bold",
-      fontSize: 18,
-    },
+    text: { color: theme.text, fontWeight: "bold", fontSize: 18 },
     subtext: {
       color: theme.text,
-      opacity: "50%",
+      opacity: 0.5,
       fontWeight: "bold",
       fontSize: 12,
     },
     title: {
       fontSize: 18,
-      display: "flex",
       flexDirection: "row",
       justifyContent: "space-between",
       width: "100%",
     },
     score: {
       textAlign: "center",
-      lineHeight: "auto",
       color: theme.text,
       fontWeight: "bold",
       fontSize: 16,
       width: 24,
       height: 24,
       borderRadius: 100,
-      boxShadow: "0 4 4 0 rgba(0,0,0,.25)",
     },
   });
 
@@ -90,7 +75,7 @@ export default function MyHistory({ cardStyle, tableName, reload }) {
       onClick={() => router.navigate(`(history)/${tableName}`)}
     >
       {Object.entries(data).map(([id, obj]) => (
-        <MyView style={[styles.card, cardStyle]} key={id}>
+        <MyView style={[styles.card, cardStyle, shadow]} key={id}>
           <Text style={styles.title}>
             <Text style={styles.text}>
               {getDate(obj.date)} {displayName}
@@ -129,46 +114,32 @@ export function MyMonthHistory({ cardStyle, tableName, month }) {
   const { displayName, unity } = getCategoryInfo(tableName);
 
   const styles = StyleSheet.create({
-    container: {
-      display: "flex",
-      alignItems: "center",
-      width: "100%",
-      gap: 10,
-    },
+    container: { alignItems: "center", width: "100%", gap: 10 },
     card: {
-      display: "flex",
       width: "100%",
-      maxWidth: 40,
+      maxWidth: 640,
       gap: 10,
       backgroundColor: theme.backgroundCard,
       borderRadius: 6,
       padding: 1,
       paddingTop: 1,
       paddingBottom: 1,
-      boxShadow: Colors.shadow,
     },
-    text: {
-      width: "fit",
-      color: theme.text,
-      fontWeight: "bold",
-      fontSize: 18,
-    },
+    text: { color: theme.text, fontWeight: "bold", fontSize: 18 },
     subtext: {
       color: theme.text,
-      opacity: "50%",
+      opacity: 0.5,
       fontWeight: "bold",
       fontSize: 12,
     },
     title: {
       fontSize: 18,
-      display: "flex",
       flexDirection: "row",
       justifyContent: "space-between",
       width: "100%",
     },
     score: {
       textAlign: "center",
-      lineHeight: "auto",
       color: theme.text,
       fontWeight: "bold",
       fontSize: 16,
@@ -198,7 +169,7 @@ export function MyMonthHistory({ cardStyle, tableName, month }) {
       onClick={() => router.navigate(`(history)/${tableName}`)}
     >
       {Object.entries(data).map(([id, obj]) => (
-        <MyView style={[styles.card, cardStyle]} key={id}>
+        <MyView style={[styles.card, cardStyle, shadow]} key={id}>
           <Text style={styles.title}>
             <Text style={styles.text}>
               {getDate(obj.date)} {displayName}
@@ -237,46 +208,32 @@ export function MyExerciseHistory({ tableName, reload }) {
   const { displayName, unity } = getCategoryInfo(tableName);
 
   const styles = StyleSheet.create({
-    container: {
-      display: "flex",
-      alignItems: "center",
-      width: "100%",
-      gap: 10,
-    },
+    container: { alignItems: "center", width: "100%", gap: 10 },
     card: {
-      display: "flex",
       width: "100%",
-      maxWidth: 40,
+      maxWidth: 640,
       gap: 10,
       backgroundColor: theme.backgroundCard,
       borderRadius: 6,
       padding: 1,
       paddingTop: 1,
       paddingBottom: 1,
-      boxShadow: Colors.shadow,
     },
-    text: {
-      width: "fit",
-      color: theme.text,
-      fontWeight: "bold",
-      fontSize: 18,
-    },
+    text: { color: theme.text, fontWeight: "bold", fontSize: 18 },
     subtext: {
       color: theme.text,
-      opacity: "50%",
+      opacity: 0.5,
       fontWeight: "bold",
       fontSize: 12,
     },
     title: {
       fontSize: 18,
-      display: "flex",
       flexDirection: "row",
       justifyContent: "space-between",
       width: "100%",
     },
     score: {
       textAlign: "center",
-      lineHeight: "auto",
       color: theme.text,
       fontWeight: "bold",
       fontSize: 16,
@@ -303,7 +260,7 @@ export function MyExerciseHistory({ tableName, reload }) {
   return (
     <MyView style={styles.container}>
       {Object.entries(data).map(([id, obj]) => (
-        <MyView style={styles.card} key={id}>
+        <MyView style={[styles.card, shadow]} key={id}>
           <Text style={styles.title}>
             <Text style={styles.text}>
               {getDate(obj.date)} {obj.trainingTime} - {displayName}

--- a/components/Score.jsx
+++ b/components/Score.jsx
@@ -1,11 +1,11 @@
 import { StyleSheet, useColorScheme } from "react-native";
 import MyButton from "./MyButton";
 import MyView from "./MyView";
-import { Colors } from "@/constants/Colors";
+import { Colors, shadow } from "@/constants/Colors";
 
 export default function Score({ onPress, value, ...props }) {
   const colorScheme = useColorScheme();
-  const theme = Colors[colorScheme] ?? theme.light;
+  const theme = Colors[colorScheme] ?? Colors.light;
   const scoreRange = 5;
 
   const styles = StyleSheet.create({
@@ -20,7 +20,6 @@ export default function Score({ onPress, value, ...props }) {
       width: 24,
       height: 24,
       borderRadius: 100,
-      boxShadow: Colors.shadow,
     },
     text: {
       fontWeight: "bold",
@@ -30,7 +29,7 @@ export default function Score({ onPress, value, ...props }) {
   });
   return (
     <MyView
-      className="flex h-fit justify-start items-center flex-row gap-[.6rem]"
+      className="flex justify-start items-center flex-row gap-2.5"
       style={styles.container}
     >
       {Array.from({ length: scoreRange + 1 }).map((_, index) => (
@@ -39,7 +38,7 @@ export default function Score({ onPress, value, ...props }) {
           title={index}
           value={value}
           compact="true"
-          style={styles.button}
+          style={[styles.button, shadow]}
           titleStyle={styles.title}
           {...props}
           onPress={() => onPress(index)}


### PR DESCRIPTION
## O quê
Issue #50 (migração de estilo / ADR-006): trocar `boxShadow: Colors.shadow` — que virou `undefined` quando `shadow` deixou de ser propriedade de `Colors` e passou a export próprio — pelo objeto `shadow` nativo do React Native, espalhado no array de `style`. De quebra, corrige valores de CSS-web que não funcionam no Android.

## Por quê
- `Colors.shadow` não existe mais → a sombra simplesmente não renderizava.
- `boxShadow` é CSS web; em RN a sombra é um objeto (`elevation`/`shadowColor`/…) aplicado via `style`.
- Vários valores CSS-web (`h-fit`, `gap-[.6rem]`, `width: "fit"`, `opacity: "50%"`, `lineHeight: "auto"`, `borderRadius: "100%"`, `display: "flex"`, `maxWidth: 40` de um `40rem` mal convertido) são ignorados ou quebram no Android.

## Arquivos
- [x] **`components/Score.jsx`** — shadow via `[styles.button, shadow]`; bug `theme` antes de existir corrigido (`?? Colors.light`); `h-fit` removido, `gap-[.6rem]` → `gap-2.5`.
- [x] **`app/index.jsx`** — shadow no `<Card>`; import passou a trazer só `shadow` (Colors ficou sem uso).
- [x] **`components/MyButton.jsx`** (`MyIconButton`) — shadow via array; `border`/`borderRadius` de CSS-web → props RN nativas.
- [x] **`components/MyHistory.jsx`** (3 componentes) — shadow nos cards; `maxWidth 40 → 640`, `opacity 0.5`, remoção de `lineHeight/width/display` inválidos e do `boxShadow` hardcoded do score.

## Validação
- 🔍 `grep boxShadow` e `grep Colors.shadow` no projeto → **zero ocorrências**.
- Babel parseia os 4 arquivos sem erro; `prettier --check` passa.
- App valida no dispositivo (erro inicial reportado era só cache do Metro).

## Notas para o reviewer
- Nenhuma lógica de negócio alterada (fora o bug pontual do fallback de tema no Score).
- Nenhuma mudança de config/dependências.

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)