### PR TITLE
feat(home): dev utilities — theme toggle and clear-all-data

### DIFF
--- a/app/index.jsx
+++ b/app/index.jsx
@@ -1,6 +1,9 @@
 // @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
 //#region imports
-import { ScrollView, Text, View } from "react-native";
+import { Alert, ScrollView, Text, View } from "react-native";
+import { useColorScheme } from "nativewind";
+import MyButton from "@/components/MyButton";
+import { clearAll } from "@/infra/database";
 
 import MyView from "@/components/MyView";
 import MyHeader from "@/components/MyHeader";
@@ -31,6 +34,18 @@ function ItemRow({ status, text }) {
 }
 
 export default function Home() {
+  const { toggleColorScheme } = useColorScheme();
+
+  function handleClear() {
+    Alert.alert(
+      "Limpar todos os dados",
+      "Isso apaga todos os registros. Tem certeza?",
+      [
+        { text: "Cancelar", style: "cancel" },
+        { text: "Limpar", style: "destructive", onPress: () => clearAll() },
+      ],
+    );
+  }
   const {
     milestonesDone,
     milestonesTotal,
@@ -95,6 +110,12 @@ export default function Home() {
             </MyView>
           </MyView>
         )}
+        {/* Utilitários */}
+        <MyView safe={false} className={`${CARD} gap-2`} style={shadow}>
+          <Text className={LABEL}>UTILITÁRIOS</Text>
+          <MyButton title="Alternar tema" onPress={() => toggleColorScheme()} />
+          <MyButton title="Limpar todos os dados" onPress={handleClear} />
+        </MyView>
       </ScrollView>
     </MyView>
   );

--- a/infra/database.js
+++ b/infra/database.js
@@ -95,3 +95,7 @@ export function getByMonth(type, month) {
     return date.getMonth() === month;
   });
 }
+
+export function clearAll() {
+  store.delTables();
+}


### PR DESCRIPTION
Refs #69. Dois utilitários sempre visíveis na Home.

## O que muda
- **`infra/database.js`**: `clearAll()` → `store.delTables()`. O persister grava o estado vazio automaticamente.
- **`app/index.jsx`**: card "Utilitários" com:
  - **Alternar tema** → `toggleColorScheme()` do NativeWind (light↔dark, sobre o `automatic`).
  - **Limpar todos os dados** → `Alert` de confirmação **destrutiva** (Cancelar / Limpar) antes de apagar.

## Validação
- ✅ `tsc`, ESLint, Prettier, `expo export`
- ✅ **Testado no Android pelo autor** (alterna tema na hora; limpar apaga após confirmar).

## Nota
Limpar pela Home não atualiza telas já montadas na hora (reload-keys manuais) — ao navegar de novo elas releem o store vazio. Follow-up opcional: hooks reativos do TinyBase.

Refs #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)