### PR TITLE
feat(data): unified Registro model with full CRUD and edit/delete

### DIFF
--- a/app/(history)/water.jsx
+++ b/app/(history)/water.jsx
@@ -24,7 +24,7 @@ import { useThemedStyles } from "@/hook/useThemedStyle";
 export default function Water() {
   //#region variables
   const pathname = usePathname().substring(1);
-  const { displayName } = getCategoryInfo(pathname) ?? {};
+  const { displayName, unit } = getCategoryInfo(pathname) ?? {};
 
   //#region states
   const [date, setDate] = useState(getDate());
@@ -108,13 +108,13 @@ export default function Water() {
     setVisible(true);
     const data = {
       date: date.ISOdate,
+      quantity: Number(quantity) || 0,
+      unit,
+      note: observation,
       min,
       max,
       ideal,
-      quantity,
       score,
-      observation,
-      unity: "ml",
     };
     add("water", data);
     setReloadKey((prev) => prev + 1);

--- a/app/(history)/water.jsx
+++ b/app/(history)/water.jsx
@@ -3,7 +3,7 @@
 import { usePathname } from "expo-router";
 
 import { useState } from "react";
-import { Text, TextInput } from "react-native";
+import { ScrollView, Text, TextInput } from "react-native";
 import { Snackbar } from "react-native-paper";
 
 import { Colors } from "@/constants/Colors";
@@ -131,103 +131,114 @@ export default function Water() {
         onDismiss={onDismissSnackBar}
         action={{
           label: "Fechar",
+          onPress: onDismissSnackBar,
         }}
       >
-        Seus dados estão salvos! (Enquanto você não recarregar o app)
+        Registro salvo!
       </Snackbar>
-      <MyView style={styles.card}>
-        <Text style={styles.title}>
-          {date.displayDate} {displayName}
-        </Text>
+      <ScrollView
+        style={{ width: "100%" }}
+        contentContainerStyle={{
+          alignItems: "center",
+          gap: 16,
+          paddingBottom: 24,
+        }}
+        showsVerticalScrollIndicator={false}
+      >
+        <MyView style={styles.card}>
+          <Text style={styles.title}>
+            {date.displayDate} {displayName}
+          </Text>
 
-        {/* card Wrapper */}
-        <MyView style={styles.cardWrapper}>
-          {/* Input Wrapper */}
-          <MyView style={styles.inputWrapper}>
-            <Text style={styles.title}>MIN</Text>
+          {/* card Wrapper */}
+          <MyView style={styles.cardWrapper}>
+            {/* Input Wrapper */}
+            <MyView style={styles.inputWrapper}>
+              <Text style={styles.title}>MIN</Text>
+              <TextInput
+                style={styles.input}
+                placeholder="--"
+                value={min}
+                onChangeText={(value) => setMin(value)}
+              />
+            </MyView>
+            {/* Input Wrapper */}
+            <MyView style={styles.inputWrapper}>
+              <Text style={styles.title}>MAX</Text>
+              <TextInput
+                style={styles.input}
+                placeholder="--"
+                value={max}
+                onChangeText={(value) => setMax(value)}
+              />
+            </MyView>
+            {/* Input Wrapper */}
+            <MyView style={styles.inputWrapper}>
+              <Text style={styles.title}>IDEAL</Text>
+              <TextInput
+                style={styles.input}
+                placeholder="--"
+                value={ideal}
+                onChangeText={(value) => setIdeal(value)}
+              />
+            </MyView>
+          </MyView>
+
+          <Text style={styles.title}>Nota</Text>
+          <Score value={score} onPress={setScore} />
+          {/* OBS */}
+          <MyView className="gap-1">
+            <Text style={styles.title}>OBS:</Text>
             <TextInput
-              style={styles.input}
-              placeholder="--"
-              value={min}
-              onChangeText={(value) => setMin(value)}
+              value={observation}
+              onChangeText={(value) => setObservation(value)}
+              style={styles.textArea}
+              placeholder="Observações sobre água..."
             />
           </MyView>
-          {/* Input Wrapper */}
-          <MyView style={styles.inputWrapper}>
-            <Text style={styles.title}>MAX</Text>
-            <TextInput
-              style={styles.input}
-              placeholder="--"
-              value={max}
-              onChangeText={(value) => setMax(value)}
-            />
-          </MyView>
-          {/* Input Wrapper */}
-          <MyView style={styles.inputWrapper}>
-            <Text style={styles.title}>IDEAL</Text>
-            <TextInput
-              style={styles.input}
-              placeholder="--"
-              value={ideal}
-              onChangeText={(value) => setIdeal(value)}
-            />
-          </MyView>
-        </MyView>
 
-        <Text style={styles.title}>Nota</Text>
-        <Score value={score} onPress={setScore} />
-        {/* OBS */}
-        <MyView className="gap-1">
-          <Text style={styles.title}>OBS:</Text>
-          <TextInput
-            value={observation}
-            onChangeText={(value) => setObservation(value)}
-            style={styles.textArea}
-            placeholder="Observações sobre água..."
-          />
-        </MyView>
-
-        <MyView className="flex-row flex-wrap gap-[16] items-center">
-          <MyView
-            style={[
-              styles.card,
-              {
-                width: "50%",
-                height: "fit",
-                justifyContent: "center",
-                alignItems: "center",
-                flexGrow: 1,
-                display: "flex",
-                flexDirection: "row",
-              },
-            ]}
-          >
-            <Text
-              style={styles.title}
-              className="flex-nowrap text-white font-bold text-nowrap text-[16]"
-            >
-              {displayName} hoje
-            </Text>
-            <TextInput
+          <MyView className="flex-row flex-wrap gap-[16] items-center">
+            <MyView
               style={[
-                styles.input,
+                styles.card,
                 {
-                  backgroundColor: "#333",
-                  width: 5,
-                  height: 32,
-                  textAlign: "center",
+                  width: "50%",
+                  height: "fit",
+                  justifyContent: "center",
+                  alignItems: "center",
+                  flexGrow: 1,
+                  display: "flex",
+                  flexDirection: "row",
                 },
               ]}
-              placeholder="--"
-              value={quantity}
-              onChangeText={(value) => setQuantity(value)}
-            />
-            <Text style={styles.title}>ml</Text>
+            >
+              <Text
+                style={styles.title}
+                className="flex-nowrap text-white font-bold text-nowrap text-[16]"
+              >
+                {displayName} hoje
+              </Text>
+              <TextInput
+                style={[
+                  styles.input,
+                  {
+                    backgroundColor: "#333",
+                    width: 5,
+                    height: 32,
+                    textAlign: "center",
+                  },
+                ]}
+                placeholder="--"
+                value={quantity}
+                onChangeText={(value) => setQuantity(value)}
+              />
+              <Text style={styles.title}>ml</Text>
+            </MyView>
+            <MyButton title="Salvar" onPress={() => handleSubmit()} />
           </MyView>
-          <MyButton title="Salvar" onPress={() => handleSubmit()} />
         </MyView>
-      </MyView>
-      <MyHistory tableName={pathname} reload={reloadKey} />
+        <MyHistory tableName={pathname} reload={reloadKey} />
+      </ScrollView>
     </MyView>
   );
 }

--- a/app/(metrics)/_layout.jsx
+++ b/app/(metrics)/_layout.jsx
@@ -2,16 +2,24 @@
 import "@/global.css";
 
 import { Stack } from "expo-router";
-import { useColorScheme } from "react-native";
+import { useColorScheme, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Colors } from "@/constants/Colors";
 import MyHeader from "@/components/MyHeader";
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();
   const theme = Colors[colorScheme] ?? Colors.light;
+  const insets = useSafeAreaInsets();
 
   return (
-    <>
+    <View
+      style={{
+        flex: 1,
+        paddingTop: insets.top,
+        backgroundColor: theme.background,
+      }}
+    >
       <MyHeader />
       <Stack
         screenOptions={{
@@ -41,6 +49,6 @@ export default function RootLayout() {
           options={{ headerShown: false, title: "Estudo" }}
         />
       </Stack>
-    </>
+    </View>
   );
 }

--- a/app/(metrics)/exercise.jsx
+++ b/app/(metrics)/exercise.jsx
@@ -3,7 +3,7 @@
 import { useLocalSearchParams, usePathname } from "expo-router";
 
 import { useEffect, useState } from "react";
-import { Text, TextInput } from "react-native";
+import { ScrollView, Text, TextInput } from "react-native";
 import { Snackbar } from "react-native-paper";
 
 import MyButton from "@/components/MyButton";
@@ -148,88 +148,99 @@ export default function Exercise() {
         onDismiss={onDismissSnackBar}
         action={{
           label: "Fechar",
+          onPress: onDismissSnackBar,
         }}
       >
-        Seus dados estão salvos! (Enquanto você não recarregar o app)
+        Registro salvo!
       </Snackbar>
-      <MyView style={styles.card}>
-        <Text style={styles.title}>
-          {date.displayDate} {displayName}
-        </Text>
+      <ScrollView
+        style={{ width: "100%" }}
+        contentContainerStyle={{
+          alignItems: "center",
+          gap: 16,
+          paddingBottom: 24,
+        }}
+        showsVerticalScrollIndicator={false}
+      >
+        <MyView style={styles.card}>
+          <Text style={styles.title}>
+            {date.displayDate} {displayName}
+          </Text>
 
-        {/* card Wrapper */}
-        <MyView style={styles.cardWrapper}>
-          <MyCheckbox
-            value={training}
-            label="Treino"
-            onValueChange={() => setTraining(!training)}
-          />
-          <MyCheckbox
-            value={cardio}
-            label="Cardio"
-            onValueChange={() => setCardio(!cardio)}
-          />
-        </MyView>
+          {/* card Wrapper */}
+          <MyView style={styles.cardWrapper}>
+            <MyCheckbox
+              value={training}
+              label="Treino"
+              onValueChange={() => setTraining(!training)}
+            />
+            <MyCheckbox
+              value={cardio}
+              label="Cardio"
+              onValueChange={() => setCardio(!cardio)}
+            />
+          </MyView>
 
-        {/* Nota */}
-        <Text style={styles.title}>Nota</Text>
-        <Score value={score} onPress={setScore} />
+          {/* Nota */}
+          <Text style={styles.title}>Nota</Text>
+          <Score value={score} onPress={setScore} />
 
-        {/* OBS */}
-        <MyView className="gap-1">
-          <Text style={styles.title}>OBS:</Text>
-          <TextInput
-            value={observation}
-            onChangeText={(value) => setObservation(value)}
-            style={styles.textArea}
-            placeholder="Observações sobre o exercício..."
-          />
-        </MyView>
+          {/* OBS */}
+          <MyView className="gap-1">
+            <Text style={styles.title}>OBS:</Text>
+            <TextInput
+              value={observation}
+              onChangeText={(value) => setObservation(value)}
+              style={styles.textArea}
+              placeholder="Observações sobre o exercício..."
+            />
+          </MyView>
 
-        <MyView className="flex-row flex-wrap gap-4 items-center">
-          {/* Hora do exercício */}
-          <MyView style={[styles.card, { alignItems: "center" }]}>
-            <Text style={styles.title}>Hora do treino</Text>
-            <MyView className="flex-row gap-1 justify-center items-center">
-              <TextInput
-                style={styles.input}
-                placeholder="--"
-                value={trainingTimeHour}
-                onChangeText={(value) => setTrainingTimeHour(value)}
-              />
-              <Text style={styles.text}>:</Text>
-              <TextInput
-                style={styles.input}
-                placeholder="--"
-                value={trainingTimeMinute}
-                onChangeText={(value) => setTrainingTimeMinute(value)}
-              />
+          <MyView className="flex-row flex-wrap gap-4 items-center">
+            {/* Hora do exercício */}
+            <MyView style={[styles.card, { alignItems: "center" }]}>
+              <Text style={styles.title}>Hora do treino</Text>
+              <MyView className="flex-row gap-1 justify-center items-center">
+                <TextInput
+                  style={styles.input}
+                  placeholder="--"
+                  value={trainingTimeHour}
+                  onChangeText={(value) => setTrainingTimeHour(value)}
+                />
+                <Text style={styles.text}>:</Text>
+                <TextInput
+                  style={styles.input}
+                  placeholder="--"
+                  value={trainingTimeMinute}
+                  onChangeText={(value) => setTrainingTimeMinute(value)}
+                />
+              </MyView>
+            </MyView>
+            {/* Tempo de treino */}
+            <MyView style={[styles.card, { alignItems: "center" }]}>
+              <Text style={styles.title}>Tempo de treino</Text>
+              <MyView className="flex flex-row gap-1 items-end">
+                <TextInput
+                  style={styles.input}
+                  placeholder="--"
+                  value={trainingDurationHour}
+                  onChangeText={(value) => setTrainingDurationHour(value)}
+                />
+                <Text style={styles.text}>h</Text>
+                <TextInput
+                  style={styles.input}
+                  placeholder="--"
+                  value={trainingDurationMinute}
+                  onChangeText={(value) => setTrainingDurationMinute(value)}
+                />
+                <Text style={styles.text}>min</Text>
+              </MyView>
             </MyView>
           </MyView>
-          {/* Tempo de treino */}
-          <MyView style={[styles.card, { alignItems: "center" }]}>
-            <Text style={styles.title}>Tempo de treino</Text>
-            <MyView className="flex flex-row gap-1 items-end">
-              <TextInput
-                style={styles.input}
-                placeholder="--"
-                value={trainingDurationHour}
-                onChangeText={(value) => setTrainingDurationHour(value)}
-              />
-              <Text style={styles.text}>h</Text>
-              <TextInput
-                style={styles.input}
-                placeholder="--"
-                value={trainingDurationMinute}
-                onChangeText={(value) => setTrainingDurationMinute(value)}
-              />
-              <Text style={styles.text}>min</Text>
-            </MyView>
-          </MyView>
+          <MyButton title="Salvar" onPress={() => handleSubmit()} />
         </MyView>
-        <MyButton title="Salvar" onPress={() => handleSubmit()} />
-      </MyView>
-      <MyExerciseHistory tableName={pathname} reload={reloadKey} />
+        <MyExerciseHistory tableName={pathname} reload={reloadKey} />
+      </ScrollView>
     </MyView>
   );
 }

--- a/app/(metrics)/exercise.jsx
+++ b/app/(metrics)/exercise.jsx
@@ -1,8 +1,8 @@
 // @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
 //#region imports
-import { usePathname } from "expo-router";
+import { useLocalSearchParams, usePathname } from "expo-router";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Text, TextInput } from "react-native";
 import { Snackbar } from "react-native-paper";
 
@@ -14,8 +14,9 @@ import Score from "@/components/Score";
 
 import { getCategoryInfo } from "@/components/categoryUtils";
 import getDate from "@/constants/getDate";
+import { hhmmToMinutes, minutesToHHMM } from "@/constants/duration";
 
-import { add } from "@/infra/database";
+import { add, getById, update } from "@/infra/database";
 import { useThemedStyles } from "@/hook/useThemedStyle";
 
 //#endregion
@@ -23,7 +24,8 @@ import { useThemedStyles } from "@/hook/useThemedStyle";
 export default function Exercise() {
   //#region variables
   const pathname = usePathname().substring(1);
-  const { displayName } = getCategoryInfo(pathname) ?? {};
+  const { displayName, unit } = getCategoryInfo(pathname) ?? {};
+  const { id } = useLocalSearchParams();
 
   //#region states
   const [cardio, setCardio] = useState(false);
@@ -37,6 +39,24 @@ export default function Exercise() {
   const [trainingDurationHour, setTrainingDurationHour] = useState("");
   const [trainingDurationMinute, setTrainingDurationMinute] = useState("");
   const [visible, setVisible] = useState(false);
+  //#endregion
+
+  //#region edição
+  useEffect(() => {
+    if (!id) return;
+    const r = getById(id);
+    if (!r) return;
+    const [dh, dm] = minutesToHHMM(r.quantity).split(":");
+    setTrainingDurationHour(dh);
+    setTrainingDurationMinute(dm);
+    const [th, tm] = String(r.trainingTime ?? ":").split(":");
+    setTrainingTimeHour(th ?? "");
+    setTrainingTimeMinute(tm ?? "");
+    setTraining(!!r.training);
+    setCardio(!!r.cardio);
+    setObservation(r.note ?? r.observation ?? "");
+    setScore(r.score);
+  }, [id]);
   //#endregion
 
   const styles = useThemedStyles((theme) => ({
@@ -102,14 +122,18 @@ export default function Exercise() {
     setVisible(true);
     const data = {
       date: date.ISOdate,
+      quantity: hhmmToMinutes(
+        `${trainingDurationHour}:${trainingDurationMinute}`,
+      ),
+      unit,
+      note: observation,
       training,
       cardio,
       trainingTime: `${trainingTimeHour}:${trainingTimeMinute}`,
-      duration: `${trainingDurationHour}:${trainingDurationMinute}`,
       score,
-      observation,
     };
-    add("exercise", data);
+    if (id) update(id, data);
+    else add("exercise", data);
     setReloadKey((prev) => prev + 1);
   }
   function onDismissSnackBar() {

--- a/app/(metrics)/feeding.jsx
+++ b/app/(metrics)/feeding.jsx
@@ -1,8 +1,8 @@
 // @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
 //#region imports
-import { usePathname } from "expo-router";
+import { useLocalSearchParams, usePathname } from "expo-router";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Text, TextInput } from "react-native";
 import { Snackbar } from "react-native-paper";
 
@@ -15,7 +15,7 @@ import Score from "@/components/Score";
 import { getCategoryInfo } from "@/components/categoryUtils";
 import getDate from "@/constants/getDate";
 
-import { add } from "@/infra/database";
+import { add, getById, update } from "@/infra/database";
 import { useThemedStyles } from "@/hook/useThemedStyle";
 
 //#endregion
@@ -23,7 +23,8 @@ import { useThemedStyles } from "@/hook/useThemedStyle";
 export default function Feeding() {
   //#region variables
   const pathname = usePathname().substring(1);
-  const { displayName } = getCategoryInfo(pathname) ?? {};
+  const { displayName, unit } = getCategoryInfo(pathname) ?? {};
+  const { id } = useLocalSearchParams();
 
   //#region states
   const [date] = useState(getDate());
@@ -32,6 +33,17 @@ export default function Feeding() {
   const [quantity, setQuantity] = useState(0);
   const [reloadKey, setReloadKey] = useState(0);
   const [visible, setVisible] = useState(false);
+  //#endregion
+
+  //#region edição
+  useEffect(() => {
+    if (!id) return;
+    const r = getById(id);
+    if (!r) return;
+    setQuantity(Number(r.quantity) || 0);
+    setObservation(r.note ?? r.observation ?? "");
+    setScore(r.score);
+  }, [id]);
   //#endregion
 
   const styles = useThemedStyles((theme) => ({
@@ -98,11 +110,13 @@ export default function Feeding() {
     setVisible(true);
     const data = {
       date: date.ISOdate,
+      quantity: Number(quantity) || 0,
+      unit,
+      note: observation,
       score,
-      observation,
-      quantity,
     };
-    add("feeding", data);
+    if (id) update(id, data);
+    else add("feeding", data);
     setReloadKey((prev) => prev + 1);
   }
   function onDismissSnackBar() {

--- a/app/(metrics)/feeding.jsx
+++ b/app/(metrics)/feeding.jsx
@@ -3,7 +3,7 @@
 import { useLocalSearchParams, usePathname } from "expo-router";
 
 import { useEffect, useState } from "react";
-import { Text, TextInput } from "react-native";
+import { ScrollView, Text, TextInput } from "react-native";
 import { Snackbar } from "react-native-paper";
 
 import MyButton from "@/components/MyButton";
@@ -131,54 +131,65 @@ export default function Feeding() {
         onDismiss={onDismissSnackBar}
         action={{
           label: "Fechar",
+          onPress: onDismissSnackBar,
         }}
       >
-        Seus dados estão salvos! (Enquanto você não recarregar o app)
+        Registro salvo!
       </Snackbar>
-      <MyView style={styles.card}>
-        <Text style={styles.title}>
-          {date.displayDate} {displayName}
-        </Text>
+      <ScrollView
+        style={{ width: "100%" }}
+        contentContainerStyle={{
+          alignItems: "center",
+          gap: 16,
+          paddingBottom: 24,
+        }}
+        showsVerticalScrollIndicator={false}
+      >
+        <MyView style={styles.card}>
+          <Text style={styles.title}>
+            {date.displayDate} {displayName}
+          </Text>
 
-        {/* card Wrapper */}
-        <MyView style={styles.cardWrapper}>
-          <MyView className="flex-row gap-5">
-            {Array.from({ length: quantity }).map((_, index) => (
+          {/* card Wrapper */}
+          <MyView style={styles.cardWrapper}>
+            <MyView className="flex-row gap-5">
+              {Array.from({ length: quantity }).map((_, index) => (
+                <MyIconButton
+                  key={index}
+                  value={index}
+                  compact="true"
+                  // style={styles.button}
+                  // titleStyle={styles.title}
+                  isSelected={true}
+                  onPress={() => setQuantity(quantity - 1)}
+                />
+              ))}
               <MyIconButton
-                key={index}
-                value={index}
+                onPress={() => setQuantity(quantity + 1)}
                 compact="true"
-                // style={styles.button}
-                // titleStyle={styles.title}
-                isSelected={true}
-                onPress={() => setQuantity(quantity - 1)}
               />
-            ))}
-            <MyIconButton
-              onPress={() => setQuantity(quantity + 1)}
-              compact="true"
+            </MyView>
+          </MyView>
+
+          {/* Nota */}
+          <Text style={styles.title}>Nota</Text>
+          <Score value={score} onPress={setScore} />
+
+          {/* OBS */}
+          <MyView className="gap-1">
+            <Text style={styles.title}>OBS:</Text>
+            <TextInput
+              value={observation}
+              onChangeText={(value) => setObservation(value)}
+              style={styles.textArea}
+              placeholder="Observações sobre refeições..."
             />
           </MyView>
+
+          <MyButton title="Salvar" onPress={() => handleSubmit()} />
         </MyView>
-
-        {/* Nota */}
-        <Text style={styles.title}>Nota</Text>
-        <Score value={score} onPress={setScore} />
-
-        {/* OBS */}
-        <MyView className="gap-1">
-          <Text style={styles.title}>OBS:</Text>
-          <TextInput
-            value={observation}
-            onChangeText={(value) => setObservation(value)}
-            style={styles.textArea}
-            placeholder="Observações sobre refeições..."
-          />
-        </MyView>
-
-        <MyButton title="Salvar" onPress={() => handleSubmit()} />
-      </MyView>
-      <MyHistory tableName={pathname} reload={reloadKey} />
+        <MyHistory tableName={pathname} reload={reloadKey} />
+      </ScrollView>
     </MyView>
   );
 }

--- a/app/(metrics)/sleep.jsx
+++ b/app/(metrics)/sleep.jsx
@@ -1,7 +1,7 @@
 // @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
 //#region imports
 import { useEffect, useState } from "react";
-import { Text, TextInput } from "react-native";
+import { ScrollView, Text, TextInput } from "react-native";
 import { Snackbar } from "react-native-paper";
 
 import MyView from "@/components/MyView";
@@ -139,91 +139,102 @@ export default function Sleep() {
         onDismiss={onDismissSnackBar}
         action={{
           label: "Fechar",
+          onPress: onDismissSnackBar,
         }}
       >
-        Seus dados estão salvos! (Enquanto você não recarregar o app)
+        Registro salvo!
       </Snackbar>
-      <MyView style={styles.card}>
-        <Text style={styles.title}>
-          {date.displayDate} {displayName}
-        </Text>
+      <ScrollView
+        style={{ width: "100%" }}
+        contentContainerStyle={{
+          alignItems: "center",
+          gap: 16,
+          paddingBottom: 24,
+        }}
+        showsVerticalScrollIndicator={false}
+      >
+        <MyView style={styles.card}>
+          <Text style={styles.title}>
+            {date.displayDate} {displayName}
+          </Text>
 
-        {/* card Wrapper */}
-        <MyView style={styles.cardWrapper}>
-          {/* Input Wrapper */}
-          <MyView style={styles.inputWrapper}>
-            <Text style={styles.title}>MIN</Text>
-            <TextInput style={styles.input} placeholder="--" value={min} />
+          {/* card Wrapper */}
+          <MyView style={styles.cardWrapper}>
+            {/* Input Wrapper */}
+            <MyView style={styles.inputWrapper}>
+              <Text style={styles.title}>MIN</Text>
+              <TextInput style={styles.input} placeholder="--" value={min} />
+            </MyView>
+            {/* Input Wrapper */}
+            <MyView style={styles.inputWrapper}>
+              <Text style={styles.title}>MAX</Text>
+              <TextInput
+                style={styles.input}
+                placeholder="--"
+                value={max}
+                onChangeText={(value) => setMax(value)}
+              />
+            </MyView>
+            {/* Input Wrapper */}
+            <MyView style={styles.inputWrapper}>
+              <Text style={styles.title}>IDEAL</Text>
+              <TextInput style={styles.input} placeholder="--" value={ideal} />
+            </MyView>
           </MyView>
-          {/* Input Wrapper */}
-          <MyView style={styles.inputWrapper}>
-            <Text style={styles.title}>MAX</Text>
+
+          <Text style={styles.title}>Nota</Text>
+          <Score value={score} onPress={setScore} />
+
+          <MyView className="gap-1">
+            <Text style={styles.title}>OBS:</Text>
             <TextInput
-              style={styles.input}
-              placeholder="--"
-              value={max}
-              onChangeText={(value) => setMax(value)}
+              value={observation}
+              onChangeText={(value) => setObservation(value)}
+              style={styles.textArea}
+              placeholder="Observações sobre sono..."
             />
           </MyView>
-          {/* Input Wrapper */}
-          <MyView style={styles.inputWrapper}>
-            <Text style={styles.title}>IDEAL</Text>
-            <TextInput style={styles.input} placeholder="--" value={ideal} />
-          </MyView>
-        </MyView>
 
-        <Text style={styles.title}>Nota</Text>
-        <Score value={score} onPress={setScore} />
-
-        <MyView className="gap-1">
-          <Text style={styles.title}>OBS:</Text>
-          <TextInput
-            value={observation}
-            onChangeText={(value) => setObservation(value)}
-            style={styles.textArea}
-            placeholder="Observações sobre sono..."
-          />
-        </MyView>
-
-        <MyView className=" flex-row flex-wrap justify-center items-center gap-4">
-          <MyView
-            className="min-w-1/2 w-full rounded-md flex-row gap-4 justify-center items-start"
-            style={[
-              styles.card,
-              {
-                width: "50%",
-                justifyContent: "center",
-                alignItems: "center",
-                flexGrow: 1,
-                flexDirection: "row",
-              },
-            ]}
-          >
-            <Text
-              style={styles.title}
-              className="text-white font-bold text-2xl"
+          <MyView className=" flex-row flex-wrap justify-center items-center gap-4">
+            <MyView
+              className="min-w-1/2 w-full rounded-md flex-row gap-4 justify-center items-start"
+              style={[
+                styles.card,
+                {
+                  width: "50%",
+                  justifyContent: "center",
+                  alignItems: "center",
+                  flexGrow: 1,
+                  flexDirection: "row",
+                },
+              ]}
             >
-              {displayName} hoje
-            </Text>
-            <TextInput
-              className="max-w-[38px] text-center bg-[#333333] h-[37px] px-1 text-xl font-normal text-white rounded-md"
-              placeholder="--"
-              value={sleepHours}
-              onChangeText={(value) => setSleepHours(value)}
-            />
-            <Text style={styles.title}>h</Text>
-            <TextInput
-              className="max-w-[38px] text-center bg-[#333333] h-[37px] px-1 text-xl font-normal text-white rounded-md"
-              placeholder="--"
-              value={sleepMinutes}
-              onChangeText={(value) => setSleepMinutes(value)}
-            />
-            <Text style={styles.title}>min</Text>
+              <Text
+                style={styles.title}
+                className="text-white font-bold text-2xl"
+              >
+                {displayName} hoje
+              </Text>
+              <TextInput
+                className="max-w-[38px] text-center bg-[#333333] h-[37px] px-1 text-xl font-normal text-white rounded-md"
+                placeholder="--"
+                value={sleepHours}
+                onChangeText={(value) => setSleepHours(value)}
+              />
+              <Text style={styles.title}>h</Text>
+              <TextInput
+                className="max-w-[38px] text-center bg-[#333333] h-[37px] px-1 text-xl font-normal text-white rounded-md"
+                placeholder="--"
+                value={sleepMinutes}
+                onChangeText={(value) => setSleepMinutes(value)}
+              />
+              <Text style={styles.title}>min</Text>
+            </MyView>
+            <MyButton title="Salvar" onPress={() => handleSubmit()} />
           </MyView>
-          <MyButton title="Salvar" onPress={() => handleSubmit()} />
         </MyView>
-      </MyView>
-      <MyHistory tableName={pathname} reload={reloadKey} />
+        <MyHistory tableName={pathname} reload={reloadKey} />
+      </ScrollView>
     </MyView>
   );
 }

--- a/app/(metrics)/sleep.jsx
+++ b/app/(metrics)/sleep.jsx
@@ -1,6 +1,6 @@
 // @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
 //#region imports
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Text, TextInput } from "react-native";
 import { Snackbar } from "react-native-paper";
 
@@ -8,10 +8,11 @@ import MyView from "@/components/MyView";
 import Score from "@/components/Score";
 import MyButton from "@/components/MyButton";
 
-import { add } from "@/infra/database";
+import { add, getById, update } from "@/infra/database";
 import MyHistory from "@/components/MyHistory";
 import getDate from "@/constants/getDate";
-import { usePathname } from "expo-router";
+import { hhmmToMinutes, minutesToHHMM } from "@/constants/duration";
+import { useLocalSearchParams, usePathname } from "expo-router";
 import { getCategoryInfo } from "@/components/categoryUtils";
 import { useThemedStyles } from "@/hook/useThemedStyle";
 
@@ -20,7 +21,8 @@ import { useThemedStyles } from "@/hook/useThemedStyle";
 export default function Sleep() {
   //#region variables
   const pathname = usePathname().substring(1);
-  const { displayName } = getCategoryInfo(pathname) ?? {};
+  const { displayName, unit } = getCategoryInfo(pathname) ?? {};
+  const { id } = useLocalSearchParams();
 
   //#region states
   const [date, setDate] = useState(getDate());
@@ -33,6 +35,22 @@ export default function Sleep() {
   const [sleepHours, setSleepHours] = useState();
   const [sleepMinutes, setSleepMinutes] = useState();
   const [visible, setVisible] = useState(false);
+  //#endregion
+
+  //#region edição
+  useEffect(() => {
+    if (!id) return;
+    const r = getById(id);
+    if (!r) return;
+    const [h, m] = minutesToHHMM(r.quantity).split(":");
+    setSleepHours(h);
+    setSleepMinutes(m);
+    setObservation(r.note ?? r.observation ?? "");
+    setMin(r.min ?? "");
+    setMax(r.max ?? "");
+    setIdeal(r.ideal ?? "");
+    setScore(r.score);
+  }, [id]);
   //#endregion
 
   const styles = useThemedStyles((theme) => ({
@@ -97,15 +115,16 @@ export default function Sleep() {
     setVisible(true);
     const data = {
       date: date.ISOdate,
+      quantity: hhmmToMinutes(`${sleepHours ?? 0}:${sleepMinutes ?? 0}`),
+      unit,
+      note: observation,
       min,
       max,
       ideal,
-      quantity: `${sleepHours ?? "00"}:${sleepMinutes ?? "00"}`,
-      unity: "h",
       score,
-      observation,
     };
-    add("sleep", data);
+    if (id) update(id, data);
+    else add("sleep", data);
     setReloadKey((prev) => prev + 1);
   }
   function onDismissSnackBar() {

--- a/app/(metrics)/study.jsx
+++ b/app/(metrics)/study.jsx
@@ -1,8 +1,8 @@
 // @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
 //#region imports
-import { usePathname } from "expo-router";
+import { useLocalSearchParams, usePathname } from "expo-router";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Text, TextInput } from "react-native";
 import { Snackbar } from "react-native-paper";
 
@@ -14,8 +14,9 @@ import Score from "@/components/Score";
 
 import { getCategoryInfo } from "@/components/categoryUtils";
 import getDate from "@/constants/getDate";
+import { hhmmToMinutes, minutesToHHMM } from "@/constants/duration";
 
-import { add } from "@/infra/database";
+import { add, getById, update } from "@/infra/database";
 import { useThemedStyles } from "@/hook/useThemedStyle";
 
 //#endregion
@@ -23,7 +24,8 @@ import { useThemedStyles } from "@/hook/useThemedStyle";
 export default function Study() {
   //#region variables
   const pathname = usePathname().substring(1);
-  const { displayName } = getCategoryInfo(pathname) ?? {};
+  const { displayName, unit } = getCategoryInfo(pathname) ?? {};
+  const { id } = useLocalSearchParams();
 
   //#region states
   const [date, setDate] = useState(getDate());
@@ -34,6 +36,20 @@ export default function Study() {
   const [studyDurationHour, setStudyDurationHour] = useState("");
   const [studyDurationMinute, setStudyDurationMinute] = useState("");
   const [visible, setVisible] = useState(false);
+  //#endregion
+
+  //#region edição
+  useEffect(() => {
+    if (!id) return;
+    const r = getById(id);
+    if (!r) return;
+    const [dh, dm] = minutesToHHMM(r.quantity).split(":");
+    setStudyDurationHour(dh);
+    setStudyDurationMinute(dm);
+    setStudied(!!r.studied);
+    setObservation(r.note ?? r.observation ?? "");
+    setScore(r.score);
+  }, [id]);
   //#endregion
 
   const styles = useThemedStyles((theme) => ({
@@ -99,11 +115,14 @@ export default function Study() {
     setVisible(true);
     const data = {
       date: date.ISOdate,
-      duration: `${studyDurationHour}:${studyDurationMinute}`,
+      quantity: hhmmToMinutes(`${studyDurationHour}:${studyDurationMinute}`),
+      unit,
+      note: observation,
       score,
-      observation,
+      studied,
     };
-    add("study", data);
+    if (id) update(id, data);
+    else add("study", data);
     setReloadKey((prev) => prev + 1);
   }
   function onDismissSnackBar() {
@@ -147,7 +166,7 @@ export default function Study() {
             value={observation}
             onChangeText={(value) => setObservation(value)}
             style={styles.textArea}
-            placeholder="Observações sobre o exercício..."
+            placeholder="Observações sobre o estudo..."
           />
         </MyView>
 

--- a/app/(metrics)/study.jsx
+++ b/app/(metrics)/study.jsx
@@ -3,7 +3,7 @@
 import { useLocalSearchParams, usePathname } from "expo-router";
 
 import { useEffect, useState } from "react";
-import { Text, TextInput } from "react-native";
+import { ScrollView, Text, TextInput } from "react-native";
 import { Snackbar } from "react-native-paper";
 
 import MyButton from "@/components/MyButton";
@@ -137,64 +137,75 @@ export default function Study() {
         onDismiss={onDismissSnackBar}
         action={{
           label: "Fechar",
+          onPress: onDismissSnackBar,
         }}
       >
-        Seus dados estão salvos! (Enquanto você não recarregar o app)
+        Registro salvo!
       </Snackbar>
-      <MyView style={styles.card}>
-        <Text style={styles.title}>
-          {date.displayDate} {displayName}
-        </Text>
+      <ScrollView
+        style={{ width: "100%" }}
+        contentContainerStyle={{
+          alignItems: "center",
+          gap: 16,
+          paddingBottom: 24,
+        }}
+        showsVerticalScrollIndicator={false}
+      >
+        <MyView style={styles.card}>
+          <Text style={styles.title}>
+            {date.displayDate} {displayName}
+          </Text>
 
-        {/* card Wrapper */}
-        <MyView style={styles.cardWrapper}>
-          <MyCheckbox
-            value={studied}
-            label="Feito"
-            onValueChange={() => setStudied(!studied)}
-          />
-        </MyView>
-
-        {/* Nota */}
-        <Text style={styles.title}>Nota</Text>
-        <Score value={score} onPress={setScore} />
-
-        {/* OBS */}
-        <MyView className="gap-1">
-          <Text style={styles.title}>OBS:</Text>
-          <TextInput
-            value={observation}
-            onChangeText={(value) => setObservation(value)}
-            style={styles.textArea}
-            placeholder="Observações sobre o estudo..."
-          />
-        </MyView>
-
-        <MyView className="flex-row gap-4 items-end justify-between">
-          {/* Tempo de treino */}
-          <MyView style={[styles.card, { alignItems: "center" }]}>
-            <Text style={styles.title}>Tempo de estudo</Text>
-            <MyView className="flex flex-row gap-1 items-end">
-              <TextInput
-                style={styles.input}
-                placeholder="--"
-                value={studyDurationHour}
-                onChangeText={(value) => setStudyDurationHour(value)}
-              />
-              <Text style={styles.text}>h</Text>
-              <TextInput
-                style={styles.input}
-                placeholder="--"
-                value={studyDurationMinute}
-                onChangeText={(value) => setStudyDurationMinute(value)}
-              />
-              <Text style={styles.text}>min</Text>
-            </MyView>
+          {/* card Wrapper */}
+          <MyView style={styles.cardWrapper}>
+            <MyCheckbox
+              value={studied}
+              label="Feito"
+              onValueChange={() => setStudied(!studied)}
+            />
           </MyView>
-          <MyButton title="Salvar" onPress={() => handleSubmit()} />
+
+          {/* Nota */}
+          <Text style={styles.title}>Nota</Text>
+          <Score value={score} onPress={setScore} />
+
+          {/* OBS */}
+          <MyView className="gap-1">
+            <Text style={styles.title}>OBS:</Text>
+            <TextInput
+              value={observation}
+              onChangeText={(value) => setObservation(value)}
+              style={styles.textArea}
+              placeholder="Observações sobre o estudo..."
+            />
+          </MyView>
+
+          <MyView className="flex-row gap-4 items-end justify-between">
+            {/* Tempo de treino */}
+            <MyView style={[styles.card, { alignItems: "center" }]}>
+              <Text style={styles.title}>Tempo de estudo</Text>
+              <MyView className="flex flex-row gap-1 items-end">
+                <TextInput
+                  style={styles.input}
+                  placeholder="--"
+                  value={studyDurationHour}
+                  onChangeText={(value) => setStudyDurationHour(value)}
+                />
+                <Text style={styles.text}>h</Text>
+                <TextInput
+                  style={styles.input}
+                  placeholder="--"
+                  value={studyDurationMinute}
+                  onChangeText={(value) => setStudyDurationMinute(value)}
+                />
+                <Text style={styles.text}>min</Text>
+              </MyView>
+            </MyView>
+            <MyButton title="Salvar" onPress={() => handleSubmit()} />
+          </MyView>
         </MyView>
-      </MyView>
-      <MyHistory tableName={pathname} reload={reloadKey} />
+        <MyHistory tableName={pathname} reload={reloadKey} />
+      </ScrollView>
     </MyView>
   );
 }

--- a/app/(metrics)/water.jsx
+++ b/app/(metrics)/water.jsx
@@ -3,7 +3,7 @@
 import { useLocalSearchParams, usePathname } from "expo-router";
 
 import { useEffect, useState } from "react";
-import { Text, TextInput } from "react-native";
+import { ScrollView, Text, TextInput } from "react-native";
 import { Snackbar } from "react-native-paper";
 
 import { Colors } from "@/constants/Colors";
@@ -140,101 +140,112 @@ export default function Water() {
         onDismiss={onDismissSnackBar}
         action={{
           label: "Fechar",
+          onPress: onDismissSnackBar,
         }}
       >
-        Seus dados estão salvos! (Enquanto você não recarregar o app)
+        Registro salvo!
       </Snackbar>
-      <MyView style={styles.card}>
-        <Text style={styles.title}>
-          {date.displayDate} {displayName}
-        </Text>
+      <ScrollView
+        style={{ width: "100%" }}
+        contentContainerStyle={{
+          alignItems: "center",
+          gap: 16,
+          paddingBottom: 24,
+        }}
+        showsVerticalScrollIndicator={false}
+      >
+        <MyView style={styles.card}>
+          <Text style={styles.title}>
+            {date.displayDate} {displayName}
+          </Text>
 
-        {/* card Wrapper */}
-        <MyView style={styles.cardWrapper}>
-          {/* Input Wrapper */}
-          <MyView style={styles.inputWrapper}>
-            <Text style={styles.title}>MIN</Text>
+          {/* card Wrapper */}
+          <MyView style={styles.cardWrapper}>
+            {/* Input Wrapper */}
+            <MyView style={styles.inputWrapper}>
+              <Text style={styles.title}>MIN</Text>
+              <TextInput
+                style={styles.input}
+                placeholder="--"
+                value={min}
+                onChangeText={(value) => setMin(value)}
+              />
+            </MyView>
+            {/* Input Wrapper */}
+            <MyView style={styles.inputWrapper}>
+              <Text style={styles.title}>MAX</Text>
+              <TextInput
+                style={styles.input}
+                placeholder="--"
+                value={max}
+                onChangeText={(value) => setMax(value)}
+              />
+            </MyView>
+            {/* Input Wrapper */}
+            <MyView style={styles.inputWrapper}>
+              <Text style={styles.title}>IDEAL</Text>
+              <TextInput
+                style={styles.input}
+                placeholder="--"
+                value={ideal}
+                onChangeText={(value) => setIdeal(value)}
+              />
+            </MyView>
+          </MyView>
+
+          <Text style={styles.title}>Nota</Text>
+          <Score value={score} onPress={setScore} />
+          {/* OBS */}
+          <MyView className="gap-1">
+            <Text style={styles.title}>OBS:</Text>
             <TextInput
-              style={styles.input}
-              placeholder="--"
-              value={min}
-              onChangeText={(value) => setMin(value)}
+              value={observation}
+              onChangeText={(value) => setObservation(value)}
+              style={styles.textArea}
+              placeholder="Observações sobre água..."
             />
           </MyView>
-          {/* Input Wrapper */}
-          <MyView style={styles.inputWrapper}>
-            <Text style={styles.title}>MAX</Text>
-            <TextInput
-              style={styles.input}
-              placeholder="--"
-              value={max}
-              onChangeText={(value) => setMax(value)}
-            />
-          </MyView>
-          {/* Input Wrapper */}
-          <MyView style={styles.inputWrapper}>
-            <Text style={styles.title}>IDEAL</Text>
-            <TextInput
-              style={styles.input}
-              placeholder="--"
-              value={ideal}
-              onChangeText={(value) => setIdeal(value)}
-            />
-          </MyView>
-        </MyView>
 
-        <Text style={styles.title}>Nota</Text>
-        <Score value={score} onPress={setScore} />
-        {/* OBS */}
-        <MyView className="gap-1">
-          <Text style={styles.title}>OBS:</Text>
-          <TextInput
-            value={observation}
-            onChangeText={(value) => setObservation(value)}
-            style={styles.textArea}
-            placeholder="Observações sobre água..."
-          />
-        </MyView>
-
-        <MyView className="flex-row flex-wrap gap-4 items-center">
-          <MyView
-            style={[
-              styles.card,
-              {
-                width: "50%",
-                justifyContent: "center",
-                alignItems: "center",
-                flexGrow: 1,
-                flexDirection: "row",
-              },
-            ]}
-          >
-            <Text
-              style={styles.title}
-              className="text-white font-bold text-2xl"
-            >
-              {displayName} hoje
-            </Text>
-            <TextInput
+          <MyView className="flex-row flex-wrap gap-4 items-center">
+            <MyView
               style={[
-                styles.input,
+                styles.card,
                 {
-                  backgroundColor: "#333",
-                  width: 80,
-                  height: 51,
-                  textAlign: "center",
+                  width: "50%",
+                  justifyContent: "center",
+                  alignItems: "center",
+                  flexGrow: 1,
+                  flexDirection: "row",
                 },
               ]}
-              placeholder="--"
-              value={quantity}
-              onChangeText={(value) => setQuantity(value)}
-            />
-            <Text style={styles.title}>ml</Text>
+            >
+              <Text
+                style={styles.title}
+                className="text-white font-bold text-2xl"
+              >
+                {displayName} hoje
+              </Text>
+              <TextInput
+                style={[
+                  styles.input,
+                  {
+                    backgroundColor: "#333",
+                    width: 80,
+                    height: 51,
+                    textAlign: "center",
+                  },
+                ]}
+                placeholder="--"
+                value={quantity}
+                onChangeText={(value) => setQuantity(value)}
+              />
+              <Text style={styles.title}>ml</Text>
+            </MyView>
+            <MyButton title="Salvar" onPress={() => handleSubmit()} />
           </MyView>
-          <MyButton title="Salvar" onPress={() => handleSubmit()} />
         </MyView>
-      </MyView>
-      <MyHistory tableName={pathname} reload={reloadKey} />
+        <MyHistory tableName={pathname} reload={reloadKey} />
+      </ScrollView>
     </MyView>
   );
 }

--- a/app/(metrics)/water.jsx
+++ b/app/(metrics)/water.jsx
@@ -1,8 +1,8 @@
 // @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
 //#region imports
-import { usePathname } from "expo-router";
+import { useLocalSearchParams, usePathname } from "expo-router";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Text, TextInput } from "react-native";
 import { Snackbar } from "react-native-paper";
 
@@ -16,7 +16,7 @@ import Score from "@/components/Score";
 import { getCategoryInfo } from "@/components/categoryUtils";
 import getDate from "@/constants/getDate";
 
-import { add } from "@/infra/database";
+import { add, getById, update } from "@/infra/database";
 import { useThemedStyles } from "@/hook/useThemedStyle";
 
 //#endregion
@@ -24,7 +24,8 @@ import { useThemedStyles } from "@/hook/useThemedStyle";
 export default function Water() {
   //#region variables
   const pathname = usePathname().substring(1);
-  const { displayName } = getCategoryInfo(pathname) ?? {};
+  const { displayName, unit } = getCategoryInfo(pathname) ?? {};
+  const { id } = useLocalSearchParams();
 
   //#region states
   const [date, setDate] = useState(getDate());
@@ -36,6 +37,20 @@ export default function Water() {
   const [reloadKey, setReloadKey] = useState(0);
   const [quantity, setQuantity] = useState();
   const [visible, setVisible] = useState(false);
+  //#endregion
+
+  //#region edição
+  useEffect(() => {
+    if (!id) return;
+    const r = getById(id);
+    if (!r) return;
+    setQuantity(String(r.quantity ?? ""));
+    setObservation(r.note ?? r.observation ?? "");
+    setMin(r.min ?? "");
+    setMax(r.max ?? "");
+    setIdeal(r.ideal ?? "");
+    setScore(r.score);
+  }, [id]);
   //#endregion
 
   const styles = useThemedStyles((theme) => ({
@@ -101,15 +116,16 @@ export default function Water() {
     setVisible(true);
     const data = {
       date: date.ISOdate,
+      quantity: Number(quantity) || 0,
+      unit,
+      note: observation,
       min,
       max,
       ideal,
-      quantity,
       score,
-      observation,
-      unity: "ml",
     };
-    add("water", data);
+    if (id) update(id, data);
+    else add("water", data);
     setReloadKey((prev) => prev + 1);
   }
   function onDismissSnackBar() {

--- a/app/_layout.jsx
+++ b/app/_layout.jsx
@@ -3,6 +3,7 @@ import "@/global.css";
 
 import { Stack } from "expo-router";
 import { useColorScheme } from "react-native";
+import { SafeAreaProvider } from "react-native-safe-area-context";
 import { Colors } from "@/constants/Colors";
 import { useRegistrosPersistencia } from "@/infra/persistence";
 
@@ -13,17 +14,19 @@ export default function RootLayout() {
   useRegistrosPersistencia();
 
   return (
-    <Stack
-      screenOptions={{
-        headerShown: false,
-        headerStyle: { backgroundColor: theme.background },
-        headerTintColor: theme.text,
-      }}
-    >
-      <Stack.Screen name="index" options={{ title: "Home" }} />
-      <Stack.Screen name="export" options={{ title: "Exportação" }} />
-      <Stack.Screen name="(history)" />
-      <Stack.Screen name="(metrics)" />
-    </Stack>
+    <SafeAreaProvider>
+      <Stack
+        screenOptions={{
+          headerShown: false,
+          headerStyle: { backgroundColor: theme.background },
+          headerTintColor: theme.text,
+        }}
+      >
+        <Stack.Screen name="index" options={{ title: "Home" }} />
+        <Stack.Screen name="export" options={{ title: "Exportação" }} />
+        <Stack.Screen name="(history)" />
+        <Stack.Screen name="(metrics)" />
+      </Stack>
+    </SafeAreaProvider>
   );
 }

--- a/components/MyHistory.jsx
+++ b/components/MyHistory.jsx
@@ -2,25 +2,22 @@
 //#region imports
 import { useEffect, useState } from "react";
 
-import { StyleSheet, Text, useColorScheme, View } from "react-native";
+import { Alert, StyleSheet, Text, useColorScheme, View } from "react-native";
 
 import MyView from "./MyView";
+import MyButton from "./MyButton";
 import { getCategoryInfo } from "./categoryUtils";
 
 import { Colors, shadow } from "@/constants/Colors";
 
-import { get, getByMonth } from "@/infra/database";
+import { get, getByMonth, remove } from "@/infra/database";
+import { minutesToHHMM } from "@/constants/duration";
 import Checkbox from "expo-checkbox";
 import { router } from "expo-router";
 //#endregion
 
-export default function MyHistory({ cardStyle, tableName, reload }) {
-  //#region variables
-  const colorScheme = useColorScheme();
-  const theme = Colors[colorScheme] ?? Colors.light;
-  const { displayName, unity } = getCategoryInfo(tableName);
-
-  const styles = StyleSheet.create({
+function makeStyles(theme) {
+  return StyleSheet.create({
     container: { alignItems: "center", width: "100%", gap: 10 },
     card: {
       width: "100%",
@@ -28,9 +25,7 @@ export default function MyHistory({ cardStyle, tableName, reload }) {
       gap: 10,
       backgroundColor: theme.backgroundCard,
       borderRadius: 6,
-      padding: 1,
-      paddingTop: 1,
-      paddingBottom: 1,
+      padding: 10,
     },
     text: { color: theme.text, fontWeight: "bold", fontSize: 18 },
     subtext: {
@@ -54,265 +49,209 @@ export default function MyHistory({ cardStyle, tableName, reload }) {
       height: 24,
       borderRadius: 100,
     },
+    actions: { flexDirection: "row", gap: 8, justifyContent: "flex-end" },
   });
-
-  const [data, setData] = useState([]);
-
-  //#endregion
-
-  function getDate(date) {
-    date = date.substring(0, 10).split("-");
-    return `${date[2]}/${date[1]}/${date[0]}`;
-  }
-
-  useEffect(() => {
-    const tableData = get(tableName) ?? {};
-    setData(tableData);
-  }, [reload]);
-
-  return (
-    <MyView
-      style={styles.container}
-      onClick={() => router.navigate(`(history)/${tableName}`)}
-    >
-      {Object.entries(data).map(([id, obj]) => (
-        <MyView style={[styles.card, cardStyle, shadow]} key={id}>
-          <Text style={styles.title}>
-            <Text style={styles.text}>
-              {getDate(obj.date)} {displayName}
-            </Text>
-            <Text
-              style={[
-                styles.score,
-                {
-                  backgroundColor:
-                    obj.score === 5 ? Colors.secondary : Colors.primary,
-                },
-              ]}
-            >
-              {obj.score}
-            </Text>
-          </Text>
-          <Text style={styles.subtext}>
-            {obj.quantity ?? obj.duration}
-            {unity} | Nota {obj.score}
-          </Text>
-          <View className="flex-row items-center">
-            <Text style={[styles.subtext, { fontSize: 16 }]}>OBS: </Text>
-            <Text style={[styles.text, { fontWeight: "medium", fontSize: 16 }]}>
-              {obj.observation}
-            </Text>
-          </View>
-        </MyView>
-      ))}
-    </MyView>
-  );
 }
-export function MyMonthHistory({ cardStyle, tableName, month }) {
-  //#region variables
-  const colorScheme = useColorScheme();
-  const theme = Colors[colorScheme] ?? Colors.light;
-  const { displayName, unity } = getCategoryInfo(tableName);
 
-  const styles = StyleSheet.create({
-    container: { alignItems: "center", width: "100%", gap: 10 },
-    card: {
-      width: "100%",
-      maxWidth: 640,
-      gap: 10,
-      backgroundColor: theme.backgroundCard,
-      borderRadius: 6,
-      padding: 1,
-      paddingTop: 1,
-      paddingBottom: 1,
-    },
-    text: { color: theme.text, fontWeight: "bold", fontSize: 18 },
-    subtext: {
-      color: theme.text,
-      opacity: 0.5,
-      fontWeight: "bold",
-      fontSize: 12,
-    },
-    title: {
-      fontSize: 18,
-      flexDirection: "row",
-      justifyContent: "space-between",
-      width: "100%",
-    },
-    score: {
-      textAlign: "center",
-      color: theme.text,
-      fontWeight: "bold",
-      fontSize: 16,
-      width: 24,
-      height: 24,
-      borderRadius: 100,
-    },
-  });
-
-  const [data, setData] = useState([]);
-
-  //#endregion
-
-  function getDate(date) {
-    date = date.substring(0, 10).split("-");
-    return `${date[2]}/${date[1]}/${date[0]}`;
-  }
-
-  useEffect(() => {
-    const tableData = getByMonth(tableName, month) ?? {};
-    setData(tableData);
-  }, [month]);
-
-  return (
-    <MyView
-      style={styles.container}
-      onClick={() => router.navigate(`(history)/${tableName}`)}
-    >
-      {Object.entries(data).map(([id, obj]) => (
-        <MyView style={[styles.card, cardStyle, shadow]} key={id}>
-          <Text style={styles.title}>
-            <Text style={styles.text}>
-              {getDate(obj.date)} {displayName}
-            </Text>
-            <Text
-              style={[
-                styles.score,
-                {
-                  backgroundColor:
-                    obj.score === 5 ? Colors.secondary : Colors.primary,
-                },
-              ]}
-            >
-              {obj.score}
-            </Text>
-          </Text>
-          <Text style={styles.subtext}>
-            {obj.quantity ?? obj.duration}
-            {unity} | Nota {obj.score}
-          </Text>
-          <View className="flex-row items-center">
-            <Text style={[styles.subtext, { fontSize: 16 }]}>OBS: </Text>
-            <Text style={[styles.text, { fontWeight: "medium", fontSize: 16 }]}>
-              {obj.observation}
-            </Text>
-          </View>
-        </MyView>
-      ))}
-    </MyView>
-  );
+function formatDate(date) {
+  const parts = String(date ?? "")
+    .substring(0, 10)
+    .split("-");
+  return `${parts[2]}/${parts[1]}/${parts[0]}`;
 }
-export function MyExerciseHistory({ tableName, reload }) {
-  //#region variables
-  const colorScheme = useColorScheme();
-  const theme = Colors[colorScheme] ?? Colors.light;
-  const { displayName, unity } = getCategoryInfo(tableName);
 
-  const styles = StyleSheet.create({
-    container: { alignItems: "center", width: "100%", gap: 10 },
-    card: {
-      width: "100%",
-      maxWidth: 640,
-      gap: 10,
-      backgroundColor: theme.backgroundCard,
-      borderRadius: 6,
-      padding: 1,
-      paddingTop: 1,
-      paddingBottom: 1,
-    },
-    text: { color: theme.text, fontWeight: "bold", fontSize: 18 },
-    subtext: {
-      color: theme.text,
-      opacity: 0.5,
-      fontWeight: "bold",
-      fontSize: 12,
-    },
-    title: {
-      fontSize: 18,
-      flexDirection: "row",
-      justifyContent: "space-between",
-      width: "100%",
-    },
-    score: {
-      textAlign: "center",
-      color: theme.text,
-      fontWeight: "bold",
-      fontSize: 16,
-      width: 24,
-      height: 24,
-      borderRadius: 100,
-    },
-  });
+// Valor principal do registro. Registros novos guardam `quantity` como
+// número (minutos, quando unit === "min"); registros antigos podem trazer
+// `quantity`/`duration` já como "HH:MM" string — daí o fallback.
+function formatQuantity(obj, unit) {
+  const raw = obj.quantity ?? obj.duration;
+  if (raw == null || raw === "") return "";
+  if (unit === "min") {
+    if (typeof raw === "string" && raw.includes(":")) return raw;
+    return minutesToHHMM(raw);
+  }
+  return String(raw);
+}
 
-  const [data, setData] = useState([]);
+function HistoryCard({
+  obj,
+  tableName,
+  displayName,
+  unit,
+  styles,
+  cardStyle,
+  exercise,
+  onChanged,
+}) {
+  const id = obj.id;
+  const note = obj.note ?? obj.observation;
 
-  //#endregion
-
-  function getDate(date) {
-    date = date.substring(0, 10).split("-");
-    return `${date[2]}/${date[1]}/${date[0]}`;
+  function handleEdit() {
+    router.navigate(`/(metrics)/${tableName}?id=${id}`);
   }
 
-  useEffect(() => {
-    const tableData = get(tableName) ?? {};
-    setData(tableData);
-  }, [reload]);
+  function handleDelete() {
+    Alert.alert("Excluir registro", "Quer mesmo excluir este registro?", [
+      { text: "Cancelar", style: "cancel" },
+      {
+        text: "Excluir",
+        style: "destructive",
+        onPress: () => {
+          remove(id);
+          onChanged?.();
+        },
+      },
+    ]);
+  }
 
   return (
-    <MyView style={styles.container}>
-      {Object.entries(data).map(([id, obj]) => (
-        <MyView style={[styles.card, shadow]} key={id}>
-          <Text style={styles.title}>
-            <Text style={styles.text}>
-              {getDate(obj.date)} {obj.trainingTime} - {displayName}
-            </Text>
+    <MyView safe={false} style={[styles.card, cardStyle, shadow]}>
+      <Text style={styles.title}>
+        <Text style={styles.text}>
+          {formatDate(obj.date)}
+          {exercise && obj.trainingTime ? ` ${obj.trainingTime}` : ""}{" "}
+          {displayName}
+        </Text>
+        <Text
+          style={[
+            styles.score,
+            {
+              backgroundColor:
+                obj.score === 5 ? Colors.secondary : Colors.primary,
+            },
+          ]}
+        >
+          {obj.score}
+        </Text>
+      </Text>
 
-            <Text
-              style={[
-                styles.score,
-                {
-                  backgroundColor:
-                    obj.score === 5 ? Colors.secondary : Colors.primary,
-                },
-              ]}
-            >
-              {obj.score}
-            </Text>
-          </Text>
-          <MyView className="flex-row gap-[6]">
-            <MyView
-              style={{
-                flexDirection: "row",
-                alignItems: "center",
-                gap: 6,
-              }}
-            >
-              <Checkbox color={Colors.primary} value={obj.training} />
-              <Text style={styles.text}>Treino</Text>
-            </MyView>
-            <MyView
-              style={{
-                flexDirection: "row",
-                alignItems: "center",
-                gap: 6,
-              }}
-            >
-              <Checkbox color={Colors.primary} value={obj.cardio} />
-              <Text style={styles.text}>Cardio</Text>
-            </MyView>
+      {exercise && (
+        <MyView safe={false} className="flex-row gap-4">
+          <MyView
+            safe={false}
+            style={{ flexDirection: "row", alignItems: "center", gap: 6 }}
+          >
+            <Checkbox color={Colors.primary} value={!!obj.training} />
+            <Text style={styles.text}>Treino</Text>
           </MyView>
-
-          <Text style={styles.subtext}>
-            {obj.quantity ?? obj.duration}
-            {unity} | Nota {obj.score}
-          </Text>
-          <View className="flex-row items-center">
-            <Text style={[styles.subtext, { fontSize: 16 }]}>OBS: </Text>
-            <Text style={[styles.text, { fontWeight: "medium", fontSize: 16 }]}>
-              {obj.observation}
-            </Text>
-          </View>
+          <MyView
+            safe={false}
+            style={{ flexDirection: "row", alignItems: "center", gap: 6 }}
+          >
+            <Checkbox color={Colors.primary} value={!!obj.cardio} />
+            <Text style={styles.text}>Cardio</Text>
+          </MyView>
         </MyView>
+      )}
+
+      <Text style={styles.subtext}>
+        {formatQuantity(obj, unit)}
+        {unit} | Nota {obj.score}
+      </Text>
+      <View className="flex-row items-center">
+        <Text style={[styles.subtext, { fontSize: 16 }]}>OBS: </Text>
+        <Text style={[styles.text, { fontWeight: "medium", fontSize: 16 }]}>
+          {note}
+        </Text>
+      </View>
+
+      <MyView safe={false} style={styles.actions}>
+        <MyButton title="Editar" onPress={handleEdit} />
+        <MyButton title="Excluir" onPress={handleDelete} />
+      </MyView>
+    </MyView>
+  );
+}
+
+export default function MyHistory({ cardStyle, tableName, reload }) {
+  const colorScheme = useColorScheme();
+  const theme = Colors[colorScheme] ?? Colors.light;
+  const styles = makeStyles(theme);
+  const { displayName, unit } = getCategoryInfo(tableName);
+
+  const [data, setData] = useState({});
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    setData(get(tableName) ?? {});
+  }, [reload, tick, tableName]);
+
+  return (
+    <MyView safe={false} style={styles.container}>
+      {Object.values(data).map((obj) => (
+        <HistoryCard
+          key={obj.id}
+          obj={obj}
+          tableName={tableName}
+          displayName={displayName}
+          unit={unit}
+          styles={styles}
+          cardStyle={cardStyle}
+          onChanged={() => setTick((t) => t + 1)}
+        />
+      ))}
+    </MyView>
+  );
+}
+
+export function MyMonthHistory({ cardStyle, tableName, month }) {
+  const colorScheme = useColorScheme();
+  const theme = Colors[colorScheme] ?? Colors.light;
+  const styles = makeStyles(theme);
+  const { displayName, unit } = getCategoryInfo(tableName);
+
+  const [data, setData] = useState([]);
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    setData(getByMonth(tableName, month) ?? []);
+  }, [month, tick, tableName]);
+
+  return (
+    <MyView safe={false} style={styles.container}>
+      {Object.values(data).map((obj) => (
+        <HistoryCard
+          key={obj.id}
+          obj={obj}
+          tableName={tableName}
+          displayName={displayName}
+          unit={unit}
+          styles={styles}
+          cardStyle={cardStyle}
+          onChanged={() => setTick((t) => t + 1)}
+        />
+      ))}
+    </MyView>
+  );
+}
+
+export function MyExerciseHistory({ cardStyle, tableName, reload }) {
+  const colorScheme = useColorScheme();
+  const theme = Colors[colorScheme] ?? Colors.light;
+  const styles = makeStyles(theme);
+  const { displayName, unit } = getCategoryInfo(tableName);
+
+  const [data, setData] = useState({});
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    setData(get(tableName) ?? {});
+  }, [reload, tick, tableName]);
+
+  return (
+    <MyView safe={false} style={styles.container}>
+      {Object.values(data).map((obj) => (
+        <HistoryCard
+          key={obj.id}
+          obj={obj}
+          tableName={tableName}
+          displayName={displayName}
+          unit={unit}
+          styles={styles}
+          cardStyle={cardStyle}
+          exercise
+          onChanged={() => setTick((t) => t + 1)}
+        />
       ))}
     </MyView>
   );

--- a/components/categoryUtils.jsx
+++ b/components/categoryUtils.jsx
@@ -2,23 +2,23 @@
 export const CATEGORY_MAP = {
   water: {
     displayName: "água",
-    unity: "ml",
+    unit: "ml",
   },
   sleep: {
     displayName: "sono",
-    unity: "h",
+    unit: "min",
   },
   exercise: {
     displayName: "exercício",
-    unity: "h",
+    unit: "min",
   },
   feeding: {
     displayName: "alimentação",
-    unity: "Refeições",
+    unit: "refeição",
   },
   study: {
     displayName: "estudo",
-    unity: "h",
+    unit: "min",
   },
 };
 
@@ -27,6 +27,6 @@ export function getCategoryInfo(key) {
     displayName: CATEGORY_MAP[key]?.displayName ?? key,
     exists: !!CATEGORY_MAP[key],
     key: CATEGORY_MAP[key]?.key ?? key,
-    unity: CATEGORY_MAP[key]?.unity ?? null,
+    unit: CATEGORY_MAP[key]?.unit ?? null,
   };
 }

--- a/constants/duration.js
+++ b/constants/duration.js
@@ -1,0 +1,26 @@
+// Conversão entre "HH:MM" e minutos, para as métricas de tempo (sono,
+// exercício, estudo). O modelo unificado guarda `quantity` como número
+// (minutos, unit "min"); a UI continua editando/exibindo em "HH:MM".
+
+/**
+ * "7:30" -> 450. Aceita horas/minutos vazios ("" -> 0).
+ * @param {string | number} hhmm
+ * @returns {number}
+ */
+export function hhmmToMinutes(hhmm) {
+  if (typeof hhmm !== "string") return Number(hhmm) || 0;
+  const [h, m] = hhmm.split(":");
+  return (Number(h) || 0) * 60 + (Number(m) || 0);
+}
+
+/**
+ * 450 -> "7:30" (minutos sempre com 2 dígitos).
+ * @param {string | number} minutes
+ * @returns {string}
+ */
+export function minutesToHHMM(minutes) {
+  const total = Number(minutes) || 0;
+  const h = Math.floor(total / 60);
+  const m = total % 60;
+  return `${h}:${String(m).padStart(2, "0")}`;
+}

--- a/infra/database.js
+++ b/infra/database.js
@@ -7,11 +7,18 @@ export const store = createStore().setTablesSchema({
   [TABLE]: {
     type: { type: "string" },
     date: { type: "string" },
+    quantity: { type: "number" },
+    unit: { type: "string" },
+    note: { type: "string" },
     details: { type: "string", default: "{}" },
     createdAt: { type: "number" },
   },
 });
 
+// Espalha `details` (JSON) de volta pro topo. É espalhado por último de
+// propósito: registros antigos (schema frouxo, com quantity/observation
+// dentro de details) continuam aparecendo achatados, dando fallback pros
+// campos que hoje viraram coluna própria.
 function hidratar(id, linha) {
   const { details, ...resto } = linha;
   let extras;
@@ -23,14 +30,46 @@ function hidratar(id, linha) {
   return { id, ...resto, ...extras };
 }
 
-export function add(type, data) {
-  const { date, ...details } = data;
-  store.addRow(TABLE, {
+// Separa os campos unificados (colunas) dos extras específicos do tipo
+// (serializados em details).
+function buildRow(type, data) {
+  const { date, quantity, unit, note, ...extras } = data;
+  return {
     type,
     date: date ?? "",
-    details: JSON.stringify(details ?? {}),
+    quantity: Number(quantity) || 0,
+    unit: unit ?? "",
+    note: note ?? "",
+    details: JSON.stringify(extras ?? {}),
     createdAt: Date.now(),
+  };
+}
+
+export function add(type, data) {
+  store.addRow(TABLE, buildRow(type, data));
+}
+
+export function update(id, data) {
+  const { quantity, unit, note, ...rest } = data;
+  const extras = { ...rest };
+  // A data não é editável na UI (é sempre "hoje"); não mexer nela aqui,
+  // senão editar um registro antigo trocaria a data original pela de hoje.
+  delete extras.date;
+  store.setPartialRow(TABLE, id, {
+    quantity: Number(quantity) || 0,
+    unit: unit ?? "",
+    note: note ?? "",
+    details: JSON.stringify(extras),
   });
+}
+
+export function remove(id) {
+  store.delRow(TABLE, id);
+}
+
+export function getById(id) {
+  if (!store.hasRow(TABLE, id)) return undefined;
+  return hidratar(id, store.getRow(TABLE, id));
 }
 
 export function get(type) {
@@ -42,6 +81,10 @@ export function get(type) {
     }
   }
   return resultado;
+}
+
+export function getAll(type) {
+  return Object.values(get(type));
 }
 
 export function getByMonth(type, month) {


### PR DESCRIPTION
Refs #62 — primeira grande entrega da Milestone 2 (Modelo de Dados Unificado).

## O que muda

Converge a store e as 5 telas de métrica para o modelo `Registro` unificado, com CRUD completo (antes só havia criação).

### Store (`infra/database.js`)
- Novas colunas no schema: `quantity` (number), `unit` (string), `note` (string), mantendo `details` para extras específicos de cada tipo.
- `add`/`update`/`remove`/`getById`/`getAll` completos (`update` via `setPartialRow`, `remove` via `delRow`).
- **Sem migração destrutiva**: `hidratar` espalha `details` achatado, então registros antigos continuam renderizando por fallback de nomes (`note ?? observation`, `quantity ?? duration`).
- `update` não mexe na `date` (não editável na UI) — evita sobrescrever a data original ao editar um registro antigo.

### Durações unificadas
- `constants/duration.js` (novo): `hhmmToMinutes`/`minutesToHHMM`. Sono, exercício e estudo agora guardam `quantity` como minutos (number, `unit: "min"`); a UI continua editando/exibindo em `HH:MM`.
- `categoryUtils`: `unity` → `unit`, valores canônicos (`ml`/`min`/`refeição`).

### As 5 telas de métrica
- Payload unificado no submit.
- **Modo edição**: `useLocalSearchParams id` → `getById` pré-preenche os campos → `Salvar` chama `update` em vez de `add`.
- `study` agora captura o campo `studied` (antes descartado).

### `MyHistory`
- Extraído um `HistoryCard` compartilhado (os 3 componentes de leitura eram quase idênticos).
- Leitura unificada com fallback para dados legados.
- Ações **Editar** (navega para a tela com `?id=`) e **Excluir** (confirmação + `remove`) por card.
- Corrigido bug `onClick` (web) → `onPress` (RN).

### Correções de UI (feedback em runtime)
- `SafeAreaProvider` na raiz — sem ele os insets do `MyView` não resolviam, e conteúdo invadia a barra de status.
- `ScrollView` nas 5 telas + histórico de água — conteúdo alto agora rola em vez de vazar da tela.
- Barra de categorias (`(metrics)/_layout.jsx`) também estava invadindo a barra de notificação (renderizava fora de qualquer wrapper com safe-area) — corrigido.
- Snackbar: botão "Fechar" não tinha `onPress` (não fechava); mensagem desatualizada ("enquanto você não recarregar") trocada por "Registro salvo!", já que a persistência sobrevive ao reload desde a #47.

## Fora de escopo (próxima fatia da M2)
- Extrair a tela de registro única (as 5 telas virarem configuração de um componente-base).
- Migração de estilo para NativeWind nessas telas/histórico (`docs/05-guia-migracao-estilo.md`) — este PR mexeu só em dados/CRUD/UX, mantendo `StyleSheet`.

## Validação
- ✅ `tsc --noEmit`, ESLint, Prettier
- ✅ `expo export` (web/Android/iOS)
- ✅ **Testado no Android pelo autor**: criar/editar/excluir em cada métrica, histórico refletindo, scroll funcionando, barra de categorias não invade mais a barra de notificação

Refs #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)