### PR TITLE
ci(release): captura a EAS_INSTALL_URL do build e abre PR

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,13 +32,17 @@ jobs:
           token: ${{ secrets.EXPO_TOKEN }}
 
       - name: Build APK no EAS
+        id: build
         run: |
-          APK_URL=$(eas build --platform android --profile preview --non-interactive --wait --json \
-            | jq -r '.[0].artifacts.applicationArchiveUrl')
-          if [ -z "$APK_URL" ] || [ "$APK_URL" = "null" ]; then
-            echo "Não foi possível obter a URL do APK do build." >&2
+          BUILD_JSON=$(eas build --platform android --profile preview --non-interactive --wait --json)
+          APK_URL=$(echo "$BUILD_JSON" | jq -r '.[0].artifacts.applicationArchiveUrl')
+          BUILD_ID=$(echo "$BUILD_JSON" | jq -r '.[0].id')
+          if [ -z "$APK_URL" ] || [ "$APK_URL" = "null" ] \
+            || [ -z "$BUILD_ID" ] || [ "$BUILD_ID" = "null" ]; then
+            echo "Não foi possível obter URL/ID do build EAS." >&2
             exit 1
           fi
+          echo "build_id=$BUILD_ID" >> "$GITHUB_OUTPUT"
           curl -sSL -o backOnTrack.apk "$APK_URL"
 
       - name: Publicar release no GitHub
@@ -49,3 +53,34 @@ jobs:
             "backOnTrack.apk#backOnTrack.apk" \
             --title "Back on Track ${{ inputs.tag }}" \
             --notes "${{ inputs.notes }}"
+
+      # Aponta a EAS_INSTALL_URL pro build recém-criado. Não commita na main
+      # (ruleset exige PR) nem abre o PR via API (PR do GITHUB_TOKEN não dispara
+      # o linting.yaml `on: pull_request`, travando os checks). Empurra a branch
+      # e deixa um link pro humano abrir o PR — aí o CI roda normal. Issue #92.
+      - name: Atualiza EAS_INSTALL_URL (branch + link de PR)
+        env:
+          BUILD_ID: ${{ steps.build.outputs.build_id }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          EAS_URL="https://expo.dev/accounts/matheushnascimento/projects/backOnTrack/builds/${BUILD_ID}"
+          sed -i -E "s#(projects/backOnTrack/builds/)[a-f0-9-]+#\1${BUILD_ID}#" constants/distribution.js
+          if git diff --quiet constants/distribution.js; then
+            echo "EAS_INSTALL_URL já aponta pro build atual — nada a fazer." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          BRANCH="chore/eas-install-url-${TAG}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add constants/distribution.js
+          git commit -m "chore(install): aponta a instalação pro build ${TAG}"
+          git push -u origin "$BRANCH"
+          PR_URL="https://github.com/matheushnascimento/backOnTrack/compare/main...${BRANCH}?expand=1"
+          {
+            echo "## EAS_INSTALL_URL do novo build"
+            echo ""
+            echo "Build \`${TAG}\` → ${EAS_URL}"
+            echo ""
+            echo "Branch \`${BRANCH}\` empurrada. **[Abrir o PR](${PR_URL})** e mergear pra atualizar o card \"Obter o app\"."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## O que

Automatiza o passo manual do #90: a cada build nativo, atualizar a `EAS_INSTALL_URL` em `constants/distribution.js`.

## Como

- Step "Build APK no EAS": captura o JSON do `eas build` uma vez e extrai `applicationArchiveUrl` **e** `.id` (output `build_id`).
- Novo step: monta `expo.dev/.../builds/<id>`, faz `sed` na constante e, se mudou, empurra a branch `chore/eas-install-url-<tag>` com commit convencional, deixando **link de "abrir PR" no resumo da run**.

## Por que branch + link (não commit direto nem PR via API)

- `main` tem ruleset `pull_request` → sem push direto (nem do bot).
- PR aberto pelo `GITHUB_TOKEN` **não dispara** o `linting.yaml` (`on: pull_request`) → checks obrigatórios não rodam → merge travaria.
- Então: workflow empurra a branch; **humano abre o PR** (CI roda) e mergeia. ~2 cliques por build nativo (raro).

## Verificação

- [x] `prettier` no workflow verde
- [x] `sed` testado local: muda **só** a linha da `EAS_INSTALL_URL`
- [ ] Fim a fim: só no próximo `Release` (workflow_dispatch) — o resumo da run trará o link do PR

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)