### PR TITLE
fix(app): assina a store em vez de reler no foco (#108)

### DIFF
--- a/app/admin.jsx
+++ b/app/admin.jsx
@@ -5,9 +5,9 @@
 // A lista vive em TinyBase local (por-device), então numa instalação de tester
 // esta tela aparece vazia; só o aparelho do admin popula.
 //#region imports
-import { useCallback, useState } from "react";
+import { useMemo, useState } from "react";
 import { Platform, ScrollView, Share, Text, View } from "react-native";
-import { useFocusEffect } from "expo-router";
+import { useTable } from "tinybase/ui-react";
 
 import MyView from "@/components/MyView";
 import MyHeader from "@/components/MyHeader";
@@ -16,7 +16,7 @@ import MyInput from "@/components/MyInput";
 
 import { shadow } from "@/constants/Colors";
 import { confirmAction, notify } from "@/constants/dialogs";
-import { getTesters, addTester, removeTester } from "@/infra/database";
+import { getTesters, addTester, removeTester, store } from "@/infra/database";
 //#endregion
 
 const CARD =
@@ -25,12 +25,14 @@ const LABEL =
   "font-bold text-xs text-light-text opacity-60 dark:text-dark-text";
 
 export default function Admin() {
-  const [testers, setTesters] = useState([]);
   const [name, setName] = useState("");
   const [phone, setPhone] = useState("");
 
-  const reload = useCallback(() => setTesters(getTesters()), []);
-  useFocusEffect(reload);
+  // Assina a tabela: re-renderiza a cada mudança — inclusive quando o
+  // `startAutoLoad()` da persistência termina. Ler só no foco fazia a lista
+  // nascer vazia no primeiro load (mesma causa do #108).
+  const testersTable = useTable("testers", store);
+  const testers = useMemo(() => getTesters(), [testersTable]);
 
   const canAdd = name.trim() !== "" && phone.trim() !== "";
 
@@ -39,7 +41,6 @@ export default function Admin() {
     addTester({ name, phone });
     setName("");
     setPhone("");
-    reload();
   }
 
   function handleRemove(tester) {
@@ -47,10 +48,7 @@ export default function Admin() {
       title: "Remover tester",
       message: `Remover ${tester.name} da lista?`,
       confirmLabel: "Remover",
-      onConfirm: () => {
-        removeTester(tester.id);
-        reload();
-      },
+      onConfirm: () => removeTester(tester.id),
     });
   }
 

--- a/app/history.jsx
+++ b/app/history.jsx
@@ -1,15 +1,15 @@
 // @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
 //#region imports
-import { useCallback, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { ScrollView, Text, View } from "react-native";
-import { useFocusEffect } from "expo-router";
+import { useTable } from "tinybase/ui-react";
 
 import MyView from "@/components/MyView";
 import MyHeader from "@/components/MyHeader";
 import MyButton from "@/components/MyButton";
 import { HistoryCard } from "@/components/MyHistory";
 
-import { getByDate } from "@/infra/database";
+import { getByDate, store } from "@/infra/database";
 import { CATEGORY_MAP, getCategoryInfo } from "@/components/categoryUtils";
 import { shadow } from "@/constants/Colors";
 //#endregion
@@ -42,18 +42,14 @@ function isSameDay(a, b) {
 
 export default function History() {
   const [date, setDate] = useState(() => startOfDay(new Date()));
-  const [tick, setTick] = useState(0);
 
-  // Relê ao focar (voltar de uma edição/exclusão). Segue o pull-manual do
-  // projeto — a store não notifica sozinha.
-  useFocusEffect(
-    useCallback(() => {
-      setTick((t) => t + 1);
-    }, []),
-  );
+  // Assina a tabela: re-renderiza a cada mudança nos registros (edição, exclusão
+  // e também o fim do `startAutoLoad()` da persistência). Ler só no foco perdia
+  // a carga inicial assíncrona — ver #108.
+  const records = useTable("records", store);
 
   // Registros do dia agrupados por type (uma passada só, via getByDate).
-  const day = useMemo(() => getByDate(date.toISOString()), [date, tick]);
+  const day = useMemo(() => getByDate(date.toISOString()), [date, records]);
 
   const isToday = isSameDay(date, new Date());
   const label = date.toLocaleDateString("pt-BR", {

--- a/app/index.jsx
+++ b/app/index.jsx
@@ -1,16 +1,17 @@
 // @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
 //#region imports
-import { useCallback, useState } from "react";
+import { useMemo } from "react";
 import { Alert, ScrollView, Text, View } from "react-native";
 import { useColorScheme } from "nativewind";
-import { router, useFocusEffect } from "expo-router";
+import { router } from "expo-router";
+import { useTable } from "tinybase/ui-react";
 
 import MyButton from "@/components/MyButton";
 import MyView from "@/components/MyView";
 import MyHeader from "@/components/MyHeader";
 import InstallApp from "@/components/InstallApp";
 
-import { clearAll, getToday } from "@/infra/database";
+import { clearAll, getToday, store } from "@/infra/database";
 import { CATEGORY_MAP } from "@/components/categoryUtils";
 import { minutesToHHMM } from "@/constants/duration";
 import { shadow } from "@/constants/Colors";
@@ -49,15 +50,14 @@ function MetricRow({ done, name, detail }) {
 
 export default function Home() {
   const { toggleColorScheme } = useColorScheme();
-  const [today, setToday] = useState({});
 
-  // Relê o resumo sempre que a tela ganha foco (ex: voltando de um registro).
-  // Segue o padrão pull-manual do projeto — a store não notifica sozinha.
-  useFocusEffect(
-    useCallback(() => {
-      setToday(getToday());
-    }, []),
-  );
+  // Assina a tabela: `useTable` re-renderiza a cada mudança nos registros —
+  // inclusive quando o `startAutoLoad()` da persistência termina de carregar.
+  // Ler só no foco (o padrão anterior) perdia essa carga: no primeiro load a
+  // tela lia a store ainda vazia e nunca era avisada quando os dados chegavam,
+  // então a Home só mostrava algo depois de ir a outra tela e voltar (#108).
+  const records = useTable("records", store);
+  const today = useMemo(() => getToday(), [records]);
 
   function handleClear() {
     Alert.alert(
@@ -68,10 +68,8 @@ export default function Home() {
         {
           text: "Limpar",
           style: "destructive",
-          onPress: () => {
-            clearAll();
-            setToday(getToday());
-          },
+          // A assinatura da store cuida do re-render; não precisa reler na mão.
+          onPress: clearAll,
         },
       ],
     );


### PR DESCRIPTION
## O bug (reportado por tester via feedback in-app)

> "Mesmo com dados salvos, a Home aparece sem dados; mas se navega para uma página com dados e volta, os dados estarão na Home."

## Causa raiz

A persistência carrega de forma **assíncrona**:
```js
await persister.startAutoLoad();   // a store nasce vazia
```
E as telas liam a store **uma vez, no foco**, sob a premissa escrita no comentário: *"a store não notifica sozinha"*.

No primeiro load o efeito de foco disparava **antes** do autoLoad terminar → lia store vazia → tela sem dados. Quando os dados chegavam, ninguém avisava a tela. Ao ir a outra tela e voltar, o efeito rodava de novo — aí já tinha carregado, e os dados apareciam. Exatamente o sintoma relatado.

**A premissa é que estava errada:** a store notifica, sim — via `tinybase/ui-react`, que **já era dependência** (a persistência usa `useCreatePersister`).

## O fix

`useTable(tabela, store)` assina a tabela e re-renderiza quando os dados mudam — inclusive quando o autoLoad termina. Isso também torna o pull-manual **desnecessário**: a assinatura já cobre mudanças feitas em outras telas.

**Três telas, mesma causa raiz** (a #108 relatou só a Home; as outras duas tinham o bug latente):

| Tela | Antes | Depois |
|---|---|---|
| `app/index.jsx` | `useFocusEffect` + `useState` | `useTable` + `useMemo` |
| `app/history.jsx` | `useFocusEffect` + contador `tick` | `useTable` + `useMemo` |
| `app/admin.jsx` | `useFocusEffect` + `reload()` manual | `useTable` + `useMemo` |

**O fix remove código**: −38/+30 linhas. Somem o `useFocusEffect` das três, o `tick` do Histórico e os `reload()` manuais do Admin.

## Verificação
- [x] `tsc`/`eslint`/`prettier` verdes.
- [x] `expo export -p web` compila.
- [ ] **Runtime (seu teste — é o que importa aqui):** com dados já salvos, **abrir a Home direto** (reload duro) → os dados devem aparecer **sem** precisar navegar e voltar. Idem Histórico e `/admin`.

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)