### PR TITLE
feat(home): instalação self-service do app na web (#74)

### DIFF
--- a/app/index.jsx
+++ b/app/index.jsx
@@ -7,6 +7,7 @@ import { clearAll } from "@/infra/database";
 
 import MyView from "@/components/MyView";
 import MyHeader from "@/components/MyHeader";
+import InstallApp from "@/components/InstallApp";
 
 import { shadow } from "@/constants/Colors";
 import { parseRoadmap, getDigest } from "@/constants/roadmap";
@@ -110,6 +111,9 @@ export default function Home() {
             </MyView>
           </MyView>
         )}
+        {/* Obter o app (só web: QR no desktop, download no celular) */}
+        <InstallApp />
+
         {/* Utilitários */}
         <MyView safe={false} className={`${CARD} gap-2`} style={shadow}>
           <Text className={LABEL}>UTILITÁRIOS</Text>

--- a/components/InstallApp.jsx
+++ b/components/InstallApp.jsx
@@ -1,0 +1,11 @@
+// Card "Obter o app" — versão nativa (no-op).
+//
+// A obtenção do APK só faz sentido na web: quem já está no app nativo não
+// precisa baixá-lo. O Metro resolve InstallApp.web.jsx no bundle web e este
+// arquivo no nativo, então o card simplesmente não existe fora da web — sem
+// espalhar checagens de Platform.OS pela árvore. Mesmo padrão de
+// infra/persistence.js vs infra/persistence.web.js.
+
+export default function InstallApp() {
+  return null;
+}

--- a/components/InstallApp.web.jsx
+++ b/components/InstallApp.web.jsx
@@ -1,0 +1,74 @@
+// Card "Obter o app" — versão web (Ciclo 3, #74).
+//
+// Só existe no bundle web (o Metro resolve este .web.jsx na web e o
+// InstallApp.jsx no nativo). Detecta o navegador:
+//  - desktop  -> QR code apontando pro APK, pra escanear com o celular e não
+//               baixar o .apk no PC;
+//  - celular  -> botão de download/instalação direta.
+// O QR é gerado offline (react-native-qrcode-svg sobre react-native-svg), sem
+// nenhuma chamada a serviço externo.
+
+import { useEffect, useState } from "react";
+import { Linking, Text, View } from "react-native";
+import QRCode from "react-native-qrcode-svg";
+
+import MyView from "@/components/MyView";
+import MyButtonRaw from "@/components/MyButton";
+import { shadow } from "@/constants/Colors";
+import { APK_URL } from "@/constants/distribution";
+
+// MyButton é legado (@ts-nocheck, ADR-002): sua assinatura inferida marca as
+// props como obrigatórias, o que quebra consumidores tipados. Tratamos como
+// any até ele ser tipado de fato.
+const MyButton = /** @type {any} */ (MyButtonRaw);
+
+const CARD =
+  "w-full max-w-[640px] rounded-lg bg-light-backgroundCard p-4 dark:bg-dark-backgroundCard";
+const LABEL =
+  "font-bold text-xs text-light-text opacity-60 dark:text-dark-text";
+const TEXT = "text-center text-base text-light-text dark:text-dark-text";
+
+function isMobileBrowser() {
+  if (typeof navigator === "undefined") return false;
+  return /Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent);
+}
+
+export default function InstallApp() {
+  // Detecta após a montagem (client-side) pra não divergir do render estático;
+  // o desktop (QR) é o default seguro enquanto não há navigator.
+  const [mobile, setMobile] = useState(false);
+  useEffect(() => setMobile(isMobileBrowser()), []);
+
+  return (
+    <MyView
+      safe={false}
+      className={`${CARD} items-center gap-3`}
+      style={shadow}
+    >
+      <Text className={`${LABEL} self-start`}>OBTER O APP</Text>
+      {mobile ? (
+        <>
+          <Text className={TEXT}>Baixe o APK e instale no seu Android.</Text>
+          <MyButton
+            title="Baixar APK"
+            onPress={() => Linking.openURL(APK_URL)}
+          />
+        </>
+      ) : (
+        <>
+          <Text className={TEXT}>
+            Aponte a câmera do celular pra baixar o APK no Android.
+          </Text>
+          <View className="rounded-lg bg-white p-3">
+            <QRCode
+              value={APK_URL}
+              size={180}
+              backgroundColor="#ffffff"
+              color="#000000"
+            />
+          </View>
+        </>
+      )}
+    </MyView>
+  );
+}

--- a/constants/distribution.js
+++ b/constants/distribution.js
@@ -1,0 +1,7 @@
+// Fonte única da URL de distribuição do app. O link /releases/latest/download
+// é estável: sempre resolve pro asset da release mais recente (não pre-release).
+// Usado pelo card de instalação na web (Ciclo 3) e, futuramente, pela mensagem
+// de notificação dos testers (Ciclo 4).
+
+export const APK_URL =
+  "https://github.com/matheushnascimento/backOnTrack/releases/latest/download/backOnTrack.apk";

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "react-dom": "19.2.7",
         "react-native": "0.86.0",
         "react-native-paper": "^5.15.3",
+        "react-native-qrcode-svg": "^6.3.21",
         "react-native-reanimated": "4.5.0",
         "react-native-safe-area-context": "~5.7.0",
         "react-native-screens": "~4.25.2",
@@ -8471,6 +8472,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/decode-uri-component": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
@@ -8617,6 +8627,12 @@
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
@@ -17443,7 +17459,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -17455,7 +17470,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/punycode": {
@@ -17483,6 +17497,183 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/qrcode/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/qrcode/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/qrcode/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/qrcode/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/query-string": {
       "version": "7.1.3",
@@ -18029,6 +18220,22 @@
         "color-string": "^1.6.0"
       }
     },
+    "node_modules/react-native-qrcode-svg": {
+      "version": "6.3.21",
+      "resolved": "https://registry.npmjs.org/react-native-qrcode-svg/-/react-native-qrcode-svg-6.3.21.tgz",
+      "integrity": "sha512-6vcj4rcdpWedvphDR+NSJcudJykNuLgNGFwm2p4xYjR8RdyTzlrELKI5LkO4ANS9cQUbqsfkpippPv64Q2tUtA==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.0",
+        "qrcode": "^1.5.4",
+        "text-encoding": "^0.7.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": ">=0.63.4",
+        "react-native-svg": ">=14.0.0"
+      }
+    },
     "node_modules/react-native-reanimated": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.5.0.tgz",
@@ -18499,6 +18706,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
+    },
     "node_modules/require-resolve": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/require-resolve/-/require-resolve-0.0.2.tgz",
@@ -18864,6 +19077,12 @@
       "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
       "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
       "license": "MIT"
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -19792,6 +20011,13 @@
         "node": "*"
       }
     },
+    "node_modules/text-encoding": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.7.0.tgz",
+      "integrity": "sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA==",
+      "deprecated": "no longer maintained",
+      "license": "(Unlicense OR Apache-2.0)"
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -20633,6 +20859,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
     },
     "node_modules/which-typed-array": {
       "version": "1.1.22",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react-dom": "19.2.7",
     "react-native": "0.86.0",
     "react-native-paper": "^5.15.3",
+    "react-native-qrcode-svg": "^6.3.21",
     "react-native-reanimated": "4.5.0",
     "react-native-safe-area-context": "~5.7.0",
     "react-native-screens": "~4.25.2",


### PR DESCRIPTION
Fecha o Ciclo 3 de distribuição: o tester obtém o APK mais recente sozinho pela Home web.

## O que muda

**Card "Obter o app" na Home — só no bundle web** (`components/InstallApp.web.jsx`; o `InstallApp.jsx` nativo é no-op, mesmo padrão de `infra/persistence.web.js`):
- **Desktop:** QR code apontando pro APK — pra escanear com o celular e não baixar o `.apk` no PC.
- **Navegador do celular:** botão "Baixar APK" com download/instalação direta.
- **App nativo:** o card não existe (quem está no app não precisa baixá-lo).
- QR gerado **offline** com `react-native-qrcode-svg` (sobre o `react-native-svg` já presente) — sem serviço externo.

**URL do APK centralizada** em `constants/distribution.js` → `https://github.com/matheushnascimento/backOnTrack/releases/latest/download/backOnTrack.apk` (release `v0.1.0-beta.1` publicada; o `/latest/` sempre resolve pro build mais novo). Fonte única, reusável pela notificação do Ciclo 4.

## Como testar (preview da Vercel)

- **Desktop:** abrir o preview → card "Obter o app" mostra o QR; escanear baixa o APK.
- **Celular (navegador):** abrir o preview → card mostra o botão "Baixar APK".
- **App nativo:** o card não aparece.

## Notas

- Gates locais verdes: prettier, eslint, tsc.
- `MyButton` (legado `@ts-nocheck`) é tratado como `any` na importação do arquivo web — sua assinatura inferida marca props como obrigatórias e quebraria o consumidor tipado. Dívida sinalizada, não propagada.

Closes #74