### PR TITLE
fix(app): faz confirmar/excluir funcionar no navegador (#124)

### DIFF
--- a/app/index.jsx
+++ b/app/index.jsx
@@ -1,7 +1,7 @@
 // @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
 //#region imports
 import { useMemo } from "react";
-import { Alert, ScrollView, Text, View } from "react-native";
+import { ScrollView, Text, View } from "react-native";
 import { useColorScheme } from "nativewind";
 import { router } from "expo-router";
 import { useTable } from "tinybase/ui-react";
@@ -12,6 +12,7 @@ import MyHeader from "@/components/MyHeader";
 import InstallApp from "@/components/InstallApp";
 
 import { clearAll, getToday, store } from "@/infra/database";
+import { confirmAction } from "@/constants/dialogs";
 import { CATEGORY_MAP } from "@/components/categoryUtils";
 import { minutesToHHMM } from "@/constants/duration";
 import { shadow } from "@/constants/Colors";
@@ -60,19 +61,13 @@ export default function Home() {
   const today = useMemo(() => getToday(), [records]);
 
   function handleClear() {
-    Alert.alert(
-      "Limpar todos os dados",
-      "Isso apaga todos os registros. Tem certeza?",
-      [
-        { text: "Cancelar", style: "cancel" },
-        {
-          text: "Limpar",
-          style: "destructive",
-          // A assinatura da store cuida do re-render; não precisa reler na mão.
-          onPress: clearAll,
-        },
-      ],
-    );
+    confirmAction({
+      title: "Limpar todos os dados",
+      message: "Isso apaga todos os registros. Tem certeza?",
+      confirmLabel: "Limpar",
+      // A assinatura da store cuida do re-render; não precisa reler na mão.
+      onConfirm: clearAll,
+    });
   }
 
   const rows = METRICS.map((type) => {

--- a/components/MyHistory.jsx
+++ b/components/MyHistory.jsx
@@ -2,7 +2,7 @@
 //#region imports
 import { useEffect, useState } from "react";
 
-import { Alert, Text, View } from "react-native";
+import { Text, View } from "react-native";
 
 import MyView from "./MyView";
 import MyButton from "./MyButton";
@@ -11,6 +11,7 @@ import { getCategoryInfo } from "./categoryUtils";
 import { Colors, shadow } from "@/constants/Colors";
 
 import { get, getByMonth, remove } from "@/infra/database";
+import { confirmAction } from "@/constants/dialogs";
 import { minutesToHHMM } from "@/constants/duration";
 import Checkbox from "expo-checkbox";
 import { router } from "expo-router";
@@ -54,17 +55,15 @@ export function HistoryCard({
   }
 
   function handleDelete() {
-    Alert.alert("Excluir registro", "Quer mesmo excluir este registro?", [
-      { text: "Cancelar", style: "cancel" },
-      {
-        text: "Excluir",
-        style: "destructive",
-        onPress: () => {
-          remove(id);
-          onChanged?.();
-        },
+    confirmAction({
+      title: "Excluir registro",
+      message: "Quer mesmo excluir este registro?",
+      confirmLabel: "Excluir",
+      onConfirm: () => {
+        remove(id);
+        onChanged?.();
       },
-    ]);
+    });
   }
 
   return (


### PR DESCRIPTION
O `Alert` do React Native **não é implementado no react-native-web**: o diálogo nunca aparece e, como a ação só roda no `onPress` do botão de confirmar, **ela nunca executa**. Os botões ficavam mortos no navegador — sem erro, sem log. No app nativo funcionavam, por isso passou batido.

Mesmo bug já corrigido no Remover da tela de admin (#109), onde nasceu o helper `constants/dialogs.js` (`confirmAction`/`notify` — web usa `confirm`/`alert` do browser, native segue com `Alert`). Estes dois eram instâncias pré-existentes.

**Importa:** tem gente usando o web — o report do #108 veio de lá (`Dispositivo: web 0.0.0`).

## Mudanças
| Arquivo | Botão | Antes (no navegador) |
|---|---|---|
| `app/index.jsx` | "Limpar todos os dados" | não fazia nada |
| `components/MyHistory.jsx` | "Excluir" (registro) | não fazia nada |

Ambos passam a usar `confirmAction`, com os mesmos textos. Sai o import de `Alert` dos dois.

**Invariante novo:** todo `Alert.alert` do projeto agora passa pelo helper cross-platform — o único uso restante está dentro do próprio `constants/dialogs.js`, que é o caminho native.

## Verificação
- [x] `tsc`/`eslint`/`prettier` verdes; `expo export -p web` compila.
- [x] Nenhum `Alert.alert` fora do helper (grep).
- [ ] **Runtime (seu teste, no navegador):** Utilitários → "Limpar todos os dados" deve abrir o confirm e **apagar de verdade**; no Histórico, "Excluir" deve confirmar e remover. No app nativo, os dois devem seguir iguais.

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)