### PR TITLE
build(android): limita o APK a arm64-v8a (114 MB → ~40 MB)

### DIFF
--- a/app.json
+++ b/app.json
@@ -37,7 +37,7 @@
       "bundler": "metro",
       "favicon": "./assets/favicon.png"
     },
-    "plugins": ["expo-router", "expo-sqlite"],
+    "plugins": ["expo-router", "expo-sqlite", "./plugins/withArm64Only.js"],
     "extra": {
       "router": {},
       "eas": {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,6 @@
 import { defineConfig, globalIgnores } from "eslint/config";
 import js from "@eslint/js";
+import globals from "globals";
 
 export default defineConfig([
   globalIgnores([
@@ -21,6 +22,14 @@ export default defineConfig([
     rules: {
       "no-unused-vars": "warn",
       "no-undef": "warn",
+    },
+  },
+  {
+    // Config plugins do Expo são tooling Node (CommonJS), não código do app.
+    files: ["plugins/**/*.js"],
+    languageOptions: {
+      sourceType: "commonjs",
+      globals: globals.node,
     },
   },
 ]);

--- a/plugins/withArm64Only.js
+++ b/plugins/withArm64Only.js
@@ -1,0 +1,26 @@
+// Limita as arquiteturas nativas do build Android a arm64-v8a (issue #87).
+//
+// O APK do perfil `preview` era "universal": empacotava libs nativas de 4
+// arquiteturas (arm64-v8a + armeabi-v7a + x86 + x86_64 = 114 MB). x86/x86_64 só
+// servem emulador e armeabi-v7a só celular 32-bit antigo — peso morto que fazia
+// o download travar no celular dos testers.
+//
+// Fixar `reactNativeArchitectures=arm64-v8a` no gradle.properties faz o
+// gradle-plugin do React Native aplicar `ndk.abiFilters` (NdkConfiguratorUtils.kt)
+// e gerar um APK só arm64 (~40 MB), que cobre a maioria esmagadora dos aparelhos
+// (2017+). Roda no prebuild do EAS.
+
+const { withGradleProperties } = require("@expo/config-plugins");
+
+const KEY = "reactNativeArchitectures";
+const VALUE = "arm64-v8a";
+
+module.exports = function withArm64Only(config) {
+  return withGradleProperties(config, (cfg) => {
+    cfg.modResults = cfg.modResults.filter(
+      (item) => !(item.type === "property" && item.key === KEY),
+    );
+    cfg.modResults.push({ type: "property", key: KEY, value: VALUE });
+    return cfg;
+  });
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
     "metro.config.js",
     "jest.config.js",
     "tailwind.config.js",
-    "scripts"
+    "scripts",
+    "plugins"
   ]
 }


### PR DESCRIPTION
## Problema

O APK do perfil `preview` é **universal** — empacota libs nativas de 4 arquiteturas: arm64-v8a (22 MB), armeabi-v7a (15 MB), x86 (23 MB), x86_64 (23 MB) = **114 MB**. `x86`/`x86_64` só servem emulador; `armeabi-v7a` só celular 32-bit antigo. O download grande **travava no celular dos testers** ("downloading infinito").

## Mudança

- **`plugins/withArm64Only.js`** (novo): config plugin usando `withGradleProperties` pra fixar `reactNativeArchitectures=arm64-v8a` no `gradle.properties` do prebuild. O gradle-plugin do RN converte em `ndk.abiFilters` (`NdkConfiguratorUtils.kt`) → APK só arm64.
- **`app.json`:** registra o plugin.
- **`tsconfig.json`:** exclui `plugins/` do checkJs (como `scripts/`).
- **`eslint.config.mjs`:** globals Node/CommonJS pra `plugins/`.

## Verificação

- [x] `prebuild -p android` local gera `gradle.properties` com `reactNativeArchitectures=arm64-v8a` (confirmado, artefatos limpos depois)
- [x] `eslint`, `prettier`, `tsc` verdes
- [ ] **Pós-merge:** build `beta.5` → inspecionar o APK (só `lib/arm64-v8a/`, ~40 MB)

## Notas

Runtime segue `1.0.0` (política `appVersion`), então o OTA **não quebra**: quem está no `beta.4` continua recebendo updates de JS. Aparelhos x86 (emulador) e 32-bit muito antigos deixam de ser suportados — aceitável pro grupo de testers.

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)