### PR TITLE
fix(feedback): serve web e função Vercel juntos (buildCommand explícito)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,18 +1,6 @@
 {
-  "builds": [
-    {
-      "src": "package.json",
-      "use": "@vercel/static-build",
-      "config": { "distDir": "dist" }
-    },
-    {
-      "src": "api/*.js",
-      "use": "@vercel/node"
-    }
-  ],
-  "routes": [
-    { "src": "/api/(.*)", "dest": "/api/$1" },
-    { "handle": "filesystem" },
-    { "src": "/(.*)", "dest": "/index.html" }
-  ]
+  "framework": null,
+  "buildCommand": "expo export",
+  "outputDirectory": "dist",
+  "rewrites": [{ "source": "/((?!api/).*)", "destination": "/index.html" }]
 }


### PR DESCRIPTION
Corrige a regressão introduzida pelo #102: a migração pro schema moderno do `vercel.json` ficou só com `outputDirectory` + `rewrites`, **sem `buildCommand`** — a Vercel rodava o `expo export` mas **não montava o `dist` como estático** (produção deu 404 no root, rotas e assets; só a `/api/feedback` respondia).

## Correção
`framework: null` + **`buildCommand: "expo export"`** explícito + `outputDirectory: dist` + `rewrites` com lookahead negativo pra `/api/`. Assim a Vercel serve o estático **e** auto-detecta a função serverless.

## Verificação (na preview desta branch, com bypass de proteção)
- `GET /` → **200** ✅
- `GET /history` (rota SPA) → **200** ✅
- `GET /_expo/...js` (asset) → **200** ✅
- `POST /api/feedback` → **201** ✅ (função cria a issue)

Refs #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)