### PR TITLE
chore(scripts): web sobe na LAN sem abrir browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "expo start --tunnel",
     "android": "expo run:android",
     "ios": "expo run:ios",
-    "web": "expo start --web",
+    "web": "BROWSER=none expo start --web --port 8081 --host lan",
     "vercel-build": "expo export",
     "notify:testers": "node scripts/notify-testers.mjs",
     "lint:prettier:check": "prettier --check .",


### PR DESCRIPTION
QoL: `npm run web` cristaliza os flags que já usávamos à mão.

`"web": "expo start --web"` → `"web": "BROWSER=none expo start --web --port 8081 --host lan"`

- `BROWSER=none` — mata o `spawn xdg-open ENOENT` no homeserver headless.
- `--host lan` — expõe na rede local (acesso pelo celular/notebook).
- `--port 8081` — porta fixa (default do Expo; exige o `evolution_api` desligado).

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)