### PR TITLE
fix(theme): habilita darkMode class no Tailwind pro toggle na web

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,6 +4,7 @@ const { Colors } = require("./constants/Colors");
 module.exports = {
   content: ["app/**/*.*", "components/**/*.*"],
   presets: [require("nativewind/preset")],
+  darkMode: "class",
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
## Problema

Na web, clicar em **"Alternar tema"** (Home › Utilitários) lançava:

```
Cannot manually set color scheme, as dark mode is type 'media'.
Please use StyleSheet.setFlag('darkMode', 'class')
```

## Causa

`tailwind.config.js` não definia `darkMode`, então o NativeWind caía no default `'media'`. Nesse modo, `setColorScheme`/`toggleColorScheme` lançam exceção — o `toggleColorScheme()` do botão quebrava na web.

## Mudança

Uma linha: `darkMode: "class"` no `tailwind.config.js`. No NativeWind v4 isso habilita a alternância manual e mantém o color scheme iniciando em `system` (segue o SO), preservando o tema automático.

## Verificação

- [x] `eslint`, `prettier`, `tsc --noEmit` verdes
- [ ] **Runtime (web):** carga inicial reflete o tema do SO; clicar "Alternar tema" alterna sem o erro no console; reload mantém consistente

Fora de escopo: warning `shadow*` deprecated e o erro de extensão do Chrome (ambos não são código do app).

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)