### PR TITLE
docs(roadmap): reflete build EAS preview instalável no M6

### DIFF
--- a/docs/04-roadmap-milestones.md
+++ b/docs/04-roadmap-milestones.md
@@ -92,7 +92,7 @@ Esta milestone não existia no plano original — ela nasceu do diagnóstico do 
 - ⬜ Tratamento de erros e estados vazios
 - ⬜ Testes nas funções de domínio (unitários); E2E opcional
 - ⬜ Exportação/backup de dados (JSON/CSV) — a rota de exportação já está prevista
-- 🟡 Build de produção via EAS, instalado fora do Expo Go — `eas.json` (perfis dev/preview/production) e `projectId` em `app.json` já configurados, mas sem build de produção real gerado/instalado
+- 🟡 Build via EAS, instalado fora do Expo Go — perfil `preview` gera **APK** instalável (`buildType: apk`, #71/#72); primeiro APK `preview` gerado e **validado num Android real**. Falta o build de **produção** (`.aab` + submit à loja).
 - ⬜ Documentação de manutenção (como rodar, como publicar updates)
 
 ---


### PR DESCRIPTION
## O que muda

Atualiza o item de build do **M6** no `docs/04-roadmap-milestones.md` para refletir a entrega do #71/#72:

- **Antes:** "sem build de produção real gerado/instalado"
- **Depois:** perfil `preview` gera APK instalável (`buildType: apk`); primeiro APK `preview` gerado e validado num Android real. Build de **produção** (`.aab` + submit) segue explicitamente em aberto.

Segue 🟡 (parcial) — a milestone não fechou, só avançou.

## Por quê

O roadmap é fonte única de verdade **e** a Home (`app/index.jsx`) deriva dele em runtime (`parseRoadmap`/`getDigest`). Manter o roadmap em dia mantém a "nota de atualização" da tela index honesta. Editar só o markdown já propaga pra Home — nenhuma mudança de código necessária.

## Validação

- Prettier verde no doc; parser (`constants/roadmap.js`) continua casando o item como 🟡.
- Sem mudança de comportamento na Home além do texto do item (a milestone "atual" exibida continua sendo o M2).