### PR TITLE
feat(ota): fixa runtime em appVersion e publica OTA no merge

### DIFF
--- a/.github/workflows/publish-update.yaml
+++ b/.github/workflows/publish-update.yaml
@@ -1,0 +1,28 @@
+name: Publish Update
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  publish:
+    name: Publica OTA no canal preview
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "lts/jod"
+
+      - run: npm ci
+
+      - uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Publica OTA
+        env:
+          MSG: ${{ github.event.head_commit.message }}
+        run: eas update --branch preview --environment preview --message "$MSG" --non-interactive

--- a/app.json
+++ b/app.json
@@ -9,8 +9,9 @@
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
     "runtimeVersion": {
-      "policy": "fingerprint"
+      "policy": "appVersion"
     },
+
     "updates": {
       "url": "https://u.expo.dev/d0a4dfc2-3743-440f-b129-b76e31351707"
     },


### PR DESCRIPTION
## Problema

Descoberto com o app mobile (`beta.3`) divergindo da web: o M2 aparecia **aberto** no app e **fechado** na web. Duas causas:

1. **`runtimeVersion: fingerprint` frágil** — o hash do `@expo/fingerprint` mudou com uma edição trivial (`homepage` + script, Ciclo 5), quebrando a compatibilidade OTA com o `beta.3`.
2. **Sem pipeline de OTA no merge** — nada publicava OTA no canal `preview` quando a `main` mudava; o último `eas update` foi manual (Ciclo 4).

## Mudança

- **`app.json`:** `runtimeVersion.policy` `fingerprint` → `appVersion` (runtime = `1.0.0`). OTA passa a alcançar todos os builds da mesma versão, estável a edições não-nativas.
- **`.github/workflows/publish-update.yaml`** (novo): `on: push` na `main` → `eas update --branch preview` (usa `EXPO_TOKEN`). O `eas.json` já mapeia o profile preview ao `channel: preview`, então o update alcança os builds preview.

## Verificação

- [x] `eslint`, `prettier`, `tsc` verdes localmente
- [ ] **Pós-merge:** o próprio merge dispara o workflow → confirmar run verde em Actions e o update publicado no branch `preview` (EAS)
- [ ] **Build `beta.4`** com a política nova (via workflow `Release`), instalar, e confirmar que um merge só-JS na `main` chega no app **sem rebuild**

## Fora de escopo

Rebaixar a versão do `app.json`; tela "hoje" do M3.

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)