### PR TITLE
feat(home): adiciona tagline sob o título

### DIFF
--- a/app/index.jsx
+++ b/app/index.jsx
@@ -73,6 +73,9 @@ export default function Home() {
           <Text className="font-bold text-2xl text-light-text dark:text-dark-text">
             Back on Track
           </Text>
+          <Text className="text-sm text-light-text opacity-70 dark:text-dark-text">
+            De volta aos trilhos, um registro por vez.
+          </Text>
           <Text className="font-bold text-base text-light-text opacity-60 dark:text-dark-text">
             {milestonesDone} de {milestonesTotal} milestones concluídas
           </Text>


### PR DESCRIPTION
## O que

Adiciona um tagline discreto sob o título "Back on Track" na Home:

> *De volta aos trilhos, um registro por vez.*

## Por quê

Duas coisas de uma vez:
1. Um toque de identidade na Home (melhoria real, vai pros testers).
2. É uma mudança **só-JS** — serve de teste de campo do OTA: depois de instalar o `beta.5`, mergear este PR dispara o `publish-update.yaml`, e a linha nova deve aparecer no app **sem rebuild**.

## Como validar o OTA (roteiro)

1. Instalar o `beta.5` (sem o tagline ainda).
2. Mergear este PR → workflow publica OTA no `preview`.
3. Fechar e reabrir o app → o tagline aparece. Mobile e web deixam de divergir.

Mudança JS pura (uma linha de texto), sem efeito nativo — runtime segue `1.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)