### PR TITLE
fix(feedback): restaura serving estático da web + rota de /api (regressão do #102)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,18 @@
 {
-  "outputDirectory": "dist",
-  "rewrites": [{ "source": "/((?!api/).*)", "destination": "/index.html" }]
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/static-build",
+      "config": { "distDir": "dist" }
+    },
+    {
+      "src": "api/*.js",
+      "use": "@vercel/node"
+    }
+  ],
+  "routes": [
+    { "src": "/api/(.*)", "dest": "/api/$1" },
+    { "handle": "filesystem" },
+    { "src": "/(.*)", "dest": "/index.html" }
+  ]
 }


### PR DESCRIPTION
O merge do #102 migrou o `vercel.json` pro schema moderno, que **quebrou o serving da SPA em produção** (404 no root, rotas e assets), apesar de o `expo export` gerar o `dist` corretamente. Só a função `/api/feedback` respondia.

## Correção
- Volta pro `@vercel/static-build` (comprovado pra servir a web) para o `dist`.
- Mantém o build `@vercel/node` da função (`api/*.js`).
- Adiciona rota explícita `{"src": "/api/(.*)", "dest": "/api/$1"}` **antes** do `handle: filesystem` e do fallback SPA, pra a função não cair no `index.html`.

## Verificação (nesta preview, antes do merge)
- [ ] Web root `GET /` → 200 (SPA carrega)
- [ ] Rota SPA `GET /history` → 200
- [ ] `POST /api/feedback` → 201 (função cria issue)

Refs #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)