### PR TITLE
fix(lint): faz o eslint enxergar o app (.jsx) e trata os achados (#128)

### DIFF
--- a/app/admin.jsx
+++ b/app/admin.jsx
@@ -32,6 +32,9 @@ export default function Admin() {
   // `startAutoLoad()` da persistência termina. Ler só no foco fazia a lista
   // nascer vazia no primeiro load (mesma causa do #108).
   const testersTable = useTable("testers", store);
+  // `testersTable` é gatilho de propósito (ver #108); remover a dep faria a
+  // lista não atualizar ao adicionar/remover tester.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const testers = useMemo(() => getTesters(), [testersTable]);
 
   const canAdd = name.trim() !== "" && phone.trim() !== "";

--- a/app/history.jsx
+++ b/app/history.jsx
@@ -49,6 +49,9 @@ export default function History() {
   const records = useTable("records", store);
 
   // Registros do dia agrupados por type (uma passada só, via getByDate).
+  // `records` é gatilho de propósito (ver #108); remover a dep, como o
+  // exhaustive-deps sugere, faria o histórico não atualizar ao excluir.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const day = useMemo(() => getByDate(date.toISOString()), [date, records]);
 
   const isToday = isSameDay(date, new Date());

--- a/app/index.jsx
+++ b/app/index.jsx
@@ -62,6 +62,10 @@ export default function Home() {
   // tela lia a store ainda vazia e nunca era avisada quando os dados chegavam,
   // então a Home só mostrava algo depois de ir a outra tela e voltar (#108).
   const records = useTable("records", store);
+  // `records` é gatilho de propósito: muda quando a tabela muda (inclui o fim do
+  // autoLoad) e força o getToday a reler. O exhaustive-deps não vê que os dois
+  // olham os mesmos dados e sugere remover — o que reintroduziria o #108.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const today = useMemo(() => getToday(), [records]);
 
   function handleClear() {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig, globalIgnores } from "eslint/config";
 import js from "@eslint/js";
 import globals from "globals";
+import reactHooks from "eslint-plugin-react-hooks";
 
 export default defineConfig([
   globalIgnores([
@@ -14,14 +15,29 @@ export default defineConfig([
     ".vscode/",
   ]),
   {
-    files: ["**/*.js"],
-    plugins: {
-      js,
-    },
+    // O código do app é .jsx (as telas/componentes) + .js (constants/infra).
+    // Antes o eslint só cobria **/*.js, e como o app é todo .jsx ele não lintava
+    // NADA — foi por isso que um `setTick` inexistente foi parar em produção
+    // (#126). Cobrir .jsx com no-undef como erro fecha essa cegueira (#128).
+    files: ["**/*.{js,jsx}"],
+    plugins: { js, "react-hooks": reactHooks },
     extends: ["js/recommended"],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+      parserOptions: { ecmaFeatures: { jsx: true } },
+      // RN/web: console, fetch, setTimeout, globalThis, navigator… vêm daqui.
+      // process (1 arquivo) fica no `/* global process */` inline dele.
+      globals: globals.browser,
+    },
     rules: {
       "no-unused-vars": "warn",
-      "no-undef": "warn",
+      // Erro (não warn): é o que faz um no-undef como o do #126 quebrar o CI.
+      "no-undef": "error",
+      // O código já trazia um disable de exhaustive-deps sem o plugin instalado
+      // — a intenção sempre foi ter o react-hooks ligado.
+      "react-hooks/rules-of-hooks": "error",
+      "react-hooks/exhaustive-deps": "warn",
     },
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.6",
         "eslint-plugin-react": "^7.37.5",
+        "eslint-plugin-react-hooks": "^7.1.1",
         "globals": "^17.7.0",
         "husky": "^9.1.7",
         "postcss": "^8.5.16",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.6",
     "eslint-plugin-react": "^7.37.5",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "globals": "^17.7.0",
     "husky": "^9.1.7",
     "postcss": "^8.5.16",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
     "metro.config.js",
     "jest.config.js",
     "tailwind.config.js",
+    "eslint.config.mjs",
     "scripts",
     "plugins",
     "api"


### PR DESCRIPTION
## O problema

O eslint cobria `files: ["**/*.js"]` — e o app é **22 `.jsx`, zero `.js`**. Ou seja: **não lintava uma linha do código do app**. O job "Eslint" passava verde sobre código que nunca olhava. Foi assim que um `setTick` inexistente foi pra produção via OTA (#126); o `tsc` também é cego (`@ts-nocheck` em tudo, ADR-002).

## Mudanças

- **`eslint.config.mjs`**: bloco principal passa a cobrir `**/*.{js,jsx}`, com parsing JSX e globals de browser (cobrem `globalThis`/`navigator`/etc. do RN; `process` segue no `/* global */` inline do único arquivo que usa). **`no-undef` vira `error`** (era `warn`) — é o que faz um `no-undef` como o do #126 **quebrar o CI**.
- **`eslint-plugin-react-hooks`** ligado (`rules-of-hooks: error`, `exhaustive-deps: warn`). O código já tinha um `// eslint-disable react-hooks/exhaustive-deps` **sem o plugin instalado** — a intenção sempre foi tê-lo.
- **Os 3 `exhaustive-deps` que apareceram** são falso-positivo sobre o padrão do #108: a dep `records`/`testersTable` é **gatilho de propósito** (o `useTable` notifica, o seletor relê a store). Seguir a sugestão do linter e removê-la **reintroduziria o #108**. Anotados com `disable` **+ explicação** — triados, não silenciados no escuro.
- **`tsconfig.json`**: exclui `eslint.config.mjs` do type-check, como já faz com `babel/metro/jest/tailwind.config` — os tipos do plugin de hooks conflitavam com o `defineConfig`.

## Prova (o objetivo de saída da issue)

Injetei o exato bug do #126 (`setTick` num `.jsx`) e rodei o CI local:
```
55:18  error  'setTket' is not defined  no-undef   ✖ 1 error
```
Antes: passava batido. Agora: quebra o CI.

## Verificação
- [x] `tsc`/`eslint`/`prettier` verdes; `expo export -p web` compila.
- [x] `no-undef` em `.jsx` agora falha o lint (demonstrado).
- [x] `react-hooks` ativo; os 3 warnings de exhaustive-deps triados com disable justificado.

## Fora de escopo
Adotar o `eslint-plugin-react` recomendado (já é dependência, mas ligar pode virar faxina própria); remover os `@ts-nocheck` (dívida do ADR-002). São candidatos a itens futuros do M4.

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)