### PR TITLE
feat(install): distribui o beta pela página do EAS (Chrome bloqueia APK do GitHub)

### DIFF
--- a/components/InstallApp.web.jsx
+++ b/components/InstallApp.web.jsx
@@ -1,10 +1,12 @@
-// Card "Obter o app" — versão web (Ciclo 3, #74).
+// Card "Obter o app" — versão web (Ciclo 3, #74; distribuição via EAS #90).
 //
 // Só existe no bundle web (o Metro resolve este .web.jsx na web e o
 // InstallApp.jsx no nativo). Detecta o navegador:
-//  - desktop  -> QR code apontando pro APK, pra escanear com o celular e não
-//               baixar o .apk no PC;
-//  - celular  -> botão de download/instalação direta.
+//  - desktop  -> QR code da página de instalação do EAS, pra escanear com o
+//               celular;
+//  - celular  -> botão que abre a página de instalação do EAS.
+// Aponta pro EAS (não pro APK direto do GitHub) porque o Chrome do Android
+// bloqueia download de APK de URL pública; a página do EAS instala no Chrome.
 // O QR é gerado offline (react-native-qrcode-svg sobre react-native-svg), sem
 // nenhuma chamada a serviço externo.
 
@@ -15,7 +17,7 @@ import QRCode from "react-native-qrcode-svg";
 import MyView from "@/components/MyView";
 import MyButtonRaw from "@/components/MyButton";
 import { shadow } from "@/constants/Colors";
-import { APK_URL } from "@/constants/distribution";
+import { EAS_INSTALL_URL } from "@/constants/distribution";
 
 // MyButton é legado (@ts-nocheck, ADR-002): sua assinatura inferida marca as
 // props como obrigatórias, o que quebra consumidores tipados. Tratamos como
@@ -48,20 +50,22 @@ export default function InstallApp() {
       <Text className={`${LABEL} self-start`}>OBTER O APP</Text>
       {mobile ? (
         <>
-          <Text className={TEXT}>Baixe o APK e instale no seu Android.</Text>
+          <Text className={TEXT}>
+            Abra a página de instalação e toque em Install.
+          </Text>
           <MyButton
-            title="Baixar APK"
-            onPress={() => Linking.openURL(APK_URL)}
+            title="Instalar o app"
+            onPress={() => Linking.openURL(EAS_INSTALL_URL)}
           />
         </>
       ) : (
         <>
           <Text className={TEXT}>
-            Aponte a câmera do celular pra baixar o APK no Android.
+            Aponte a câmera do celular pra abrir a instalação no Android.
           </Text>
           <View className="rounded-lg bg-white p-3">
             <QRCode
-              value={APK_URL}
+              value={EAS_INSTALL_URL}
               size={180}
               backgroundColor="#ffffff"
               color="#000000"

--- a/constants/distribution.js
+++ b/constants/distribution.js
@@ -1,7 +1,18 @@
-// Fonte única da URL de distribuição do app. O link /releases/latest/download
-// é estável: sempre resolve pro asset da release mais recente (não pre-release).
-// Usado pelo card de instalação na web (Ciclo 3) e, futuramente, pela mensagem
-// de notificação dos testers (Ciclo 4).
+// Fonte única das URLs de distribuição do app.
+//
+// EAS_INSTALL_URL: página de instalação interna do build EAS. É o que o card
+// "Obter o app" usa, porque o Chrome do Android BLOQUEIA o download direto de
+// APK de URL pública (o Safe Browsing baixa 100% e descarta o arquivo); a
+// página do EAS instala mesmo no Chrome (testado deslogado, em aba anônima).
+// É POR BUILD — trocar a cada build NATIVO novo (raro: o OTA cobre mudanças de
+// JS). Ver issue #90.
+//
+// APK_URL: download direto do APK via GitHub Releases (/latest/, estável).
+// Mantido como arquivo/histórico e fallback (funciona em Firefox/Samsung
+// Internet, mas trava no Chrome). Ciclo 3, #74.
+
+export const EAS_INSTALL_URL =
+  "https://expo.dev/accounts/matheushnascimento/projects/backOnTrack/builds/a847923f-2975-4b74-9ccc-2661999e595c";
 
 export const APK_URL =
   "https://github.com/matheushnascimento/backOnTrack/releases/latest/download/backOnTrack.apk";


### PR DESCRIPTION
## Problema

O download direto do APK pelo GitHub Releases **trava no Chrome do Android**: o Safe Browsing baixa 100% e descarta o APK de URL pública, sem "manter" (relato real). Não é tamanho nem host — `curl`/LAN baixam inteiro, e o link completa em Firefox/Samsung Internet.

## Descoberta

A **página de instalação interna do EAS** (`expo.dev/.../builds/<id>`) instala **no mesmo Chrome**, testada **deslogada, em aba anônima** → serve pros testers sem conta Expo.

## Mudança

- `constants/distribution.js`: adiciona `EAS_INSTALL_URL` (mantém `APK_URL` como arquivo/fallback).
- `components/InstallApp.web.jsx`: QR (desktop) e botão (celular) apontam pro EAS; copy ajustada ("Instalar o app" / "abrir a instalação").
- Mensagem dos testers **não muda** (aponta pra `homepage`, que renderiza o card → agora via EAS).

## Notas / verificação

- [x] `eslint`/`prettier`/`tsc` verdes
- [ ] **Pós-merge:** Vercel redeploya a Home; abrir `backontrack.mhdn.com.br` no celular → botão/QR levam pra instalação do EAS.
- `EAS_INSTALL_URL` é **por build** (`builds/<id>`): atualizar a cada **build nativo** (raro — o OTA cobre JS). Futuro: automatizar a captura no `release.yaml`.

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)