### PR TITLE
chore(docker): adiciona container de dev para testar feature branches

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+.expo
+dist
+web-build
+.git
+.github
+.husky
+.vscode
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:24-bookworm-slim
+
+WORKDIR /app
+
+COPY package.json package-lock.json .npmrc ./
+RUN npm ci
+
+COPY . .
+
+EXPOSE 8081
+
+CMD ["npm", "run", "web"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  web:
+    build: .
+    container_name: backontrack-web
+    ports:
+      - "8081:8081"
+    volumes:
+      - .:/app
+      - node_modules:/app/node_modules
+    environment:
+      - BROWSER=none
+    restart: unless-stopped
+    stdin_open: true
+    tty: true
+
+volumes:
+  node_modules:


### PR DESCRIPTION
## Resumo

- Adiciona `Dockerfile` + `docker-compose.yml` para subir o Metro web server (`npm run web`) em container.
- Código montado como bind mount em `/app`, `node_modules` isolado num volume nomeado.
- Objetivo: refletir a branch local ativa dentro do container (hot reload via Metro), sem precisar rodar `npm run web` manualmente a cada troca de branch para testes.

## Uso

```
docker compose up -d --build   # primeira vez, ou quando package.json mudar
docker compose up -d           # depois disso, basta trocar de branch no host
```

Testado localmente: build ok, `curl localhost:8081` retornou o HTML da app, e uma edição no host apareceu instantaneamente dentro do container via bind mount.

## Test plan

- [x] `docker compose up -d --build` builda e sobe sem erro
- [x] `curl localhost:8081` retorna o bundle web (200 + HTML da app)
- [x] Edição de arquivo no host reflete no container (bind mount confirmado)
- [x] `lint:prettier:check`, `lint:eslint:check`, `lint:types:check` passam

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JzFThLSjxM1RscsDLWC4Yd