### PR TITLE
feat(home): tela "hoje" com o resumo do dia na landing

### DIFF
--- a/app/_layout.jsx
+++ b/app/_layout.jsx
@@ -22,7 +22,8 @@ export default function RootLayout() {
           headerTintColor: theme.text,
         }}
       >
-        <Stack.Screen name="index" options={{ title: "Home" }} />
+        <Stack.Screen name="index" options={{ title: "Hoje" }} />
+        <Stack.Screen name="roadmap" options={{ title: "Roadmap" }} />
         <Stack.Screen name="export" options={{ title: "Exportação" }} />
         <Stack.Screen name="(history)" />
         <Stack.Screen name="(metrics)" />

--- a/app/index.jsx
+++ b/app/index.jsx
@@ -1,41 +1,63 @@
 // @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
 //#region imports
+import { useCallback, useState } from "react";
 import { Alert, ScrollView, Text, View } from "react-native";
 import { useColorScheme } from "nativewind";
-import MyButton from "@/components/MyButton";
-import { clearAll } from "@/infra/database";
+import { router, useFocusEffect } from "expo-router";
 
+import MyButton from "@/components/MyButton";
 import MyView from "@/components/MyView";
 import MyHeader from "@/components/MyHeader";
 import InstallApp from "@/components/InstallApp";
 
+import { clearAll, getToday } from "@/infra/database";
+import { CATEGORY_MAP } from "@/components/categoryUtils";
+import { minutesToHHMM } from "@/constants/duration";
 import { shadow } from "@/constants/Colors";
-import { parseRoadmap, getDigest } from "@/constants/roadmap";
-// Caminho relativo de propósito: o babel-plugin-inline-import resolve pelo
-// arquivo, não pelo alias @/. Editar o roadmap exige reiniciar com --clear.
-import roadmapMd from "../docs/04-roadmap-milestones.md";
 //#endregion
-
-const STATUS_ICON = { done: "✅", partial: "🟡", todo: "⬜" };
-const digest = getDigest(parseRoadmap(roadmapMd));
 
 const CARD =
   "w-full max-w-[640px] rounded-lg bg-light-backgroundCard p-4 dark:bg-dark-backgroundCard";
 const LABEL =
   "font-bold text-xs text-light-text opacity-60 dark:text-dark-text";
-const ITEM_TEXT = "flex-1 text-base text-light-text dark:text-dark-text";
 
-function ItemRow({ status, text }) {
+const METRICS = Object.keys(CATEGORY_MAP);
+const TOTAL = METRICS.length;
+
+// Total do dia formatado por unidade: minutos -> HH:MM; refeição pluraliza;
+// o resto (ml) sai cru com a unidade.
+function formatTotal(unit, total) {
+  if (unit === "min") return minutesToHHMM(total);
+  if (unit === "refeição")
+    return `${total} ${total === 1 ? "refeição" : "refeições"}`;
+  return `${total} ${unit}`;
+}
+
+function MetricRow({ done, name, detail }) {
   return (
-    <View className="flex-row gap-2">
-      <Text className="text-base">{STATUS_ICON[status] ?? "•"}</Text>
-      <Text className={ITEM_TEXT}>{text}</Text>
+    <View className="flex-row items-center gap-2">
+      <Text className="text-base">{done ? "✅" : "⬜"}</Text>
+      <Text className="flex-1 text-base text-light-text dark:text-dark-text">
+        {name}
+      </Text>
+      <Text className="text-sm text-light-text opacity-70 dark:text-dark-text">
+        {detail}
+      </Text>
     </View>
   );
 }
 
 export default function Home() {
   const { toggleColorScheme } = useColorScheme();
+  const [today, setToday] = useState({});
+
+  // Relê o resumo sempre que a tela ganha foco (ex: voltando de um registro).
+  // Segue o padrão pull-manual do projeto — a store não notifica sozinha.
+  useFocusEffect(
+    useCallback(() => {
+      setToday(getToday());
+    }, []),
+  );
 
   function handleClear() {
     Alert.alert(
@@ -43,20 +65,34 @@ export default function Home() {
       "Isso apaga todos os registros. Tem certeza?",
       [
         { text: "Cancelar", style: "cancel" },
-        { text: "Limpar", style: "destructive", onPress: () => clearAll() },
+        {
+          text: "Limpar",
+          style: "destructive",
+          onPress: () => {
+            clearAll();
+            setToday(getToday());
+          },
+        },
       ],
     );
   }
-  const {
-    milestonesDone,
-    milestonesTotal,
-    current,
-    currentProgress,
-    recentDone,
-  } = digest;
-  const pct = milestonesTotal
-    ? Math.round((milestonesDone / milestonesTotal) * 100)
-    : 0;
+
+  const rows = METRICS.map((type) => {
+    const { displayName, unit } = CATEGORY_MAP[type];
+    const registros = today[type] ?? [];
+    const total = registros.reduce((s, r) => s + (Number(r.quantity) || 0), 0);
+    const done = registros.length > 0;
+    return {
+      type,
+      name: displayName,
+      done,
+      detail: done ? `${formatTotal(unit, total)} · ${registros.length}×` : "—",
+    };
+  });
+
+  const registradas = rows.filter((r) => r.done).length;
+  const pct = Math.round((registradas / TOTAL) * 100);
+  const dataHoje = new Date().toLocaleDateString("pt-BR");
 
   return (
     <MyView
@@ -68,16 +104,13 @@ export default function Home() {
         contentContainerStyle={{ padding: 16, gap: 16, alignItems: "center" }}
         showsVerticalScrollIndicator={false}
       >
-        {/* Progresso geral */}
+        {/* Resumo do dia */}
         <MyView safe={false} className={`${CARD} gap-2`} style={shadow}>
           <Text className="font-bold text-2xl text-light-text dark:text-dark-text">
-            Back on Track
-          </Text>
-          <Text className="text-sm text-light-text opacity-70 dark:text-dark-text">
-            De volta aos trilhos, um registro por vez.
+            Hoje
           </Text>
           <Text className="font-bold text-base text-light-text opacity-60 dark:text-dark-text">
-            {milestonesDone} de {milestonesTotal} milestones concluídas
+            {dataHoje} · {registradas} de {TOTAL} métricas registradas
           </Text>
           <View className="h-2 w-full overflow-hidden rounded-full bg-light-background dark:bg-dark-background">
             <View
@@ -87,33 +120,21 @@ export default function Home() {
           </View>
         </MyView>
 
-        {/* Milestone atual */}
-        {current && (
-          <MyView safe={false} className={`${CARD} gap-3`} style={shadow}>
-            <Text className={LABEL}>EM ANDAMENTO</Text>
-            <Text className="font-bold text-lg text-light-text dark:text-dark-text">
-              {current.id} · {current.title} ({currentProgress.done}/
-              {currentProgress.total})
-            </Text>
-            <MyView safe={false} className="gap-2">
-              {current.items.map((item, i) => (
-                <ItemRow key={i} status={item.status} text={item.text} />
-              ))}
-            </MyView>
+        {/* Métricas do dia */}
+        <MyView safe={false} className={`${CARD} gap-3`} style={shadow}>
+          <Text className={LABEL}>MÉTRICAS DE HOJE</Text>
+          <MyView safe={false} className="gap-2">
+            {rows.map((r) => (
+              <MetricRow
+                key={r.type}
+                done={r.done}
+                name={r.name}
+                detail={r.detail}
+              />
+            ))}
           </MyView>
-        )}
+        </MyView>
 
-        {/* Concluído recentemente */}
-        {recentDone.length > 0 && (
-          <MyView safe={false} className={`${CARD} gap-3`} style={shadow}>
-            <Text className={LABEL}>CONCLUÍDO RECENTEMENTE</Text>
-            <MyView safe={false} className="gap-2">
-              {recentDone.map((item, i) => (
-                <ItemRow key={i} status="done" text={item.text} />
-              ))}
-            </MyView>
-          </MyView>
-        )}
         {/* Obter o app (só web: QR no desktop, download no celular) */}
         <InstallApp />
 
@@ -122,6 +143,10 @@ export default function Home() {
           <Text className={LABEL}>UTILITÁRIOS</Text>
           <MyButton title="Alternar tema" onPress={() => toggleColorScheme()} />
           <MyButton title="Limpar todos os dados" onPress={handleClear} />
+          <MyButton
+            title="Roadmap do projeto"
+            onPress={() => router.navigate("/roadmap")}
+          />
         </MyView>
       </ScrollView>
     </MyView>

--- a/app/roadmap.jsx
+++ b/app/roadmap.jsx
@@ -1,0 +1,104 @@
+// @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
+//#region imports
+import { ScrollView, Text, View } from "react-native";
+
+import MyView from "@/components/MyView";
+import MyHeader from "@/components/MyHeader";
+
+import { shadow } from "@/constants/Colors";
+import { parseRoadmap, getDigest } from "@/constants/roadmap";
+// Caminho relativo de propósito: o babel-plugin-inline-import resolve pelo
+// arquivo, não pelo alias @/. Editar o roadmap exige reiniciar com --clear.
+import roadmapMd from "../docs/04-roadmap-milestones.md";
+//#endregion
+
+const STATUS_ICON = { done: "✅", partial: "🟡", todo: "⬜" };
+const digest = getDigest(parseRoadmap(roadmapMd));
+
+const CARD =
+  "w-full max-w-[640px] rounded-lg bg-light-backgroundCard p-4 dark:bg-dark-backgroundCard";
+const LABEL =
+  "font-bold text-xs text-light-text opacity-60 dark:text-dark-text";
+const ITEM_TEXT = "flex-1 text-base text-light-text dark:text-dark-text";
+
+function ItemRow({ status, text }) {
+  return (
+    <View className="flex-row gap-2">
+      <Text className="text-base">{STATUS_ICON[status] ?? "•"}</Text>
+      <Text className={ITEM_TEXT}>{text}</Text>
+    </View>
+  );
+}
+
+export default function Roadmap() {
+  const {
+    milestonesDone,
+    milestonesTotal,
+    current,
+    currentProgress,
+    recentDone,
+  } = digest;
+  const pct = milestonesTotal
+    ? Math.round((milestonesDone / milestonesTotal) * 100)
+    : 0;
+
+  return (
+    <MyView
+      safe={true}
+      className="flex-1 bg-light-background dark:bg-dark-background"
+    >
+      <MyHeader />
+      <ScrollView
+        contentContainerStyle={{ padding: 16, gap: 16, alignItems: "center" }}
+        showsVerticalScrollIndicator={false}
+      >
+        {/* Progresso geral */}
+        <MyView safe={false} className={`${CARD} gap-2`} style={shadow}>
+          <Text className="font-bold text-2xl text-light-text dark:text-dark-text">
+            Back on Track
+          </Text>
+          <Text className="text-sm text-light-text opacity-70 dark:text-dark-text">
+            De volta aos trilhos, um registro por vez.
+          </Text>
+          <Text className="font-bold text-base text-light-text opacity-60 dark:text-dark-text">
+            {milestonesDone} de {milestonesTotal} milestones concluídas
+          </Text>
+          <View className="h-2 w-full overflow-hidden rounded-full bg-light-background dark:bg-dark-background">
+            <View
+              className="h-2 rounded-full bg-secondary"
+              style={{ width: `${pct}%` }}
+            />
+          </View>
+        </MyView>
+
+        {/* Milestone atual */}
+        {current && (
+          <MyView safe={false} className={`${CARD} gap-3`} style={shadow}>
+            <Text className={LABEL}>EM ANDAMENTO</Text>
+            <Text className="font-bold text-lg text-light-text dark:text-dark-text">
+              {current.id} · {current.title} ({currentProgress.done}/
+              {currentProgress.total})
+            </Text>
+            <MyView safe={false} className="gap-2">
+              {current.items.map((item, i) => (
+                <ItemRow key={i} status={item.status} text={item.text} />
+              ))}
+            </MyView>
+          </MyView>
+        )}
+
+        {/* Concluído recentemente */}
+        {recentDone.length > 0 && (
+          <MyView safe={false} className={`${CARD} gap-3`} style={shadow}>
+            <Text className={LABEL}>CONCLUÍDO RECENTEMENTE</Text>
+            <MyView safe={false} className="gap-2">
+              {recentDone.map((item, i) => (
+                <ItemRow key={i} status="done" text={item.text} />
+              ))}
+            </MyView>
+          </MyView>
+        )}
+      </ScrollView>
+    </MyView>
+  );
+}

--- a/docs/04-roadmap-milestones.md
+++ b/docs/04-roadmap-milestones.md
@@ -54,7 +54,7 @@ Esta milestone não existia no plano original — ela nasceu do diagnóstico do 
 **Objetivo de saída:** o papel pode ser aposentado.
 
 - ✅ As 5 telas de registro rápido, sobre o componente-base unificado (#80/#81): rota dinâmica `[metric].jsx` + config por métrica sobre `MetricScreen`
-- ⬜ Tela "hoje" consolidando o progresso do dia (uma query só, graças à tabela única)
+- ✅ Tela "hoje" consolidando o progresso do dia (uma query só, graças à tabela única): landing vira o resumo do dia (`app/index.jsx`), lendo `getToday()` (uma passada em `records`, agrupa por `type`); barra "N de 5 métricas" + total consolidado por métrica. Sem metas diárias ainda. Painel de roadmap movido pra `app/roadmap.jsx` (#94)
 - 🟡 Histórico navegável por data (as rotas de histórico já existem, precisam consumir a store nova) — `MyHistory` já lê a store via `get`/`getByMonth`, mas ainda falta a navegação por data e as rotas `(history)/*` são stubs
 - ✅ Editar/excluir registros (#63): o `MyHistory` tem ações **Editar** (abre a tela via `?id=`) e **Excluir** (com confirmação) por registro
 - ⬜ Primeiro dia de uso real substituindo o papel

--- a/infra/database.js
+++ b/infra/database.js
@@ -96,6 +96,32 @@ export function getByMonth(type, month) {
   });
 }
 
+// Todos os registros de um dia, agrupados por type. Uma passada única na tabela
+// (a "uma query só" da tela hoje), reusando hidratar. Compara ano/mês/dia local
+// de `date` (ISO string) — mesma convenção de getByMonth.
+export function getByDate(isoDate) {
+  const alvo = new Date(isoDate);
+  const linhas = store.getTable(TABLE);
+  const porTipo = {};
+  for (const [id, linha] of Object.entries(linhas)) {
+    if (!linha.date) continue;
+    const d = new Date(linha.date);
+    if (
+      d.getFullYear() === alvo.getFullYear() &&
+      d.getMonth() === alvo.getMonth() &&
+      d.getDate() === alvo.getDate()
+    ) {
+      if (!porTipo[linha.type]) porTipo[linha.type] = [];
+      porTipo[linha.type].push(hidratar(id, linha));
+    }
+  }
+  return porTipo;
+}
+
+export function getToday() {
+  return getByDate(new Date().toISOString());
+}
+
 export function clearAll() {
   store.delTables();
 }


### PR DESCRIPTION
## O que (item ⬜ do M3)

A landing (`app/index.jsx`) vira a **tela "hoje"** — resumo do progresso do dia, consolidando a tabela única numa **query só**.

_(Substitui o #95, fechado sem querer ao renomear a branch pro padrão inglês `feat/94-today-screen`.)_

## Mudanças

- **`infra/database.js`:** `getByDate(isoDate)` / `getToday()` — uma passada em `store.getTable("records")`, filtra pelo dia e agrupa por `type`. Reusa `hidratar`.
- **`app/index.jsx` (tela "hoje"):** `MyHeader` + card "Hoje" com barra _"N de 5 métricas registradas"_ + uma linha por métrica (✅/⬜, total consolidado via `minutesToHHMM`/`ml`/contagem, e nº de registros). `useFocusEffect` relê ao focar. Mantém `InstallApp` + Utilitários.
- **Painel de roadmap → `app/roadmap.jsx`** (novo) + rota no `_layout`; botão "Roadmap do projeto" nos Utilitários. Tagline foi junto.
- **`roadmap.md`:** item da tela hoje marcado ✅.

## Fora de escopo

Metas diárias por métrica; remoção do painel de roadmap + redesign (v1.0.0).

## Verificação

- [x] `eslint`/`prettier`/`tsc` verdes; `expo export -p web` compila.
- [ ] **Runtime (seu teste):** landing = "Hoje"; registrar reflete (✅ + total + Nº); barra sobe; sono em HH:MM; link "Roadmap do projeto" abre `/roadmap`.

Refs #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)