### PR TITLE
feat(updates): avisa quando há atualização OTA pendente (#131)

### DIFF
--- a/app/_layout.jsx
+++ b/app/_layout.jsx
@@ -2,10 +2,11 @@
 import "@/global.css";
 
 import { Stack } from "expo-router";
-import { useColorScheme } from "react-native";
+import { useColorScheme, View } from "react-native";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { Colors } from "@/constants/Colors";
 import { useRegistrosPersistencia } from "@/infra/persistence";
+import UpdateBanner from "@/components/UpdateBanner";
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();
@@ -15,22 +16,26 @@ export default function RootLayout() {
 
   return (
     <SafeAreaProvider>
-      <Stack
-        screenOptions={{
-          headerShown: false,
-          headerStyle: { backgroundColor: theme.background },
-          headerTintColor: theme.text,
-        }}
-      >
-        <Stack.Screen name="index" options={{ title: "Hoje" }} />
-        <Stack.Screen name="roadmap" options={{ title: "Roadmap" }} />
-        <Stack.Screen name="export" options={{ title: "Exportação" }} />
-        <Stack.Screen name="history" options={{ title: "Histórico" }} />
-        <Stack.Screen name="feedback" options={{ title: "Feedback" }} />
-        {/* Rota de admin (testers) — acesso só por deep link backontrack://admin */}
-        <Stack.Screen name="admin" options={{ title: "Admin" }} />
-        <Stack.Screen name="(metrics)" />
-      </Stack>
+      {/* View de raiz só pra ancorar o UpdateBanner sobre a rota atual. */}
+      <View className="flex-1">
+        <Stack
+          screenOptions={{
+            headerShown: false,
+            headerStyle: { backgroundColor: theme.background },
+            headerTintColor: theme.text,
+          }}
+        >
+          <Stack.Screen name="index" options={{ title: "Hoje" }} />
+          <Stack.Screen name="roadmap" options={{ title: "Roadmap" }} />
+          <Stack.Screen name="export" options={{ title: "Exportação" }} />
+          <Stack.Screen name="history" options={{ title: "Histórico" }} />
+          <Stack.Screen name="feedback" options={{ title: "Feedback" }} />
+          {/* Rota de admin (testers) — acesso só por deep link backontrack://admin */}
+          <Stack.Screen name="admin" options={{ title: "Admin" }} />
+          <Stack.Screen name="(metrics)" />
+        </Stack>
+        <UpdateBanner />
+      </View>
     </SafeAreaProvider>
   );
 }

--- a/app/index.jsx
+++ b/app/index.jsx
@@ -13,6 +13,7 @@ import InstallApp from "@/components/InstallApp";
 
 import { clearAll, getToday, store } from "@/infra/database";
 import { confirmAction } from "@/constants/dialogs";
+import { getEnvironmentInfo } from "@/constants/environment";
 import { CATEGORY_MAP } from "@/components/categoryUtils";
 import { minutesToHHMM } from "@/constants/duration";
 import { shadow } from "@/constants/Colors";
@@ -22,6 +23,9 @@ const CARD =
   "w-full max-w-[640px] rounded-lg bg-light-backgroundCard p-4 dark:bg-dark-backgroundCard";
 const LABEL =
   "font-bold text-xs text-light-text opacity-60 dark:text-dark-text";
+
+// Versão/bundle exibidos nos Utilitários (#131).
+const ENV = getEnvironmentInfo();
 
 const METRICS = Object.keys(CATEGORY_MAP);
 const TOTAL = METRICS.length;
@@ -148,6 +152,12 @@ export default function Home() {
             title="Roadmap do projeto"
             onPress={() => router.navigate("/roadmap")}
           />
+          {/* Versão visível pro tester saber (e reportar) em qual bundle está —
+              o OTA troca o JS sem mudar a versão do app (#131). */}
+          <Text className="pt-1 text-center text-xs text-light-text opacity-50 dark:text-dark-text">
+            v{ENV.appVersion}
+            {ENV.bundle ? ` · ${ENV.bundle}` : ""}
+          </Text>
         </MyView>
       </ScrollView>
     </MyView>

--- a/components/UpdateBanner.jsx
+++ b/components/UpdateBanner.jsx
@@ -1,0 +1,41 @@
+// @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
+//
+// Aviso de atualização OTA pendente (#131).
+//
+// O expo-updates baixa o update em background mas só o aplica na abertura
+// SEGUINTE — e faz isso em silêncio. Na prática o tester roda um bundle velho
+// sem saber: testa um bug já corrigido, bate nele e reporta "continua quebrado".
+// Este banner torna esse estado visível e deixa aplicar na hora.
+//
+// Não recarrega sozinho de propósito: seria brusco no meio de um registro.
+//
+// Posicionado absoluto no rodapé porque cada tela já monta o próprio safe-area
+// (MyView safe) e o app é edge-to-edge: em fluxo, no topo, ele brigaria com o
+// inset das telas (gap duplo) ou ficaria sob a status bar. Absoluto flutua sobre
+// a rota atual sem mexer no layout de ninguém.
+//
+// Em dev/web o expo-updates é no-op: `isUpdatePending` fica false e o banner
+// nunca aparece.
+import { Pressable, Text } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useUpdates, reloadAsync } from "expo-updates";
+
+export default function UpdateBanner() {
+  const { isUpdatePending } = useUpdates();
+  const insets = useSafeAreaInsets();
+
+  if (!isUpdatePending) return null;
+
+  return (
+    <Pressable
+      onPress={() => reloadAsync()}
+      android_ripple={{ color: "#00000022" }}
+      className="absolute right-0 bottom-0 left-0 items-center bg-secondary px-4 pt-3"
+      style={{ paddingBottom: insets.bottom + 12 }}
+    >
+      <Text className="text-center font-bold text-light-outerText dark:text-dark-text">
+        Atualização pronta — toque para reiniciar
+      </Text>
+    </Pressable>
+  );
+}


### PR DESCRIPTION
## O que (M3-6 — veio do uso real)

Ao validar o fix do #126, o app seguia crashando; depois de fechar, esperar e reabrir, funcionou. Não foi acaso — é o **comportamento padrão e invisível** do `expo-updates`:

```
abre  → checa e BAIXA em background → mas segue rodando o bundle ANTIGO
fecha → abre → só agora o novo aplica
```

**Por que importa mais do que parece:** isso **envenena o circuito de feedback**. Um tester pode testar um bug já corrigido, bater nele porque o OTA não aplicou, e reportar "continua quebrado". O #116 nos deu o `Bundle: OTA <id>` na issue — resolve pra **nós** na triagem, mas o **tester** segue no escuro, e o retrabalho já aconteceu.

## Mudanças
- **`components/UpdateBanner.jsx`** (novo): quando `isUpdatePending` (`useUpdates()`), mostra *"Atualização pronta — toque para reiniciar"* → `reloadAsync()`. **Não recarrega sozinho** de propósito: seria brusco no meio de um registro.
- **`app/_layout.jsx`**: banner ancorado sobre a rota atual (o download termina em background, em qualquer tela).
- **`app/index.jsx`**: Utilitários passam a mostrar **versão + bundle**, pro tester conferir/reportar onde está — o OTA troca o JS **sem mudar a versão do app**. Reusa o `getEnvironmentInfo()` do #116.

### Por que o banner é absoluto no rodapé
Cada tela já monta o próprio safe-area (`MyView safe`) e o app é **edge-to-edge**. Em fluxo, no topo, o banner ou brigaria com o inset das telas (gap duplo) ou ficaria sob a status bar. Absoluto flutua sobre a rota sem mexer no layout de ninguém.

## Fora de escopo — e o porquê
`fallbackToCacheTimeout` (app esperar e já aplicar na abertura) é **config nativa**: muda o fingerprint do `runtimeVersion`, **exige rebuild do APK e não chega por OTA** — e ainda atrasaria todo cold start. O banner é só JS: chega nos testers hoje.

## Verificação
- [x] `tsc`/`eslint`/`prettier` verdes; `expo export -p web` compila com a API de UI do `expo-updates`.
- [ ] **Runtime (seu teste, pós-merge):** este PR é o próprio OTA — ao mergear, o app baixa e o banner deve aparecer na **abertura seguinte**. Tocar → reinicia e aplica. Confirmar também a versão nos Utilitários.

> ⚠️ Nota honesta: o banner **não pode ser testado antes do merge** — ele só aparece quando existe um OTA pendente de verdade, e OTA só publica na main. No web ele nunca aparece (expo-updates é no-op lá).

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)