### PR TITLE
Add database schema and persistence layer for TinyBase

### DIFF
--- a/docs/03-decisoes-tecnicas.md
+++ b/docs/03-decisoes-tecnicas.md
@@ -101,7 +101,7 @@ Cada entrada documenta uma decisão de arquitetura: o contexto, a decisão tomad
 
 **Contexto:** o código de armazenamento existente já era genérico por `tableName` (uma função `add`/`get` reaproveitada entre métricas), mas nada garantia que cada tabela manteria o mesmo formato de dados ao longo do tempo — exatamente o tipo de fragmentação silenciosa que costuma virar a "arquitetura que não escala" dos reboots anteriores.
 
-**Decisão:** uma única tabela `registros`, com o campo `tipo` distinguindo as métricas (5 no MVP), e um `TablesSchema` do TinyBase (`setTablesSchema`) que obriga todo registro — de qualquer métrica — a manter o formato-base definido no documento de Escopo & MVP.
+**Decisão:** uma única tabela `records`, com o campo `tipo` distinguindo as métricas (5 no MVP), e um `TablesSchema` do TinyBase (`setTablesSchema`) que obriga todo registro — de qualquer métrica — a manter o formato-base definido no documento de Escopo & MVP.
 
 **Consequências:**
 
@@ -109,6 +109,37 @@ Cada entrada documenta uma decisão de arquitetura: o contexto, a decisão tomad
 - O schema barra, em tempo de execução, qualquer registro que fuja do formato combinado — a fragmentação fica estruturalmente mais difícil de acontecer de novo.
 - Campos específicos de cada métrica (ex: horário de dormir do sono) continuam possíveis via o campo `detalhes`, sem abrir mão do formato comum.
 - Adicionar a 6ª métrica (autocuidado) no futuro é só um novo valor de `tipo` — sem tabela nova, sem migração de schema.
+
+---
+
+## ADR-008 — Schema frouxo com `detalhes` JSON durante o desenvolvimento
+
+**Status:** decidido, e explicitamente temporário. Refina o ADR-007 (tabela única) para a fase de desenvolvimento — não o contradiz.
+
+**Contexto:** o ADR-007 definiu uma tabela única `records` com um formato-base. Mas os dados reais de hoje são heterogêneos entre métricas: água tem `min`/`max`/`ideal`/`quantity`, exercício tem `training`/`cardio`/`trainingTime`/`duration`, estudo tem `duration`, todas têm `score`/`observation`. Definir agora um schema rígido que contemple todos esses campos exigiria decidir a forma final do dado **antes** de ter uso real que informe o que é necessário e o que sobra. Isso é decisão prematura — o tipo de over-engineering que trava o desenvolvimento sem retorno.
+
+**Decisão:** durante o desenvolvimento (até o M2 fechar com uso real), usar um schema deliberadamente **frouxo**: apenas os campos comuns a todas as métricas ficam no nível superior do registro; tudo que é específico de cada métrica vai serializado como JSON num único campo `detalhes`.
+
+Campos de topo (estáveis, comuns a todas as métricas):
+
+- `tipo` — "water", "sleep", "exercise", "feeding", "study"
+- `date` — data do registro (ISO)
+- `criadoEm` — timestamp
+
+Campo flexível:
+
+- `detalhes` — string JSON com todo o resto (`score`, `observation`, e os campos próprios de cada métrica). O schema não conhece nem valida o conteúdo de `detalhes`.
+
+**Por que assim, agora:**
+
+- Não perde nenhum dado atual — todos os campos existentes cabem em `detalhes` sem conversão.
+- Não obriga a decidir a forma final do dado antes do uso real.
+- Destrava a persistência (#47) imediatamente: dá pra persistir hoje, com os dados como estão.
+- É reversível: quando o schema maduro chegar (M2+), lê-se o `detalhes` JSON dos registros antigos e transforma-se no formato novo, uma vez só.
+
+**Trade-off aceito:** com `detalhes` como JSON string, perde-se validação de tipo por campo e queries diretas por campo interno (ex: "registros com `score > 3`" fica mais trabalhoso). Na fase de desenvolvimento isso não é necessário — query por campo interno é otimização de quando houver uso e volume. Troca-se validação futura por flexibilidade agora, conscientemente.
+
+**Quando revisitar:** ao entrar no M2 (modelo unificado maduro), com base no que o uso real mostrar ser necessário/desnecessário. Este ADR existe justamente para que essa decisão temporária não seja confundida com descuido no futuro — o `detalhes` como JSON solto é deliberado, não acidental.
 
 ---
 

--- a/infra/database.js
+++ b/infra/database.js
@@ -1,22 +1,53 @@
 import { createStore } from "tinybase";
 
-const store = createStore();
+const TABELA = "registros";
 
-function add(tableName, data) {
-  const id = Math.random().toString(30).substring(2, 20);
-  store.setRow(tableName, id, data);
+export const store = createStore().setTablesSchema({
+  [TABELA]: {
+    tipo: { type: "string" },
+    date: { type: "string" },
+    detalhes: { type: "string", default: "{}" },
+    criadoEm: { type: "number" },
+  },
+});
+
+function hidratar(id, linha) {
+  const { detalhes, ...resto } = linha;
+  let extras;
+  try {
+    extras = JSON.parse(detalhes || "{}");
+  } catch {
+    extras = {};
+  }
+  return { id, ...resto, ...extras };
 }
 
-function get(tableName) {
-  const data = store.getTable(tableName);
-  if (Object.keys(data).length !== 0) return data;
+export function add(tipo, data) {
+  const { date, ...detalhes } = data;
+  store.addRow(TABELA, {
+    tipo,
+    date: date ?? "",
+    detalhes: JSON.stringify(detalhes ?? {}),
+    criadoEm: Date.now(),
+  });
 }
-function getByMonth(tableName, month) {
-  const data = get(tableName) ?? {};
-  return Object.values(data).filter((row) => {
+
+export function get(tipo) {
+  const linhas = store.getTable(TABELA);
+  const resultado = {};
+  for (const [id, linha] of Object.entries(linhas)) {
+    if (linha.tipo === tipo) {
+      resultado[id] = hidratar(id, linha);
+    }
+  }
+  return resultado;
+}
+
+export function getByMonth(tipo, month) {
+  const registros = get(tipo);
+  return Object.values(registros).filter((row) => {
+    if (!row.date) return false;
     const date = new Date(row.date);
     return date.getMonth() === month;
   });
 }
-
-export { add, get, getByMonth };

--- a/infra/database.js
+++ b/infra/database.js
@@ -1,9 +1,9 @@
 import { createStore } from "tinybase";
 
-const TABELA = "registros";
+const TABLE = "records";
 
 export const store = createStore().setTablesSchema({
-  [TABELA]: {
+  [TABLE]: {
     tipo: { type: "string" },
     date: { type: "string" },
     detalhes: { type: "string", default: "{}" },
@@ -24,7 +24,7 @@ function hidratar(id, linha) {
 
 export function add(tipo, data) {
   const { date, ...detalhes } = data;
-  store.addRow(TABELA, {
+  store.addRow(TABLE, {
     tipo,
     date: date ?? "",
     detalhes: JSON.stringify(detalhes ?? {}),
@@ -33,7 +33,7 @@ export function add(tipo, data) {
 }
 
 export function get(tipo) {
-  const linhas = store.getTable(TABELA);
+  const linhas = store.getTable(TABLE);
   const resultado = {};
   for (const [id, linha] of Object.entries(linhas)) {
     if (linha.tipo === tipo) {
@@ -44,8 +44,8 @@ export function get(tipo) {
 }
 
 export function getByMonth(tipo, month) {
-  const registros = get(tipo);
-  return Object.values(registros).filter((row) => {
+  const records = get(tipo);
+  return Object.values(records).filter((row) => {
     if (!row.date) return false;
     const date = new Date(row.date);
     return date.getMonth() === month;

--- a/infra/persistence.js
+++ b/infra/persistence.js
@@ -1,0 +1,29 @@
+import { openDatabaseSync } from "expo-sqlite";
+import { createExpoSqlitePersister } from "tinybase/persisters/persister-expo-sqlite";
+import { useCreatePersister } from "tinybase/ui-react";
+import { store } from "./database";
+
+const db = openDatabaseSync("back_on_track.db");
+
+/**
+ * Chame este hook uma vez, perto da raiz do app (ex: app/_layout.jsx),
+ * pra carregar os dados salvos ao abrir o app e manter tudo persistido
+ * automaticamente a cada mudança. Sem isso, a store do TinyBase vive só
+ * na memória e some a cada reload — é o motivo mais provável do app
+ * hoje parecer "só visual".
+ *
+ * Nota: o persister de Expo SQLite ainda é experimental (a própria
+ * documentação do TinyBase marca assim), então vale testar bem o ciclo
+ * salvar → fechar o app → abrir de novo → dado ainda está lá.
+ */
+export function useRegistrosPersistencia() {
+  useCreatePersister(
+    store,
+    (store) => createExpoSqlitePersister(store, db, "back_on_track"),
+    [],
+    async (persister) => {
+      await persister.startAutoLoad();
+      await persister.startAutoSave();
+    },
+  );
+}


### PR DESCRIPTION
## Summary
This PR refactors the database layer to use TinyBase's schema validation and adds a persistence layer using Expo SQLite, enabling data to survive app restarts instead of being lost on reload.

## Key Changes
- **Database schema definition**: Added explicit table schema for "registros" with typed fields (tipo, date, detalhes, criadoEm) to enforce data structure
- **Data hydration**: Introduced `hidratar()` function to deserialize the `detalhes` JSON field and merge it back into the row object for easier consumption
- **Query filtering by type**: Modified `get()` and `getByMonth()` to filter records by `tipo` field instead of using separate tables
- **Persistence layer**: Created new `persistence.js` module with `useRegistrosPersistencia()` hook that:
  - Opens an Expo SQLite database ("back_on_track.db")
  - Automatically loads saved data on app startup
  - Automatically saves all store changes to disk
- **Export changes**: Converted all database functions to named exports and exported the store instance for use in persistence setup

## Implementation Details
- The `detalhes` field stores extra data as JSON, allowing flexible schema extension without modifying the core table structure
- The `criadoEm` timestamp is automatically set to `Date.now()` on record creation
- The persistence hook should be called once near the app root (e.g., `app/_layout.jsx`) to ensure data survives app lifecycle
- Note: Expo SQLite persister is marked as experimental in TinyBase documentation and should be tested thoroughly

https://claude.ai/code/session_01DvxxAMLtRH9YGk12oVDe7h