### PR TITLE
Padroniza campos de topo do schema para inglês

### DIFF
--- a/docs/02-escopo-mvp.md
+++ b/docs/02-escopo-mvp.md
@@ -18,6 +18,8 @@ O MVP cobre **5 métricas**, que são as que já existem como tela no código at
 
 Como as 6 métricas compartilham estrutura, o sistema é modelado em torno de uma única entidade genérica - o **Registro** - em vez de 6 entidades separadas e desconectadas. Campos específicos de cada métrica fica isolada num campo de detalhes, mantendo o núcleo do modelo uniforme.
 
+> **Modelo-alvo (M2), não o schema atual.** A `interface Registro` abaixo é o **modelo maduro** que o projeto pretende alcançar no M2 — a forma final de seus campos ainda será decidida nesse marco, informada pelo uso real. Ela **não** descreve o schema em uso hoje. O schema atual é o **frouxo do ADR-008** (`type` / `date` / `details` / `createdAt`), no qual os campos específicos de cada métrica ficam serializados como JSON dentro de `details`.
+
 ```typescript
 interface Registro {
   id: string;
@@ -45,7 +47,7 @@ Exemplos de uso por tipo:
 
 Essa modelagem permite que **toda tela de registro, toda listagem e todo histórico usem o mesmo componente base**, variando apenas configuração.
 
-> **Nota de estado atual:** o código de hoje ainda não usa este modelo. As telas gravam campos ad-hoc por métrica (`score`, `min`/`max`/`ideal`, `observation`, `training`/`cardio`, etc.). Convergir os dados existentes para este `Registro` unificado é o trabalho de M1 no roadmap.O campo de observação livre passa a se chamar `nota` (o código atual usa `observation`).
+> **Nota de estado atual:** o código de hoje ainda não usa este modelo. As telas gravam campos ad-hoc por métrica (`score`, `min`/`max`/`ideal`, `observation`, `training`/`cardio`, etc.), que hoje vivem serializados dentro do campo `details` do schema frouxo do ADR-008 (`type`/`date`/`details`/`createdAt`). Convergir os dados existentes para este `Registro` unificado é o trabalho de M1 no roadmap. O campo de observação livre passa a se chamar `nota` (o código atual usa `observation`).
 
 ## Escopo do MVP (v1)
 

--- a/docs/03-decisoes-tecnicas.md
+++ b/docs/03-decisoes-tecnicas.md
@@ -101,45 +101,45 @@ Cada entrada documenta uma decisão de arquitetura: o contexto, a decisão tomad
 
 **Contexto:** o código de armazenamento existente já era genérico por `tableName` (uma função `add`/`get` reaproveitada entre métricas), mas nada garantia que cada tabela manteria o mesmo formato de dados ao longo do tempo — exatamente o tipo de fragmentação silenciosa que costuma virar a "arquitetura que não escala" dos reboots anteriores.
 
-**Decisão:** uma única tabela `records`, com o campo `tipo` distinguindo as métricas (5 no MVP), e um `TablesSchema` do TinyBase (`setTablesSchema`) que obriga todo registro — de qualquer métrica — a manter o formato-base definido no documento de Escopo & MVP.
+**Decisão:** uma única tabela `records`, com o campo `type` distinguindo as métricas (5 no MVP), e um `TablesSchema` do TinyBase (`setTablesSchema`) que obriga todo registro — de qualquer métrica — a manter o formato-base definido no documento de Escopo & MVP.
 
 **Consequências:**
 
 - A query da tela "hoje" (tudo que foi registrado hoje, não importa a métrica) vira uma leitura só, não cinco.
 - O schema barra, em tempo de execução, qualquer registro que fuja do formato combinado — a fragmentação fica estruturalmente mais difícil de acontecer de novo.
-- Campos específicos de cada métrica (ex: horário de dormir do sono) continuam possíveis via o campo `detalhes`, sem abrir mão do formato comum.
-- Adicionar a 6ª métrica (autocuidado) no futuro é só um novo valor de `tipo` — sem tabela nova, sem migração de schema.
+- Campos específicos de cada métrica (ex: horário de dormir do sono) continuam possíveis via o campo `details`, sem abrir mão do formato comum.
+- Adicionar a 6ª métrica (autocuidado) no futuro é só um novo valor de `type` — sem tabela nova, sem migração de schema.
 
 ---
 
-## ADR-008 — Schema frouxo com `detalhes` JSON durante o desenvolvimento
+## ADR-008 — Schema frouxo com `details` JSON durante o desenvolvimento
 
 **Status:** decidido, e explicitamente temporário. Refina o ADR-007 (tabela única) para a fase de desenvolvimento — não o contradiz.
 
 **Contexto:** o ADR-007 definiu uma tabela única `records` com um formato-base. Mas os dados reais de hoje são heterogêneos entre métricas: água tem `min`/`max`/`ideal`/`quantity`, exercício tem `training`/`cardio`/`trainingTime`/`duration`, estudo tem `duration`, todas têm `score`/`observation`. Definir agora um schema rígido que contemple todos esses campos exigiria decidir a forma final do dado **antes** de ter uso real que informe o que é necessário e o que sobra. Isso é decisão prematura — o tipo de over-engineering que trava o desenvolvimento sem retorno.
 
-**Decisão:** durante o desenvolvimento (até o M2 fechar com uso real), usar um schema deliberadamente **frouxo**: apenas os campos comuns a todas as métricas ficam no nível superior do registro; tudo que é específico de cada métrica vai serializado como JSON num único campo `detalhes`.
+**Decisão:** durante o desenvolvimento (até o M2 fechar com uso real), usar um schema deliberadamente **frouxo**: apenas os campos comuns a todas as métricas ficam no nível superior do registro; tudo que é específico de cada métrica vai serializado como JSON num único campo `details`.
 
 Campos de topo (estáveis, comuns a todas as métricas):
 
-- `tipo` — "water", "sleep", "exercise", "feeding", "study"
+- `type` — "water", "sleep", "exercise", "feeding", "study"
 - `date` — data do registro (ISO)
-- `criadoEm` — timestamp
+- `createdAt` — timestamp
 
 Campo flexível:
 
-- `detalhes` — string JSON com todo o resto (`score`, `observation`, e os campos próprios de cada métrica). O schema não conhece nem valida o conteúdo de `detalhes`.
+- `details` — string JSON com todo o resto (`score`, `observation`, e os campos próprios de cada métrica). O schema não conhece nem valida o conteúdo de `details`.
 
 **Por que assim, agora:**
 
-- Não perde nenhum dado atual — todos os campos existentes cabem em `detalhes` sem conversão.
+- Não perde nenhum dado atual — todos os campos existentes cabem em `details` sem conversão.
 - Não obriga a decidir a forma final do dado antes do uso real.
 - Destrava a persistência (#47) imediatamente: dá pra persistir hoje, com os dados como estão.
-- É reversível: quando o schema maduro chegar (M2+), lê-se o `detalhes` JSON dos registros antigos e transforma-se no formato novo, uma vez só.
+- É reversível: quando o schema maduro chegar (M2+), lê-se o `details` JSON dos registros antigos e transforma-se no formato novo, uma vez só.
 
-**Trade-off aceito:** com `detalhes` como JSON string, perde-se validação de tipo por campo e queries diretas por campo interno (ex: "registros com `score > 3`" fica mais trabalhoso). Na fase de desenvolvimento isso não é necessário — query por campo interno é otimização de quando houver uso e volume. Troca-se validação futura por flexibilidade agora, conscientemente.
+**Trade-off aceito:** com `details` como JSON string, perde-se validação de tipo por campo e queries diretas por campo interno (ex: "registros com `score > 3`" fica mais trabalhoso). Na fase de desenvolvimento isso não é necessário — query por campo interno é otimização de quando houver uso e volume. Troca-se validação futura por flexibilidade agora, conscientemente.
 
-**Quando revisitar:** ao entrar no M2 (modelo unificado maduro), com base no que o uso real mostrar ser necessário/desnecessário. Este ADR existe justamente para que essa decisão temporária não seja confundida com descuido no futuro — o `detalhes` como JSON solto é deliberado, não acidental.
+**Quando revisitar:** ao entrar no M2 (modelo unificado maduro), com base no que o uso real mostrar ser necessário/desnecessário. Este ADR existe justamente para que essa decisão temporária não seja confundida com descuido no futuro — o `details` como JSON solto é deliberado, não acidental.
 
 ---
 

--- a/infra/database.js
+++ b/infra/database.js
@@ -4,47 +4,47 @@ const TABLE = "records";
 
 export const store = createStore().setTablesSchema({
   [TABLE]: {
-    tipo: { type: "string" },
+    type: { type: "string" },
     date: { type: "string" },
-    detalhes: { type: "string", default: "{}" },
-    criadoEm: { type: "number" },
+    details: { type: "string", default: "{}" },
+    createdAt: { type: "number" },
   },
 });
 
 function hidratar(id, linha) {
-  const { detalhes, ...resto } = linha;
+  const { details, ...resto } = linha;
   let extras;
   try {
-    extras = JSON.parse(detalhes || "{}");
+    extras = JSON.parse(details || "{}");
   } catch {
     extras = {};
   }
   return { id, ...resto, ...extras };
 }
 
-export function add(tipo, data) {
-  const { date, ...detalhes } = data;
+export function add(type, data) {
+  const { date, ...details } = data;
   store.addRow(TABLE, {
-    tipo,
+    type,
     date: date ?? "",
-    detalhes: JSON.stringify(detalhes ?? {}),
-    criadoEm: Date.now(),
+    details: JSON.stringify(details ?? {}),
+    createdAt: Date.now(),
   });
 }
 
-export function get(tipo) {
+export function get(type) {
   const linhas = store.getTable(TABLE);
   const resultado = {};
   for (const [id, linha] of Object.entries(linhas)) {
-    if (linha.tipo === tipo) {
+    if (linha.type === type) {
       resultado[id] = hidratar(id, linha);
     }
   }
   return resultado;
 }
 
-export function getByMonth(tipo, month) {
-  const records = get(tipo);
+export function getByMonth(type, month) {
+  const records = get(type);
   return Object.values(records).filter((row) => {
     if (!row.date) return false;
     const date = new Date(row.date);


### PR DESCRIPTION
Renomeia os campos de topo do schema em infra/database.js, alinhando-os com o restante do código (que já usa score, observation, date, etc.):

- tipo -> type
- detalhes -> details
- criadoEm -> createdAt

O nome da tabela (records) e a assinatura pública (add/get/getByMonth) já eram/continuam iguais; o conteúdo de details não muda.

Atualiza as referências de campo nos ADR-007 e ADR-008 e adiciona ao docs/02-escopo-mvp.md a distinção entre o modelo-alvo do M2 (interface Registro) e o schema frouxo em uso hoje (ADR-008).


Claude-Session: https://claude.ai/code/session_01UNeExScmHd8xLoAG8iy5yY