### PR TITLE
feat(scripts): gera mensagem de release pros testers (#78)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "backOnTrack",
   "version": "1.0.0",
+  "homepage": "https://backontrack.mhdn.com.br",
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start --tunnel",
@@ -8,6 +9,7 @@
     "ios": "expo run:ios",
     "web": "expo start --web",
     "vercel-build": "expo export",
+    "notify:testers": "node scripts/notify-testers.mjs",
     "lint:prettier:check": "prettier --check .",
     "lint:prettier:fix": "prettier --write .",
     "lint:eslint:check": "eslint .",

--- a/scripts/notify-testers.mjs
+++ b/scripts/notify-testers.mjs
@@ -1,0 +1,101 @@
+// Notificar Testers (Ciclo 5, #78) — WhatsApp assistido.
+//
+// Monta a mensagem de aviso da release mais recente pra colar na lista de
+// transmissão do WhatsApp. NÃO envia nada: lista de transmissão não tem API
+// oficial e automação não-oficial viola o ToS. Só imprime e, se possível, copia
+// pro clipboard.
+//
+// Uso: npm run notify:testers
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+/** @param {string} msg */
+function fail(msg) {
+  console.error(`✖ ${msg}`);
+  process.exit(1);
+}
+
+function readHomepage() {
+  const pkg = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf8"));
+  if (!pkg.homepage) {
+    fail("package.json não tem o campo 'homepage' (URL pública da Home).");
+  }
+  return pkg.homepage;
+}
+
+function readLatestRelease() {
+  try {
+    const out = execFileSync(
+      "gh",
+      ["release", "view", "--json", "tagName,body"],
+      { cwd: ROOT, encoding: "utf8" },
+    );
+    return JSON.parse(out);
+  } catch {
+    fail(
+      "não consegui ler a release mais recente via 'gh'. Confira se o gh está " +
+        "instalado, autenticado, e se há releases publicadas.",
+    );
+  }
+}
+
+/**
+ * @param {{ tagName: string, body?: string | null }} release
+ * @param {string} homepage
+ * @returns {string}
+ */
+function buildMessage({ tagName, body }, homepage) {
+  const novidades = (body ?? "").trim();
+  const linhas = [`🚀 Back on Track — ${tagName}`, ""];
+  if (novidades) linhas.push(novidades, "");
+  linhas.push(
+    "📲 Instalar / atualizar:",
+    homepage,
+    "",
+    "ℹ️ Já tem o app? Melhorias pequenas chegam sozinhas ao abrir. Baixe de " +
+      "novo só quando eu avisar que é versão nova.",
+  );
+  return linhas.join("\n");
+}
+
+/**
+ * @param {string} text
+ * @returns {string | null}
+ */
+function copyToClipboard(text) {
+  const tools = [
+    ["wl-copy", []],
+    ["xclip", ["-selection", "clipboard"]],
+    ["xsel", ["--clipboard", "--input"]],
+  ];
+  for (const [cmd, args] of tools) {
+    try {
+      execFileSync(cmd, args, { input: text });
+      return cmd;
+    } catch {
+      // ferramenta ausente/indisponível: tenta a próxima
+    }
+  }
+  return null;
+}
+
+const homepage = readHomepage();
+const release = readLatestRelease();
+const message = buildMessage(release, homepage);
+
+console.log(message);
+console.log("\n" + "─".repeat(40));
+
+const copied = copyToClipboard(message);
+if (copied) {
+  console.log(
+    `✓ Copiado pro clipboard (${copied}). Cole na lista de transmissão.`,
+  );
+} else {
+  console.log("ℹ Clipboard indisponível — copie o texto acima manualmente.");
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
     "babel.config.js",
     "metro.config.js",
     "jest.config.js",
-    "tailwind.config.js"
+    "tailwind.config.js",
+    "scripts"
   ]
 }


### PR DESCRIPTION
Fecha o Ciclo 5 — último dos três tópicos originais da trilha de distribuição (utilitários ✅, download self-service ✅, **notificar testers** = este).

## O que muda

- **`scripts/notify-testers.mjs`** (novo) — `npm run notify:testers`:
  - Lê a release mais recente via `gh` (`tagName`, `body`).
  - Monta a mensagem de aviso: título com a tag + novidades (notas da release) + link público da Home + nota curta sobre OTA ("melhorias pequenas chegam sozinhas; baixe de novo só quando avisar").
  - **Imprime** e **copia pro clipboard** (best-effort: `wl-copy` → `xclip` → `xsel`; se nenhum, só imprime).
  - **WhatsApp assistido:** não envia nada (lista de transmissão não tem API; automação não-oficial viola ToS) — só prepara o texto pra colar na lista.
- **`package.json`** — script `notify:testers` + campo `homepage` (`https://backontrack.mhdn.com.br`, fonte única da URL pública da Home).
- **`tsconfig.json`** — exclui `scripts/` (tooling Node roda fora do runtime do app; segue o precedente dos outros arquivos de config já excluídos).

## Validação

- Gates verdes: prettier, eslint, tsc.
- Rodado localmente: gera a mensagem correta pra `v0.1.0-beta.2` com as notas e o link público. (Clipboard caiu no fallback por não haver ferramenta instalada neste ambiente — degrada como esperado.)

## Como testar

1. `npm run notify:testers` → confere a mensagem (tag/notas/link).
2. Abrir `https://backontrack.mhdn.com.br` numa aba anônima → garante que é público (o que o tester vê).

Closes #78