### PR TITLE
feat(feedback): identifica app vs navegador, user agent e bundle OTA (#116)

### DIFF
--- a/api/feedback.js
+++ b/api/feedback.js
@@ -50,6 +50,11 @@ export default async function handler(req, res) {
 
   const category = String(payload.category ?? "").trim();
   const appVersion = String(payload.appVersion ?? "").trim();
+  const environment = String(payload.environment ?? "").trim();
+  const userAgent = String(payload.userAgent ?? "").trim();
+  const bundle = String(payload.bundle ?? "").trim();
+  // Legado: bundles anteriores ao #116 mandam `device` ("android 36"). Enquanto
+  // o OTA não alcança todos os testers, os dois formatos convivem.
   const device = String(payload.device ?? "").trim();
 
   const title = (
@@ -63,8 +68,11 @@ export default async function handler(req, res) {
     "_Enviado pela tela de feedback do app._",
   ];
   if (category) bodyLines.push(`- Categoria: ${category}`);
+  if (environment) bodyLines.push(`- Ambiente: ${environment}`);
+  else if (device) bodyLines.push(`- Dispositivo: ${device}`);
   if (appVersion) bodyLines.push(`- Versão do app: ${appVersion}`);
-  if (device) bodyLines.push(`- Dispositivo: ${device}`);
+  if (bundle) bodyLines.push(`- Bundle: ${bundle}`);
+  if (userAgent) bodyLines.push(`- User agent: ${userAgent}`);
   const body = bodyLines.join("\n").slice(0, MAX_BODY);
 
   const gh = await fetch(`https://api.github.com/repos/${repo}/issues`, {

--- a/app/feedback.jsx
+++ b/app/feedback.jsx
@@ -1,9 +1,8 @@
 // @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
 //#region imports
 import { useState } from "react";
-import { Linking, Platform, ScrollView, Text, View } from "react-native";
+import { Linking, ScrollView, Text, View } from "react-native";
 import { router } from "expo-router";
-import Constants from "expo-constants";
 
 import MyView from "@/components/MyView";
 import MyHeader from "@/components/MyHeader";
@@ -12,6 +11,7 @@ import MyInput from "@/components/MyInput";
 
 import { shadow } from "@/constants/Colors";
 import { FEEDBACK_ENDPOINT, FEEDBACK_KEY } from "@/constants/feedback";
+import { getEnvironmentInfo } from "@/constants/environment";
 //#endregion
 
 const CARD =
@@ -23,8 +23,7 @@ const INPUT = "w-full";
 const CATEGORIES = ["Bug", "Sugestão", "Outro"];
 
 // Contexto que ajuda a triar a issue depois, coletado sem o tester digitar.
-const APP_VERSION = Constants.expoConfig?.version ?? "?";
-const DEVICE = `${Platform.OS} ${Platform.Version ?? ""}`.trim();
+const ENV = getEnvironmentInfo();
 
 export default function Feedback() {
   const [category, setCategory] = useState("");
@@ -52,8 +51,7 @@ export default function Feedback() {
           title: title.trim(),
           body: description.trim(),
           category,
-          appVersion: APP_VERSION,
-          device: DEVICE,
+          ...ENV,
         }),
       });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);

--- a/constants/environment.js
+++ b/constants/environment.js
@@ -1,0 +1,54 @@
+// Contexto de execução que acompanha o feedback, pra triagem (#116).
+//
+// Antes daqui o único campo era `Platform.OS + Platform.Version`, que produzia
+// "android 36" ou "web 0.0.0". A informação existia, mas exigia saber que
+// `web` = navegador e `android` = app nativo — quem tria a issue não sabe. E no
+// navegador o "web 0.0.0" não dizia NADA: nem qual browser, nem qual OS, justo
+// no caso mais difícil de reproduzir.
+//
+// O `appVersion` também engana sozinho: as entregas chegam por OTA sem mudar o
+// "1.0.0", então dois testers em bundles JS diferentes reportavam a mesma
+// versão. Daí o campo `bundle`.
+
+import { Platform } from "react-native";
+import Constants from "expo-constants";
+import * as Updates from "expo-updates";
+
+/** @returns {string} ex: "App nativo (Android 36)" | "Navegador" */
+function describeEnvironment() {
+  if (Platform.OS === "web") return "Navegador";
+  const os = Platform.OS === "ios" ? "iOS" : "Android";
+  return `App nativo (${os} ${Platform.Version ?? "?"})`;
+}
+
+/**
+ * Identifica o bundle JS em execução. Sem isso, "1.0.0" é ambíguo entre todas
+ * as entregas OTA feitas sobre a mesma versão nativa.
+ * @returns {string}
+ */
+function describeBundle() {
+  try {
+    // Em dev/web esses campos vêm nulos — degrada sem quebrar.
+    const { updateId, channel, isEmbeddedLaunch } = Updates;
+    if (!updateId) return isEmbeddedLaunch ? "embutido no app" : "";
+    const curto = String(updateId).slice(0, 8);
+    return channel ? `OTA ${curto} (canal: ${channel})` : `OTA ${curto}`;
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Tudo que o app sabe sobre o próprio ambiente, sem o tester digitar nada.
+ * @returns {{ environment: string, userAgent: string, appVersion: string, bundle: string }}
+ */
+export function getEnvironmentInfo() {
+  return {
+    environment: describeEnvironment(),
+    // Só faz sentido no web; no native não existe navegador.
+    userAgent:
+      Platform.OS === "web" ? (globalThis.navigator?.userAgent ?? "") : "",
+    appVersion: Constants.expoConfig?.version ?? "?",
+    bundle: describeBundle(),
+  };
+}


### PR DESCRIPTION
## O que (M3-6 — veio do uso real dos testers)

A #115 chegou com `Dispositivo: android 36` e a #108 com `web 0.0.0`. A informação existia (`Platform.OS`), mas **codificada de um jeito que só um dev de RN decodifica**: quem tria não sabe que `android` = app nativo e `web` = navegador. E no navegador o `web 0.0.0` **não dizia nada** — nem qual browser, nem qual OS — justo no caso mais difícil de reproduzir.

## Mudanças
- **`constants/environment.js`** (novo): monta o contexto de execução.
  - **`Ambiente`** explícito: `App nativo (Android 36)` / `App nativo (iOS 17)` / `Navegador`.
  - **`User agent`** — só no web (no native não existe navegador).
  - **`Bundle`** via `expo-updates`: `OTA 1a2b3c4d (canal: preview)` ou `embutido no app`. Motivo: **`Versão do app: 1.0.0` é ambíguo** — tela Hoje, Histórico e Feedback chegaram todas por OTA sem mudar o `1.0.0`, então dois testers em bundles JS diferentes reportavam a mesma versão. Em dev/web os campos vêm nulos e degradam sem quebrar.
- **`app/feedback.jsx`**: usa o helper (some o `Platform`/`Constants` inline).
- **`api/feedback.js`**: renderiza `Ambiente` / `Bundle` / `User agent`. **Aceita os dois formatos** — bundles anteriores a este OTA seguem mandando `device` e continuam renderizando (`- Dispositivo: ...`), porque o OTA não alcança todo mundo de imediato.

## Antes / depois

```
- Categoria: Sugestão          - Categoria: Sugestão
- Versão do app: 1.0.0    →    - Ambiente: App nativo (Android 36)
- Dispositivo: android 36      - Versão do app: 1.0.0
                               - Bundle: OTA 1a2b3c4d (canal: preview)
```

## Verificação
- [x] `tsc`/`eslint`/`prettier` verdes.
- [x] `expo export -p web` compila com o `expo-updates` importado (o `expo-sqlite` já quebrou o build web antes — por isso a checagem).
- [ ] Função na preview: payload novo → `Ambiente`/`Bundle`/`User agent`; payload legado (`device`) → segue renderizando.
- [ ] Runtime no app (pós-merge/OTA).

Refs #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)