### PR TITLE
feat(components): migrate shared components to NativeWind (ADR-006)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Aplicação React Native para registro de métricas pessoais mínimas. O MVP cob
 2. [Escopo & MVP](docs/02-escopo-mvp.md) — modelo de domínio, o que entra na v1, non-goals
 3. [Decisões Técnicas (ADR)](docs/03-decisoes-tecnicas.md) — stack escolhida e o porquê de cada decisão
 4. [Roadmap de Milestones](docs/04-roadmap-milestones.md) — sequência de desenvolvimento (projeto em adaptação)
+5. [Guia de Migração de Estilo](docs/05-guia-migracao-estilo.md) — mapa de → para CSS-web → NativeWind
 
 ## Como usar esta documentação
 

--- a/app/(history)/water.jsx
+++ b/app/(history)/water.jsx
@@ -224,11 +224,7 @@ export default function Water() {
             />
             <Text style={styles.title}>ml</Text>
           </MyView>
-          <MyButton
-            style={{ height: "fit-content" }}
-            title="Salvar"
-            onPress={() => handleSubmit()}
-          />
+          <MyButton title="Salvar" onPress={() => handleSubmit()} />
         </MyView>
       </MyView>
       <MyHistory tableName={pathname} reload={reloadKey} />

--- a/components/MyButton.jsx
+++ b/components/MyButton.jsx
@@ -1,63 +1,65 @@
 // @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
 import { Colors, shadow } from "@/constants/Colors";
-import { useState } from "react";
-import { Text, useColorScheme } from "react-native";
-import { Button } from "react-native-paper";
+import { useColorScheme } from "nativewind";
+import { Pressable, Text } from "react-native";
 
 export default function MyButton({
   isSelected = false,
   title,
   Icon,
-  titleStyle,
-  styles,
+  titleClassName,
+  className,
+  style,
   ...props
 }) {
-  const colorScheme = useColorScheme();
-  const theme = Colors[colorScheme] ?? Colors.light;
-
   return (
-    <Button
-      buttonColor={isSelected ? Colors.secondary : Colors.primary}
-      textColor={theme.text}
-      mode="elevated"
-      style={styles}
+    <Pressable
+      className={`flex-row items-center justify-center rounded-full px-4 py-2 ${
+        isSelected ? "bg-secondary" : "bg-primary"
+      } ${className ?? ""}`}
+      style={[shadow, style]}
+      android_ripple={{ color: "#00000022" }}
       {...props}
     >
-      {title && <Text style={titleStyle}>{title}</Text>}
-      {Icon && <Icon size={24} color="#333" />}{" "}
-    </Button>
+      {title != null && (
+        <Text
+          className={`font-bold text-light-text dark:text-dark-text ${
+            titleClassName ?? ""
+          }`}
+        >
+          {title}
+        </Text>
+      )}
+      {Icon && <Icon size={24} color="#333" />}
+    </Pressable>
   );
 }
+
 export function MyIconButton({
   Icon,
   isSelected = false,
-  titleStyle,
-  styles,
+  className,
+  style,
   ...props
 }) {
-  const colorScheme = useColorScheme();
-  const theme = Colors[colorScheme] ?? Colors.light;
+  const { colorScheme } = useColorScheme();
+  const themeText =
+    colorScheme === "dark" ? Colors.dark.text : Colors.light.text;
 
   return (
-    <Button
-      style={[
-        {
-          borderWidth: isSelected ? 0 : 1,
-          borderColor: "#333",
-          borderRadius: 9999,
-          padding: 3,
-          overflow: "hidden",
-        },
-        shadow,
-      ]}
-      buttonColor={isSelected ? Colors.secondary : "transparent"}
-      textColor={theme.text}
-      mode="outlined"
+    <Pressable
+      className={`items-center justify-center overflow-hidden rounded-full p-[3px] ${
+        isSelected
+          ? "border-0 bg-secondary"
+          : "border border-[#333] bg-transparent"
+      } ${className ?? ""}`}
+      style={[shadow, style]}
+      android_ripple={{ color: "#00000022" }}
       {...props}
     >
       {Icon && (
-        <Icon size={40} color={isSelected ? Colors.primary : theme.text} />
+        <Icon size={40} color={isSelected ? Colors.primary : themeText} />
       )}
-    </Button>
+    </Pressable>
   );
 }

--- a/components/MyCheckbox.jsx
+++ b/components/MyCheckbox.jsx
@@ -4,26 +4,18 @@ import MyView from "./MyView";
 
 import { Colors } from "@/constants/Colors";
 import { Text } from "react-native";
-import { useThemedStyles } from "@/hook/useThemedStyle";
 
 export default function MyCheckbox({ label, onValueChange, value }) {
-  const styles = useThemedStyles((theme) => ({
-    container: { flexDirection: "row", alignItems: "center", gap: 6 },
-    text: {
-      fontWeight: "bold",
-      fontSize: 16,
-      color: theme.text,
-    },
-  }));
-
   return (
-    <MyView style={styles.container}>
+    <MyView className="flex-row items-center gap-1.5">
       <Checkbox
         color={value ? Colors.primary : "gray"}
         value={value}
         onValueChange={onValueChange}
       />
-      <Text style={styles.text}>{label}</Text>
+      <Text className="font-bold text-base text-light-text dark:text-dark-text">
+        {label}
+      </Text>
     </MyView>
   );
 }

--- a/components/MyHeader.jsx
+++ b/components/MyHeader.jsx
@@ -4,21 +4,12 @@ import { useEffect, useState } from "react";
 import Button from "./MyButton";
 import { getCategoryInfo, CATEGORY_MAP } from "./categoryUtils";
 import { router, usePathname } from "expo-router";
-import {
-  FlatList,
-  ScrollView,
-  ScrollViewBase,
-  useColorScheme,
-} from "react-native";
-import { Colors } from "@/constants/Colors";
+import { ScrollView } from "react-native";
 
 export default function MyHeader() {
-  const colorScheme = useColorScheme();
   const pathname = usePathname().substring(1);
 
   const { key } = getCategoryInfo(pathname);
-
-  const theme = Colors[colorScheme] ?? Colors.light;
 
   const [selectedButton, setSelectedButton] = useState(key);
 
@@ -43,21 +34,16 @@ export default function MyHeader() {
   return (
     <ScrollView
       horizontal={true}
-      style={{
-        flexGrow: 0,
-        padding: 12,
-        gap: 20,
-        backgroundColor: theme.background,
-      }}
+      className="grow-0 bg-light-background p-3 dark:bg-dark-background"
     >
       {Object.entries(CATEGORY_MAP).map(([index, category]) => (
         <Button
-          style={{ marginHorizontal: "1rem" }}
+          className="mx-4"
           key={index}
           title={category.displayName}
           isSelected={selectedButton === index}
           onPress={() => handleButtonSelection(index)}
-        ></Button>
+        />
       ))}
     </ScrollView>
   );
@@ -77,24 +63,15 @@ export function MyMonthHeader({ onMonthSelect }) {
   }
 
   return (
-    <ScrollView
-      horizontal={true}
-      style={{
-        width: "100%",
-        flexGrow: 0,
-        padding: 12,
-        gap: 20,
-        backgroundColor: "transparent",
-      }}
-    >
+    <ScrollView horizontal={true} className="w-full grow-0 bg-transparent p-3">
       {months.map((month, index) => (
         <Button
-          style={{ marginHorizontal: "1rem" }}
+          className="mx-4"
           key={index}
           title={month.toUpperCase().substring(0, 3)}
           isSelected={selectedMonth === index}
           onPress={() => handleButtonSelection(index)}
-        ></Button>
+        />
       ))}
     </ScrollView>
   );

--- a/components/MyInput.jsx
+++ b/components/MyInput.jsx
@@ -1,17 +1,34 @@
 // @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
-import { Colors } from "@/constants/Colors";
-import { Text, TextInput, useColorScheme, View } from "react-native";
+import { Text, TextInput } from "react-native";
 import MyView from "./MyView";
 
 export default function MyInput({
-  className,
   label,
   placeholder = "--",
+  value,
+  onChangeText,
+  className,
   style,
   ...props
 }) {
-  const colorScheme = useColorScheme();
-  const theme = Colors[colorScheme] ?? Colors.light;
-
-  return <MyView className="w-fit"></MyView>;
+  return (
+    <MyView safe={false} className="gap-1.5 self-start">
+      {label != null && (
+        <Text className="font-bold text-base text-light-text dark:text-dark-text">
+          {label}
+        </Text>
+      )}
+      <TextInput
+        className={`rounded border border-[#333] px-2 py-1 text-light-text dark:text-dark-text ${
+          className ?? ""
+        }`}
+        style={style}
+        placeholder={placeholder}
+        placeholderTextColor="#888"
+        value={value}
+        onChangeText={onChangeText}
+        {...props}
+      />
+    </MyView>
+  );
 }

--- a/components/MyView.jsx
+++ b/components/MyView.jsx
@@ -1,14 +1,11 @@
 // @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
-import { Colors } from "@/constants/Colors";
-import { useColorScheme, View } from "react-native";
+import { View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 export default function MyView({ className, style, safe = true, ...props }) {
-  const colorScheme = useColorScheme();
-  const themes = Colors[colorScheme] || Colors.light;
-  if (!safe) return <View className={className} style={style} {...props} />;
-
   const insets = useSafeAreaInsets();
+
+  if (!safe) return <View className={className} style={style} {...props} />;
 
   return (
     <View

--- a/components/Score.jsx
+++ b/components/Score.jsx
@@ -1,46 +1,20 @@
 // @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
-import { StyleSheet, useColorScheme } from "react-native";
 import MyButton from "./MyButton";
 import MyView from "./MyView";
-import { Colors, shadow } from "@/constants/Colors";
+import { shadow } from "@/constants/Colors";
 
 export default function Score({ onPress, value, ...props }) {
-  const colorScheme = useColorScheme();
-  const theme = Colors[colorScheme] ?? Colors.light;
   const scoreRange = 5;
 
-  const styles = StyleSheet.create({
-    container: {
-      display: "flex",
-      flexDirection: "row",
-      flexWrap: "wrap",
-      padding: 6,
-    },
-    button: {
-      justifyContent: "center",
-      width: 24,
-      height: 24,
-      borderRadius: 100,
-    },
-    text: {
-      fontWeight: "bold",
-      fontSize: 16,
-      color: theme.text,
-    },
-  });
   return (
-    <MyView
-      className="flex justify-start items-center flex-row gap-2.5"
-      style={styles.container}
-    >
+    <MyView className="flex-row flex-wrap items-center justify-start gap-2.5 p-1.5">
       {Array.from({ length: scoreRange + 1 }).map((_, index) => (
         <MyButton
           key={index}
           title={index}
-          value={value}
-          compact="true"
-          style={[styles.button, shadow]}
-          titleStyle={styles.title}
+          className="h-6 w-6 justify-center rounded-full"
+          style={shadow}
+          titleClassName="text-base"
           {...props}
           onPress={() => onPress(index)}
           isSelected={value === index}

--- a/docs/05-guia-migracao-estilo.md
+++ b/docs/05-guia-migracao-estilo.md
@@ -1,0 +1,89 @@
+# Guia de Migração de Estilo — CSS-web → NativeWind
+
+O código atual mistura três coisas: `StyleSheet`/`useThemedStyles`, `className` (NativeWind) e valores de CSS web (`rem`, `boxShadow`, `fit-content`) que não são nativos do React Native. Eles renderizam no preview do navegador, mas quebram ou são ignorados no Android.
+
+Este guia é o mapa "de → para" pra migrar cada tela pra um sistema só (NativeWind), com valores que funcionam no Android.
+
+## Regra mental
+
+Não existe `rem` no React Native nativo. `16px` no navegador ≈ `1rem`. A base do RN é o **número puro** (`fontSize: 16`), sem unidade. Na prática, para converter `rem` → número: **multiplique por 16** (`1.6rem` → `26`, arredondando; `.4rem` → `6`; `1.2rem` → `19`). Ajuste no olho depois, rodando no Android.
+
+No NativeWind, o Tailwind já usa uma escala própria (`text-base`, `p-2`, etc.) que resolve isso — então prefira as classes da escala a valores arbitrários `[..]`.
+
+## Tabela de conversão
+
+| CSS-web (atual)                            | NativeWind (className)                | Observação                                 |
+| ------------------------------------------ | ------------------------------------- | ------------------------------------------ |
+| `fontSize: "1.6rem"`                       | `text-2xl` (~24px) ou `text-[24px]`   | prefira a escala; evite `text-[1.6rem]`    |
+| `fontSize: "1.2rem"`                       | `text-lg` (~18px)                     |                                            |
+| `fontSize: 18`                             | `text-lg`                             | número já era válido, mas unifique         |
+| `fontWeight: "bold"`                       | `font-bold`                           |                                            |
+| `padding: ".4rem"`                         | `p-1.5` (~6px)                        |                                            |
+| `padding: 10`                              | `p-2.5` (10px)                        |                                            |
+| `gap: "1rem"`                              | `gap-4` (16px)                        |                                            |
+| `gap: ".6rem"`                             | `gap-2.5` (~10px)                     |                                            |
+| `borderRadius: ".6rem"`                    | `rounded-md`                          |                                            |
+| `borderRadius: "100%"`                     | `rounded-full`                        | `100%` não existe em RN                    |
+| `maxWidth: "40rem"`                        | `max-w-[640px]`                       |                                            |
+| `width: "fit"` / `"fit-content"`           | `self-start` ou remover               | RN não tem fit-content; a View já encolhe  |
+| `height: "fit-content"`                    | remover                               | idem                                       |
+| `display: "flex"`                          | remover                               | tudo em RN já é flex; string dá warning    |
+| `flexDirection: "row"`                     | `flex-row`                            |                                            |
+| `border: "solid 1px #333"`                 | `border border-[#333]`                | RN quer borderWidth + borderColor          |
+| `boxShadow: Colors.shadow`                 | `style={shadow}` (import)             | ver abaixo — sombra fica fora do className |
+| `backgroundColor: "#333"` / `bg-[#333333]` | `bg-dark-background`                  | use o token, não o hex hardcoded           |
+| `color: "white"`                           | `text-white`                          |                                            |
+| `color: theme.text`                        | `text-light-text dark:text-dark-text` | NativeWind resolve dark/light sozinho      |
+
+## Cores: use os tokens, não os hex
+
+Depois que o `tailwind.config.js` passa a importar do `Colors.js`, você tem estes tokens no `className`:
+
+- `bg-primary`, `text-primary`, `border-primary` (azul `#2E5A88`)
+- `bg-secondary` (verde `#4CAF50`)
+- `bg-light-background` / `bg-dark-background`
+- `text-light-text` / `text-dark-text`
+- `bg-light-backgroundCard` / `bg-dark-backgroundCard`
+
+Nunca mais escreva `bg-[#2E5A88]` ou `bg-[#333333]` — quando a cor mudar no `Colors.js`, o token acompanha sozinho; o hex hardcoded não.
+
+## Dark mode
+
+NativeWind lê o color scheme do sistema com o prefixo `dark:`. Isso substitui todo o padrão atual de `Colors[colorScheme] ?? Colors.light` espalhado em cada componente:
+
+```jsx
+// antes: lógica manual de tema em cada arquivo
+const theme = Colors[colorScheme] ?? Colors.light;
+<View style={{ backgroundColor: theme.background }} />
+
+// depois: NativeWind resolve
+<View className="bg-light-background dark:bg-dark-background" />
+```
+
+Pra isso funcionar, garanta que o `darkMode` do NativeWind está ativo (o preset já cuida disso na maioria dos setups) e que o app declara suporte a dark mode no `app.json` (`"userInterfaceStyle": "automatic"`).
+
+> **Estado atual (#60):** o `app.json` está travado em `"userInterfaceStyle": "dark"` — o app roda só em dark hoje. Escreva as classes no formato `text-light-x dark:text-dark-x` mesmo assim (custo zero e já fica pronto): com o app em dark, o variant `dark:` sempre vence. Trocar para `"automatic"` e ligar o tema claro de verdade é um passo separado (follow-up), fora do escopo da migração de estilo.
+
+## Sombra: o único caso que NÃO vai pro className
+
+Sombra em RN é um objeto de estilo (elevation no Android), não uma classe utilitária limpa. Mantenha via `style`, importando o objeto `shadow` corrigido:
+
+```jsx
+import { shadow } from "@/constants/Colors";
+
+<View className="bg-light-backgroundCard rounded-md p-2.5" style={shadow} />;
+```
+
+Pode combinar `className` + `style` no mesmo elemento sem problema — o `className` cuida do layout/cor, o `style` cuida da sombra.
+
+## Ordem de ataque, por arquivo
+
+1. Comece por **um** arquivo já unificado como referência (sugiro `water.jsx`, a métrica mais simples).
+2. Rode no Android **antes e depois** — compare lado a lado.
+3. Só passe pro próximo arquivo quando o anterior renderizar igual (ou melhor) no Android.
+4. Componentes compartilhados primeiro (`MyView`, `MyButton`, `Score`, `MyCheckbox`), telas depois — assim a correção do componente já beneficia todas as telas que o usam.
+
+## Não esqueça
+
+- Os **componentes compartilhados já foram migrados** em #60 (`MyButton`/`MyIconButton` reescritos com `Pressable` + `className`, `MyView`, `Score`, `MyCheckbox`, `MyHeader`, e `MyInput` implementado). Ao migrar as telas, confie neles: passe `className`/`titleClassName` ao `MyButton` (a API antiga `styles`/`titleStyle` foi removida) e use os tokens de cor em vez de hex.
+- O `MyButton` agora expõe `className`, `titleClassName`, `style` (escape hatch p/ objeto RN como a `shadow`) — não passe mais valores CSS-web (`marginHorizontal: "1rem"`, `height: "fit-content"`); use `mx-4`, `self-start`, etc.

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,6 +7,8 @@ module.exports = {
   theme: {
     extend: {
       colors: {
+        primary: Colors.primary,
+        secondary: Colors.secondary,
         light: Colors.light,
         dark: Colors.dark,
       },


### PR DESCRIPTION
Refs #60 — último item da Milestone 1.

## O que muda

Migra os **componentes compartilhados** para NativeWind (`className` + `dark:` variants), eliminando o estado misto `StyleSheet`/`useThemedStyles`/`style` inline que o ADR-006 ataca. Escopo: pasta `components/` + pré-requisito no `tailwind.config.js`. As telas (`app/`) ficam para PRs incrementais seguintes, guiadas pelo `docs/05-guia-migracao-estilo.md`.

## Decisões

- **MyButton/MyIconButton → `Pressable` + `className`** (sai o `Button` do react-native-paper como autoridade de estilo — Paper segue como dep por causa do `Card`). Ripple via `android_ripple`, elevação via objeto `shadow` nativo. Nova API: `className`/`titleClassName`/`style`; removidas as props mortas `styles`/`titleStyle`.
- **`primary`/`secondary` expostos** no `tailwind.config.js` (aditivo).
- **Dark mode:** mantém o automático do NativeWind (sem `darkMode:"class"`). `app.json` fica em `"userInterfaceStyle": "dark"` neste ciclo (preserva comportamento); `dark:` sempre resolve para dark. Tema automático real = follow-up.
- **`MyInput`** implementado de verdade (era stub vazio).
- **`@ts-nocheck`** mantido (ADR-002).

## Correções de brinde

- Bug do `Score`: `titleStyle` apontava para chave `undefined` — números agora renderizam (inclusive o `0`).
- `MyView`: corrige *rules-of-hooks* (`useSafeAreaInsets` antes do early return) + remove lookups mortos de tema.
- Remove valores CSS-web quebrados: `marginHorizontal:"1rem"` → `mx-4`, `height:"fit-content"` (botão Salvar do histórico de água) removido.

## Validação

- ✅ `tsc --noEmit`, ESLint, Prettier
- ✅ `expo export` (web/Android/iOS) compila
- ⏳ **Falta teste no Android (antes/depois)** — ADR-006 exige validação runtime; aguardando o teste do autor.

## Notas para o revisor

- **Risco visual:** os botões deixam de ser Material (Paper) e passam a `Pressable` custom — comparar no Android o "Salvar" das métricas, a linha do `Score`, o `MyIconButton` em feeding, e o espaçamento do `MyHeader`.
- **Coordenação:** há um fix paralelo do *rules-of-hooks* do `MyView` em andamento; este PR já inclui essa correção — reconciliar no merge (rebase) se o outro entrar antes.

Refs #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)