### PR TITLE
chore(eas): gera apk instalável no perfil preview

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -9,7 +9,10 @@
       "distribution": "internal"
     },
     "preview": {
-      "distribution": "internal"
+      "distribution": "internal",
+      "android": {
+        "buildType": "apk"
+      }
     },
     "production": {
       "autoIncrement": true


### PR DESCRIPTION
## O que muda

Adiciona `android.buildType: "apk"` ao perfil **preview** do `eas.json`. O padrão do EAS para Android é `.aab` (formato de loja, não instalável direto); com `apk` o build `preview` produz um **APK instalável fora do Expo Go**.

```diff
     "preview": {
-      "distribution": "internal"
+      "distribution": "internal",
+      "android": {
+        "buildType": "apk"
+      }
     },
```

## Por quê

Item pendente do **M6** do roadmap (primeiro build EAS instalável). É o **habilitador** dos próximos ciclos: *Notificar Testers* (precisa de URL de download) e *Download do APK no index* (precisa de um APK hospedado).

## Validação

- ✅ Build EAS `preview` **finalizado com sucesso** e gerou **APK** (não .aab), confirmando o `buildType`: [build 15095837](https://expo.dev/accounts/matheushnascimento/projects/backOnTrack/builds/15095837-716f-47da-a88e-091cc237b47d)
- **APK:** https://expo.dev/artifacts/eas/s346_kqpeyJPLKFpBq4mPyw6R0snOeJZ2n5ZVAIGkXM.apk
- ⏳ Pendente: instalar num Android real para confirmar que abre/roda.
- ✅ Lint local verde: prettier (eas.json), eslint, tsc.

Closes #71