### PR TITLE
feat(infra): enable TinyBase persistence in root layout

### DIFF
--- a/app/_layout.jsx
+++ b/app/_layout.jsx
@@ -3,10 +3,13 @@ import "@/global.css";
 import { Stack } from "expo-router";
 import { useColorScheme } from "react-native";
 import { Colors } from "@/constants/Colors";
+import { useRegistrosPersistencia } from "@/infra/persistence";
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();
   const theme = Colors[colorScheme] ?? Colors.light;
+
+  useRegistrosPersistencia();
 
   return (
     <Stack


### PR DESCRIPTION
## What changes

Calls the `useRegistrosPersistencia()` hook inside `RootLayout` in `app/_layout.jsx`, enabling the TinyBase + Expo SQLite persister's `startAutoLoad`/`startAutoSave` on app startup.

## Why

PR #53 introduced the whole persistence layer (`infra/persistence.js`, typed schema in `infra/database.js`, `expo-sqlite`/`tinybase` deps), **but the hook was never called anywhere** — it was only exported. As a result the TinyBase store lived only in memory and data was lost on every reload, exactly the bug described in issue #47 ("saved until you reload").

This change is the final missing step to make the integration effective.

## Details

- 3 lines in `app/_layout.jsx`: import the hook (via the `@/infra/persistence` alias) + call it inside `RootLayout`.
- No signature or public API change.

## Checks

- ✅ `eslint .` clean
- ✅ `prettier --check` OK
- ✅ Alias `@/*` → `./*` resolves correctly

## Notes for the reviewer

- The Expo SQLite persister is marked **experimental** in the TinyBase docs. Manual validation of the full cycle is recommended before closing the issue: **save → close the app → reopen → confirm the data persists**. This runtime validation is not covered by lint.

Refs #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)