### PR TITLE
feat(home): derive the index screen from the roadmap file

### DIFF
--- a/app/index.jsx
+++ b/app/index.jsx
@@ -1,58 +1,101 @@
 // @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
 //#region imports
-
-import { Text } from "react-native";
-import { Card } from "react-native-paper";
+import { ScrollView, Text, View } from "react-native";
 
 import MyView from "@/components/MyView";
+import MyHeader from "@/components/MyHeader";
 
 import { shadow } from "@/constants/Colors";
-import MyHeader from "@/components/MyHeader";
+import { parseRoadmap, getDigest } from "@/constants/roadmap";
+// Caminho relativo de propósito: o babel-plugin-inline-import resolve pelo
+// arquivo, não pelo alias @/. Editar o roadmap exige reiniciar com --clear.
+import roadmapMd from "../docs/04-roadmap-milestones.md";
 //#endregion
 
-export default function Home() {
+const STATUS_ICON = { done: "✅", partial: "🟡", todo: "⬜" };
+const digest = getDigest(parseRoadmap(roadmapMd));
+
+const CARD =
+  "w-full max-w-[640px] rounded-lg bg-light-backgroundCard p-4 dark:bg-dark-backgroundCard";
+const LABEL =
+  "font-bold text-xs text-light-text opacity-60 dark:text-dark-text";
+const ITEM_TEXT = "flex-1 text-base text-light-text dark:text-dark-text";
+
+function ItemRow({ status, text }) {
   return (
-    <MyView className="flex-1 items-center bg-light-background dark:bg-dark-background">
+    <View className="flex-row gap-2">
+      <Text className="text-base">{STATUS_ICON[status] ?? "•"}</Text>
+      <Text className={ITEM_TEXT}>{text}</Text>
+    </View>
+  );
+}
+
+export default function Home() {
+  const {
+    milestonesDone,
+    milestonesTotal,
+    current,
+    currentProgress,
+    recentDone,
+  } = digest;
+  const pct = milestonesTotal
+    ? Math.round((milestonesDone / milestonesTotal) * 100)
+    : 0;
+
+  return (
+    <MyView
+      safe={true}
+      className="flex-1 bg-light-background dark:bg-dark-background"
+    >
       <MyHeader />
-      <Card style={[{ margin: 10, minHeight: "50%" }, shadow]}>
-        <Card.Title
-          title="Olá, mundo!"
-          subtitle="Esse pedaço de tecnologia está em construção!"
-        />
-        <Card.Content className="bg-light-backgroundCard dark:bg-dark-backgroundCard">
-          <Text
-            className="text-light-text dark:text-dark-text"
-            variant="headlineMedium"
-          >
-            Essa versão beta conta com as seguintes funcionalidades
+      <ScrollView
+        contentContainerStyle={{ padding: 16, gap: 16, alignItems: "center" }}
+        showsVerticalScrollIndicator={false}
+      >
+        {/* Progresso geral */}
+        <MyView safe={false} className={`${CARD} gap-2`} style={shadow}>
+          <Text className="font-bold text-2xl text-light-text dark:text-dark-text">
+            Back on Track
           </Text>
-          <MyView className="flex-row items-center">
-            <Text className=" text-light-text dark:text-dark-text">
-              * Registro diário de ingestão de água
+          <Text className="font-bold text-base text-light-text opacity-60 dark:text-dark-text">
+            {milestonesDone} de {milestonesTotal} milestones concluídas
+          </Text>
+          <View className="h-2 w-full overflow-hidden rounded-full bg-light-background dark:bg-dark-background">
+            <View
+              className="h-2 rounded-full bg-secondary"
+              style={{ width: `${pct}%` }}
+            />
+          </View>
+        </MyView>
+
+        {/* Milestone atual */}
+        {current && (
+          <MyView safe={false} className={`${CARD} gap-3`} style={shadow}>
+            <Text className={LABEL}>EM ANDAMENTO</Text>
+            <Text className="font-bold text-lg text-light-text dark:text-dark-text">
+              {current.id} · {current.title} ({currentProgress.done}/
+              {currentProgress.total})
             </Text>
+            <MyView safe={false} className="gap-2">
+              {current.items.map((item, i) => (
+                <ItemRow key={i} status={item.status} text={item.text} />
+              ))}
+            </MyView>
           </MyView>
-          <MyView className="flex-row items-center">
-            <Text className="text-light-text dark:text-dark-text">
-              * Registro diário de sono
-            </Text>
+        )}
+
+        {/* Concluído recentemente */}
+        {recentDone.length > 0 && (
+          <MyView safe={false} className={`${CARD} gap-3`} style={shadow}>
+            <Text className={LABEL}>CONCLUÍDO RECENTEMENTE</Text>
+            <MyView safe={false} className="gap-2">
+              {recentDone.map((item, i) => (
+                <ItemRow key={i} status="done" text={item.text} />
+              ))}
+            </MyView>
           </MyView>
-          <MyView className="flex-row items-center">
-            <Text className="text-light-text dark:text-dark-text">
-              * Registro diário de exercício
-            </Text>
-          </MyView>
-          <MyView className="flex-row items-center">
-            <Text className="text-light-text dark:text-dark-text">
-              * Registro diário de refeições
-            </Text>
-          </MyView>
-          <MyView className="flex-row items-center">
-            <Text className="text-light-text dark:text-dark-text">
-              * Registro diário de estudo
-            </Text>
-          </MyView>
-        </Card.Content>
-      </Card>
+        )}
+      </ScrollView>
     </MyView>
   );
 }

--- a/babel.config.js
+++ b/babel.config.js
@@ -5,5 +5,7 @@ module.exports = function (api) {
       ["babel-preset-expo", { jsxImportSource: "nativewind" }],
       "nativewind/babel",
     ],
+    // Importa arquivos .md como string (ex.: docs/04-roadmap na Home).
+    plugins: [["babel-plugin-inline-import", { extensions: [".md"] }]],
   };
 };

--- a/constants/roadmap.js
+++ b/constants/roadmap.js
@@ -1,0 +1,149 @@
+// Parser da estrutura do docs/04-roadmap-milestones.md para a Home ("nota
+// de atualização"). O roadmap é a fonte única; aqui só extraímos milestones
+// e itens (✅/🟡/⬜) e limpamos o jargão dev para exibir. É tolerante: linhas
+// fora do padrão são ignoradas, nunca quebra a tela.
+
+/**
+ * @typedef {"done" | "partial" | "todo"} Status
+ * @typedef {{ status: Status, text: string }} RoadmapItem
+ * @typedef {{ id: string, title: string, status: Status, items: RoadmapItem[] }} Milestone
+ * @typedef {{ id: string, title: string, headerStatus: Status | null, items: RoadmapItem[] }} RawMilestone
+ */
+
+/** @type {Record<string, Status>} */
+const STATUS = { "✅": "done", "🟡": "partial", "⬜": "todo" };
+
+const MILESTONE_RE = /^##\s+(M\d+)\b[:\s—–-]*(.*)$/;
+const ITEM_RE = /^\s*-\s+(✅|🟡|⬜)\s+(.*)$/;
+
+/**
+ * Remove markdown e refs técnicas, mantendo só a "manchete" do item.
+ * @param {string} raw
+ * @returns {string}
+ */
+export function cleanText(raw) {
+  let s = String(raw ?? "");
+  s = s.replace(/\[([^\]]+)\]\([^)]*\)/g, "$1"); // [label](url) -> label
+  s = s.replace(/`([^`]+)`/g, "$1"); // `code` -> code
+  s = s.replace(/\*\*([^*]+)\*\*/g, "$1"); // **bold** -> bold
+  s = s.replace(/\([^)]*\)/g, ""); // remove parênteses (refs/detalhes)
+  s = s.replace(/\s#\d+/g, ""); // refs #63 soltas
+  // manchete: corta no primeiro ":", em dash, ou fim da 1ª frase
+  const cut = s.search(/:\s|\s[—–]\s|\.\s|\.$/);
+  if (cut > 15) s = s.slice(0, cut);
+  s = s.replace(/\s+([,.;:])/g, "$1"); // " ," -> ","
+  s = s
+    .replace(/\s{2,}/g, " ")
+    .replace(/[\s.,;:—–-]+$/, "")
+    .trim();
+  return s;
+}
+
+/**
+ * @param {string} headerRest
+ * @returns {Status | null}
+ */
+function titleStatus(headerRest) {
+  for (const emoji of Object.keys(STATUS)) {
+    if (headerRest.includes(emoji)) return STATUS[emoji];
+  }
+  if (/conclu[ií]d/i.test(headerRest)) return "done";
+  if (/andamento/i.test(headerRest)) return "partial";
+  return null;
+}
+
+/**
+ * @param {string} headerRest
+ * @returns {string}
+ */
+function cleanTitle(headerRest) {
+  return headerRest
+    .replace(/[✅🟡⬜]/gu, "")
+    .replace(/\b(conclu[ií]do|em andamento)\b/gi, "")
+    .replace(/\s{2,}/g, " ")
+    .trim();
+}
+
+/**
+ * @param {RoadmapItem[]} items
+ * @returns {Status}
+ */
+function inferStatus(items) {
+  if (items.length === 0) return "todo";
+  if (items.every((i) => i.status === "done")) return "done";
+  if (items.every((i) => i.status === "todo")) return "todo";
+  return "partial";
+}
+
+/**
+ * @param {string} md
+ * @returns {Milestone[]}
+ */
+export function parseRoadmap(md) {
+  /** @type {RawMilestone[]} */
+  const milestones = [];
+  /** @type {RawMilestone | null} */
+  let current = null;
+
+  for (const line of String(md ?? "").split("\n")) {
+    const m = line.match(MILESTONE_RE);
+    if (m) {
+      current = {
+        id: m[1],
+        title: cleanTitle(m[2]),
+        headerStatus: titleStatus(m[2]),
+        items: [],
+      };
+      milestones.push(current);
+      continue;
+    }
+    if (!current) continue;
+    const it = line.match(ITEM_RE);
+    if (it) {
+      const text = cleanText(it[2]);
+      if (text) current.items.push({ status: STATUS[it[1]], text });
+    }
+  }
+
+  return milestones.map(({ headerStatus, ...ms }) => ({
+    ...ms,
+    status: headerStatus ?? inferStatus(ms.items),
+  }));
+}
+
+/**
+ * Seleciona o resumo para a Home a partir das milestones parseadas.
+ * @param {Milestone[]} milestones
+ */
+export function getDigest(milestones) {
+  const total = milestones.length;
+  const done = milestones.filter((m) => m.status === "done").length;
+
+  const currentIndex = (() => {
+    const partial = milestones.findIndex((m) => m.status === "partial");
+    if (partial !== -1) return partial;
+    const todo = milestones.findIndex((m) => m.status === "todo");
+    return todo !== -1 ? todo : Math.max(0, milestones.length - 1);
+  })();
+
+  const current = milestones[currentIndex] ?? null;
+  const currentItems = current?.items ?? [];
+  const currentDone = currentItems.filter((i) => i.status === "done").length;
+
+  // "Concluído recentemente": os ✅ da milestone atual; se poucos, completa
+  // com os da milestone anterior.
+  let recentDone = currentItems.filter((i) => i.status === "done");
+  if (recentDone.length < 3 && currentIndex > 0) {
+    const prev = milestones[currentIndex - 1]?.items ?? [];
+    recentDone = [...prev.filter((i) => i.status === "done"), ...recentDone];
+  }
+  recentDone = recentDone.slice(-4);
+
+  return {
+    milestonesDone: done,
+    milestonesTotal: total,
+    current,
+    currentProgress: { done: currentDone, total: currentItems.length },
+    recentDone,
+  };
+}

--- a/docs/05-guia-migracao-estilo.md
+++ b/docs/05-guia-migracao-estilo.md
@@ -62,7 +62,17 @@ const theme = Colors[colorScheme] ?? Colors.light;
 
 Pra isso funcionar, garanta que o `darkMode` do NativeWind está ativo (o preset já cuida disso na maioria dos setups) e que o app declara suporte a dark mode no `app.json` (`"userInterfaceStyle": "automatic"`).
 
-> **Estado atual (#60):** o `app.json` está travado em `"userInterfaceStyle": "dark"` — o app roda só em dark hoje. Escreva as classes no formato `text-light-x dark:text-dark-x` mesmo assim (custo zero e já fica pronto): com o app em dark, o variant `dark:` sempre vence. Trocar para `"automatic"` e ligar o tema claro de verdade é um passo separado (follow-up), fora do escopo da migração de estilo.
+> **Estado atual (#65):** o `app.json` já está em `"userInterfaceStyle": "automatic"` — o tema claro/escuro real está ligado e segue o sistema. Sempre escreva as duas variantes (`text-light-x dark:text-dark-x`); classes fixas como `text-white` só valem sobre fundo que é escuro nos dois temas.
+
+## Cache: reinicie com `--clear` ao mexer em fontes de build
+
+Nem tudo é resolvido em runtime. Algumas coisas são compiladas em **build** e ficam no cache do Metro — editá-las **não reflete** no app até reiniciar limpando o cache:
+
+```bash
+npx expo start --tunnel --clear
+```
+
+Isso vale para: `constants/Colors.js` e `tailwind.config.js` (as cores de `className` são geradas em build), `babel.config.js`, e qualquer arquivo importado via `babel-plugin-inline-import` (ex.: o `docs/04-roadmap-milestones.md` exibido na Home). Sintoma clássico: você troca uma cor no `Colors.js` ou edita o roadmap e "nada acontece" — é o cache. Já mudanças em `style={{...}}` ou em `Colors.x` usados via JS atualizam na hora (são runtime).
 
 ## Sombra: o único caso que NÃO vai pro className
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "@eslint/json": "^2.0.1",
         "@tailwindcss/postcss": "^4.3.2",
         "@types/react": "~19.2.17",
+        "babel-plugin-inline-import": "^3.0.0",
         "eslint": "^10.6.0",
         "eslint-config-expo": "^57.0.0",
         "eslint-config-prettier": "^10.1.8",
@@ -7086,6 +7087,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-inline-import": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-inline-import/-/babel-plugin-inline-import-3.0.0.tgz",
+      "integrity": "sha512-thnykl4FMb8QjMjVCuZoUmAM7r2mnTn5qJwrryCvDv6rugbJlTHZMctdjDtEgD0WBAXJOLJSGXN3loooEwx7UQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-resolve": "0.0.2"
       }
     },
     "node_modules/babel-plugin-istanbul": {
@@ -16926,6 +16937,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-extra": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/path-extra/-/path-extra-1.0.3.tgz",
+      "integrity": "sha512-vYm3+GCkjUlT1rDvZnDVhNLXIRvwFPaN8ebHAFcuMJM/H0RBOPD7JrcldiNLd9AS3dhAyUHLa4Hny5wp1A+Ffw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -18479,6 +18497,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-resolve": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/require-resolve/-/require-resolve-0.0.2.tgz",
+      "integrity": "sha512-eafQVaxdQsWUB8HybwognkdcIdKdQdQBwTxH48FuE6WI0owZGKp63QYr1MRp73PoX0AcyB7MDapZThYUY8FD0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "x-path": "^0.0.2"
       }
     },
     "node_modules/resolve": {
@@ -20788,6 +20816,16 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/x-path": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/x-path/-/x-path-0.0.2.tgz",
+      "integrity": "sha512-zQ4WFI0XfJN1uEkkrB19Y4TuXOlHqKSxUJo0Yt+axPjRm8tCG6SJ6+Wo3/+Kjg4c2c8IvBXuJ0uYoshxNn4qMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-extra": "^1.0.2"
       }
     },
     "node_modules/xcode": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@eslint/json": "^2.0.1",
     "@tailwindcss/postcss": "^4.3.2",
     "@types/react": "~19.2.17",
+    "babel-plugin-inline-import": "^3.0.0",
     "eslint": "^10.6.0",
     "eslint-config-expo": "^57.0.0",
     "eslint-config-prettier": "^10.1.8",


### PR DESCRIPTION
Refs #67. Substitui o conteúdo hardcoded do `app/index.jsx` por um **digest da milestone atual derivado do `docs/04-roadmap-milestones.md`** — a Home vira uma "nota de atualização" que se atualiza sozinha quando o roadmap é editado (fonte única).

## O que muda
- **`babel-plugin-inline-import`** (+ `babel.config.js`): importa o `.md` como string. Caminho relativo (`../docs/...`) porque o plugin resolve pelo arquivo, não pelo alias `@/`.
- **`constants/roadmap.js`** (novo, JSDoc-tipado): `parseRoadmap` extrai milestones + itens (✅/🟡/⬜) e **limpa o jargão dev** (crases, bold, links, refs, parênteses) em manchetes legíveis; `getDigest` seleciona a milestone atual, o progresso e os concluídos recentes. Tolerante — linhas fora do padrão são ignoradas, nunca quebra a tela.
- **`app/index.jsx`**: UI do digest em NativeWind (barra de progresso + milestone atual + concluído recentemente), theme-aware, mantendo o `MyHeader`.
- **`docs/05`**: documenta a pegadinha do cache transform-time (`--clear`) e atualiza a nota defasada do `app.json`.

## Como fica (com o roadmap atual)
- Progresso: **2/7 milestones** concluídas.
- Milestone atual: **M2 · Modelo de Dados Unificado (3/4)** — itens: ✅ Implementar o Registro unificado na store · ✅ Mapear os campos ad-hoc para o formato unificado · ✅ Ligar as telas ao CRUD · ⬜ Extrair a tela de registro única.
- Concluído recentemente: os 3 itens ✅ acima.

## Validação
- ✅ `tsc`, ESLint, Prettier
- ✅ `expo export` (web/Android/iOS) — **confirma que o `inline-import` do `.md` funciona no bundle**
- ✅ Sanidade do parser contra o roadmap real (digest correto, texto limpo)
- ⏳ **Falta teste no Android** (nos dois temas).

## Notas para o revisor
- **Testar claro/escuro** e conferir a legibilidade do texto limpo.
- **Fonte única:** editar um item no `docs/04`, reiniciar com `--clear`, e a Home reflete.
- Fallback documentado no plano se o `inline-import` desse problema (não deu): `assetExts` + `expo-file-system`.

Refs #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)