### PR TITLE
chore: ignora o rascunho de mensagem do sender (#122)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ yarn-error.*
 
 # Lista de testers exportada do app (PII) — nunca versionar.
 scripts/testers.json
+
+# Rascunho local da mensagem do sender (notify-testers.mjs --text-file).
+convite.txt


### PR DESCRIPTION
O `notify-testers.mjs --text-file` lê a mensagem de um arquivo local. O `convite.txt` do disparo do M3-5 ficou não-versionado na raiz, aparecendo em todo `git status`.

Adiciona `convite.txt` ao `.gitignore` — é rascunho local, não fonte. (A lista de testers, essa sim PII, já era ignorada em `scripts/testers.json`.)

Refs #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)