### PR TITLE
feat(feedback): tela de feedback in-app que cria issue no GitHub (Track B do #101)

### DIFF
--- a/api/feedback.js
+++ b/api/feedback.js
@@ -1,0 +1,89 @@
+// Função serverless (Vercel) que cria uma issue de feedback no GitHub em nome do
+// tester — assim quem não tem conta ou familiaridade com o GitHub reporta direto
+// do app. O PAT fica SÓ aqui (env GITHUB_ISSUE_TOKEN), nunca no cliente.
+//
+// Env necessárias na Vercel:
+//   GITHUB_ISSUE_TOKEN  PAT fine-grained com issues:write no repo (obrigatório)
+//   FEEDBACK_KEY        segredo compartilhado; o app manda em x-feedback-key.
+//                       Se não definido, o endpoint não exige o header (abre depois).
+//   GITHUB_REPO         opcional; default matheushnascimento/backOnTrack
+
+const DEFAULT_REPO = "matheushnascimento/backOnTrack";
+const LABEL = "tester-feedback";
+const MAX_TITLE = 140;
+const MAX_BODY = 5000;
+
+export default async function handler(req, res) {
+  // CORS liberado: o web export roda na mesma origem e o app nativo nem usa
+  // CORS, mas isso deixa robusto pra testar via navegador.
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type, x-feedback-key");
+
+  if (req.method === "OPTIONS") return res.status(204).end();
+  if (req.method !== "POST")
+    return res.status(405).json({ error: "method_not_allowed" });
+
+  const key = process.env.FEEDBACK_KEY;
+  if (key && req.headers["x-feedback-key"] !== key)
+    return res.status(401).json({ error: "unauthorized" });
+
+  const token = process.env.GITHUB_ISSUE_TOKEN;
+  if (!token) return res.status(500).json({ error: "server_misconfigured" });
+
+  const repo = process.env.GITHUB_REPO || DEFAULT_REPO;
+
+  let payload = req.body;
+  if (typeof payload === "string") {
+    try {
+      payload = JSON.parse(payload);
+    } catch {
+      payload = {};
+    }
+  }
+  payload = payload || {};
+
+  const rawTitle = String(payload.title ?? "").trim();
+  const rawBody = String(payload.body ?? "").trim();
+  if (!rawTitle && !rawBody)
+    return res.status(400).json({ error: "empty_feedback" });
+
+  const category = String(payload.category ?? "").trim();
+  const appVersion = String(payload.appVersion ?? "").trim();
+  const device = String(payload.device ?? "").trim();
+
+  const title = (
+    (category ? `[${category}] ` : "") + (rawTitle || rawBody.slice(0, 60))
+  ).slice(0, MAX_TITLE);
+
+  const bodyLines = [
+    rawBody || "(sem descrição)",
+    "",
+    "---",
+    "_Enviado pela tela de feedback do app._",
+  ];
+  if (category) bodyLines.push(`- Categoria: ${category}`);
+  if (appVersion) bodyLines.push(`- Versão do app: ${appVersion}`);
+  if (device) bodyLines.push(`- Dispositivo: ${device}`);
+  const body = bodyLines.join("\n").slice(0, MAX_BODY);
+
+  const gh = await fetch(`https://api.github.com/repos/${repo}/issues`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "Content-Type": "application/json",
+      "User-Agent": "backOnTrack-feedback",
+    },
+    body: JSON.stringify({ title, body, labels: [LABEL] }),
+  });
+
+  if (!gh.ok) {
+    const detail = await gh.text();
+    console.error("GitHub issue create failed", gh.status, detail);
+    return res.status(502).json({ error: "github_error", status: gh.status });
+  }
+
+  const issue = await gh.json();
+  return res.status(201).json({ url: issue.html_url, number: issue.number });
+}

--- a/app/_layout.jsx
+++ b/app/_layout.jsx
@@ -26,6 +26,7 @@ export default function RootLayout() {
         <Stack.Screen name="roadmap" options={{ title: "Roadmap" }} />
         <Stack.Screen name="export" options={{ title: "Exportação" }} />
         <Stack.Screen name="history" options={{ title: "Histórico" }} />
+        <Stack.Screen name="feedback" options={{ title: "Feedback" }} />
         <Stack.Screen name="(metrics)" />
       </Stack>
     </SafeAreaProvider>

--- a/app/feedback.jsx
+++ b/app/feedback.jsx
@@ -1,0 +1,178 @@
+// @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
+//#region imports
+import { useState } from "react";
+import { Linking, Platform, ScrollView, Text, View } from "react-native";
+import { router } from "expo-router";
+import Constants from "expo-constants";
+
+import MyView from "@/components/MyView";
+import MyHeader from "@/components/MyHeader";
+import MyButton from "@/components/MyButton";
+import MyInput from "@/components/MyInput";
+
+import { shadow } from "@/constants/Colors";
+import { FEEDBACK_ENDPOINT, FEEDBACK_KEY } from "@/constants/feedback";
+//#endregion
+
+const CARD =
+  "w-full max-w-[640px] rounded-lg bg-light-backgroundCard p-4 dark:bg-dark-backgroundCard";
+const LABEL =
+  "font-bold text-xs text-light-text opacity-60 dark:text-dark-text";
+const INPUT = "w-full";
+
+const CATEGORIES = ["Bug", "Sugestão", "Outro"];
+
+// Contexto que ajuda a triar a issue depois, coletado sem o tester digitar.
+const APP_VERSION = Constants.expoConfig?.version ?? "?";
+const DEVICE = `${Platform.OS} ${Platform.Version ?? ""}`.trim();
+
+export default function Feedback() {
+  const [category, setCategory] = useState("");
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [status, setStatus] = useState("idle"); // idle | sending | ok | error
+  const [result, setResult] = useState(null); // { number, url }
+  const [errorMsg, setErrorMsg] = useState("");
+
+  const canSend =
+    status !== "sending" && (title.trim() !== "" || description.trim() !== "");
+
+  async function handleSend() {
+    if (!canSend) return;
+    setStatus("sending");
+    setErrorMsg("");
+    try {
+      const res = await fetch(FEEDBACK_ENDPOINT, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(FEEDBACK_KEY ? { "x-feedback-key": FEEDBACK_KEY } : {}),
+        },
+        body: JSON.stringify({
+          title: title.trim(),
+          body: description.trim(),
+          category,
+          appVersion: APP_VERSION,
+          device: DEVICE,
+        }),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      setResult(data);
+      setStatus("ok");
+    } catch (e) {
+      setErrorMsg(String(e?.message ?? e));
+      setStatus("error");
+    }
+  }
+
+  function resetForm() {
+    setCategory("");
+    setTitle("");
+    setDescription("");
+    setResult(null);
+    setStatus("idle");
+    setErrorMsg("");
+  }
+
+  return (
+    <MyView
+      safe={true}
+      className="flex-1 bg-light-background dark:bg-dark-background"
+    >
+      <MyHeader />
+      <ScrollView
+        contentContainerStyle={{ padding: 16, gap: 16, alignItems: "center" }}
+        showsVerticalScrollIndicator={false}
+        keyboardShouldPersistTaps="handled"
+      >
+        {status === "ok" ? (
+          <MyView safe={false} className={`${CARD} gap-3`} style={shadow}>
+            <Text className="font-bold text-2xl text-light-text dark:text-dark-text">
+              Recebido! 🙌
+            </Text>
+            <Text className="text-base text-light-text opacity-70 dark:text-dark-text">
+              Abrimos o chamado #{result?.number}. Obrigado por reportar — dá
+              pra acompanhar quando quiser.
+            </Text>
+            {result?.url && (
+              <MyButton
+                title="Ver o chamado"
+                onPress={() => Linking.openURL(result.url)}
+              />
+            )}
+            <MyButton title="Enviar outro" onPress={resetForm} />
+            <MyButton
+              title="Voltar ao início"
+              onPress={() => router.navigate("/")}
+            />
+          </MyView>
+        ) : (
+          <>
+            <MyView safe={false} className={`${CARD} gap-1`} style={shadow}>
+              <Text className="font-bold text-2xl text-light-text dark:text-dark-text">
+                Enviar feedback
+              </Text>
+              <Text className="text-sm text-light-text opacity-70 dark:text-dark-text">
+                Achou um problema ou tem uma sugestão? Conta aqui — abrimos o
+                chamado pra você automaticamente.
+              </Text>
+            </MyView>
+
+            <MyView safe={false} className={`${CARD} gap-4`} style={shadow}>
+              {/* Categoria (opcional) */}
+              <MyView safe={false} className="gap-1.5">
+                <Text className={LABEL}>CATEGORIA (OPCIONAL)</Text>
+                <View className="flex-row flex-wrap gap-2">
+                  {CATEGORIES.map((c) => (
+                    <MyButton
+                      key={c}
+                      title={c}
+                      isSelected={category === c}
+                      onPress={() => setCategory(category === c ? "" : c)}
+                    />
+                  ))}
+                </View>
+              </MyView>
+
+              <MyInput
+                label="Título"
+                placeholder="Resumo em uma linha"
+                value={title}
+                onChangeText={setTitle}
+                containerClassName="w-full"
+                className={INPUT}
+                maxLength={140}
+              />
+
+              <MyInput
+                label="Descrição"
+                placeholder="O que aconteceu? Se for um bug, como reproduzir?"
+                value={description}
+                onChangeText={setDescription}
+                containerClassName="w-full"
+                className={INPUT}
+                multiline
+                numberOfLines={6}
+                style={{ minHeight: 120, textAlignVertical: "top" }}
+              />
+
+              {status === "error" && (
+                <Text className="text-sm text-red-500">
+                  Não consegui enviar ({errorMsg}). Tenta de novo em instantes.
+                </Text>
+              )}
+
+              <MyButton
+                title={status === "sending" ? "Enviando…" : "Enviar"}
+                onPress={handleSend}
+                disabled={!canSend}
+                className={canSend ? "" : "opacity-50"}
+              />
+            </MyView>
+          </>
+        )}
+      </ScrollView>
+    </MyView>
+  );
+}

--- a/app/index.jsx
+++ b/app/index.jsx
@@ -148,6 +148,10 @@ export default function Home() {
           />
           <MyButton title="Limpar todos os dados" onPress={handleClear} />
           <MyButton
+            title="Enviar feedback"
+            onPress={() => router.navigate("/feedback")}
+          />
+          <MyButton
             title="Roadmap do projeto"
             onPress={() => router.navigate("/roadmap")}
           />

--- a/components/MyInput.jsx
+++ b/components/MyInput.jsx
@@ -8,11 +8,14 @@ export default function MyInput({
   value,
   onChangeText,
   className,
+  // Wrapper estreito (self-start) por padrão, como os forms de métrica querem;
+  // telas de form largo (ex: feedback) passam "w-full" pra esticar no card.
+  containerClassName = "self-start",
   style,
   ...props
 }) {
   return (
-    <MyView safe={false} className="gap-1.5 self-start">
+    <MyView safe={false} className={`gap-1.5 ${containerClassName}`}>
       {label != null && (
         <Text className="font-bold text-base text-light-text dark:text-dark-text">
           {label}

--- a/constants/feedback.js
+++ b/constants/feedback.js
@@ -1,0 +1,13 @@
+/* global process */
+// Configuração da tela de feedback (Track B do M3-5, #101).
+//
+// FEEDBACK_ENDPOINT: função serverless na Vercel, mesma origem do web export
+// (ver package.json "homepage"). É ela que guarda o PAT e abre a issue.
+// FEEDBACK_KEY: segredo compartilhado semi-público (EXPO_PUBLIC_*, embutido no
+// bundle) só pra deter abuso casual — o token real fica só na Vercel. Se vazio,
+// o endpoint aceita sem header (liga-se o segredo depois definindo a env dos
+// dois lados).
+
+export const FEEDBACK_ENDPOINT = "https://backontrack.mhdn.com.br/api/feedback";
+
+export const FEEDBACK_KEY = process.env.EXPO_PUBLIC_FEEDBACK_KEY ?? "";

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -32,4 +32,12 @@ export default defineConfig([
       globals: globals.node,
     },
   },
+  {
+    // Funções serverless (Vercel) rodam em Node (ESM), não no app.
+    files: ["api/**/*.js"],
+    languageOptions: {
+      sourceType: "module",
+      globals: globals.node,
+    },
+  },
 ]);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
     "jest.config.js",
     "tailwind.config.js",
     "scripts",
-    "plugins"
+    "plugins",
+    "api"
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -6,7 +6,7 @@
       "config": { "distDir": "dist" }
     },
     {
-      "src": "api/**/*.js",
+      "src": "api/*.js",
       "use": "@vercel/node"
     }
   ],

--- a/vercel.json
+++ b/vercel.json
@@ -4,6 +4,10 @@
       "src": "package.json",
       "use": "@vercel/static-build",
       "config": { "distDir": "dist" }
+    },
+    {
+      "src": "api/**/*.js",
+      "use": "@vercel/node"
     }
   ],
   "routes": [

--- a/vercel.json
+++ b/vercel.json
@@ -1,22 +1,4 @@
 {
-  "builds": [
-    {
-      "src": "package.json",
-      "use": "@vercel/static-build",
-      "config": { "distDir": "dist" }
-    },
-    {
-      "src": "api/*.js",
-      "use": "@vercel/node"
-    }
-  ],
-  "routes": [
-    {
-      "handle": "filesystem"
-    },
-    {
-      "src": "/(.*)",
-      "dest": "/index.html"
-    }
-  ]
+  "outputDirectory": "dist",
+  "rewrites": [{ "source": "/((?!api/).*)", "dest": "/index.html" }]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,4 @@
 {
   "outputDirectory": "dist",
-  "rewrites": [{ "source": "/((?!api/).*)", "dest": "/index.html" }]
+  "rewrites": [{ "source": "/((?!api/).*)", "destination": "/index.html" }]
 }


### PR DESCRIPTION
## O que (Track B do M3-5, #101)

Habilitador do **primeiro dia de uso real**: os testers passam a reportar **direto do app**, sem precisar de conta no GitHub. A tela POSTa pra uma função serverless na Vercel que abre a issue por eles.

## Mudanças

- **`api/feedback.js`** (novo, Vercel serverless): `POST {title, body, category, appVersion, device}` → cria issue via GitHub Issues API com o PAT em env (`GITHUB_ISSUE_TOKEN`), label `tester-feedback`; valida header `x-feedback-key` (se a env `FEEDBACK_KEY` estiver definida); retorna `{url, number}`. **O token fica só na Vercel — nunca no cliente.**
- **`app/feedback.jsx`** (novo): form (categoria opcional + título + descrição multiline), estados loading/sucesso/erro, mostra o nº do chamado + link. Coleta versão do app e device p/ triagem. Registrada no `_layout` e linkada em Utilitários (`Enviar feedback`).
- **`constants/feedback.js`** (novo): endpoint + chave (`EXPO_PUBLIC_FEEDBACK_KEY`).
- **`components/MyInput.jsx`**: novo prop `containerClassName` (retrocompatível, default `self-start`) pra permitir input full-width no form largo.
- **`vercel.json`**: publica a função `/api` junto do `@vercel/static-build`.
- **`tsconfig.json` / `eslint.config.mjs`**: `api/` tratado como código Node (excluído do tsc; globals Node no eslint), espelhando `scripts/` e `plugins/`.

## Setup necessário (Vercel) ⚠️

Antes do disparo aos testers, definir na Vercel: **`GITHUB_ISSUE_TOKEN`** (PAT fine-grained com `issues:write` no repo) e, opcional, **`FEEDBACK_KEY`** (+ `EXPO_PUBLIC_FEEDBACK_KEY` no build do app).

## Fora de escopo

Rate-limit/anti-spam além do header (follow-up); infra Evolution API + sender (Track A); item M3-6.

## Verificação

- [x] `tsc` / `eslint` / `prettier` verdes; `expo export -p web` compila com a rota nova.
- [ ] **Runtime (seu teste):** Utilitários → `Enviar feedback` → enviar → issue criada com label `tester-feedback` + estado de sucesso com o link. Validar claro/escuro. (Depende das envs da Vercel acima.)

Refs #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)