### PR TITLE
fix(history): remove referência órfã que derrubava a tela ao excluir (#126)

### DIFF
--- a/app/history.jsx
+++ b/app/history.jsx
@@ -127,7 +127,8 @@ export default function History() {
                     unit={unit}
                     exercise={type === "exercise"}
                     hideDate
-                    onChanged={() => setTick((t) => t + 1)}
+                    // Sem onChanged de propósito: o useTable acima já assina a
+                    // store e re-renderiza quando um registro é excluído.
                   />
                 ))}
               </MyView>


### PR DESCRIPTION
## ⚠️ Regressão minha, do #108 — e está em produção via OTA

Ao confirmar um **Excluir no Histórico** (app nativo): a tela inteira some, e ao reabrir o app **o registro está de volta**.

## Causa raiz

Ao trocar o contador de `tick` pela assinatura da store no #108, removi o estado mas deixei a referência órfã:

```jsx
onChanged={() => setTick((t) => t + 1)}   // app/history.jsx:130 — setTick não existe mais
```

1. `remove(id)` atualiza a store **em memória**
2. `onChanged?.()` chama `setTick` → **ReferenceError** → tela cai
3. O crash ocorre **antes** do `autoSave` assíncrono gravar no SQLite → ao reabrir, o registro voltou

**Por que o web mascarou:** erro em event handler vira só log no console; a store já tinha propagado, o item sumia e parecia funcionar.

## O fix

Remove o `onChanged` — ele é **desnecessário** aqui: o `useTable` já assina a store e re-renderiza quando o registro sai.

## Por que o CI não pegou (o achado maior)

Um `no-undef` teria barrado isso antes do commit. Mas o `eslint.config.mjs` cobre `files: ["**/*.js"]` — e o app tem **22 `.jsx` e zero `.js`**. **O eslint não linta uma linha do app.** O `tsc` também é cego (`@ts-nocheck` em todos, ADR-002).

Comprovado com config ad-hoc sobre o arquivo antes do fix:
```
130:38  error  'setTick' is not defined  no-undef   ✖ 1 problem
```
Vou abrir issue separada pra isso — cobrir `.jsx` provavelmente revela mais coisa nos 22 arquivos nunca lintados.

## Verificação
- [x] `tsc`/`eslint`/`prettier` verdes; `expo export -p web` compila.
- [x] Nenhum `setTick`/`tick` restante em `app/history.jsx`.
- [x] eslint ad-hoc: erro **antes**, limpo **depois**.
- [ ] **Runtime (seu teste, no app pós-OTA):** Histórico → Excluir → confirmar → registro some, **tela não cai**; fechar e reabrir → **continua excluído**.

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)