### PR TITLE
test(domain): cobre duration.js e o parser do roadmap (#140)

### DIFF
--- a/tests/duration.test.js
+++ b/tests/duration.test.js
@@ -1,0 +1,46 @@
+// @ts-nocheck -- teste; globals do jest não são tipados (ADR-002)
+// Conversão HH:MM ↔ minutos (M4, #140). Sustenta as métricas de tempo
+// (sono/exercício/estudo): a UI edita em "HH:MM", a store guarda minutos.
+import { hhmmToMinutes, minutesToHHMM } from "../constants/duration";
+
+describe("hhmmToMinutes", () => {
+  test.each([
+    ["7:30", 450],
+    ["0:00", 0],
+    ["1:00", 60],
+    ["10:5", 605],
+    ["", 0],
+  ])("'%s' → %i", (input, expected) => {
+    expect(hhmmToMinutes(input)).toBe(expected);
+  });
+
+  test("número passa direto (sem parse de string)", () => {
+    expect(hhmmToMinutes(450)).toBe(450);
+  });
+
+  test("lixo vira 0, sem quebrar", () => {
+    expect(hhmmToMinutes("abc")).toBe(0);
+  });
+});
+
+describe("minutesToHHMM", () => {
+  test.each([
+    [450, "7:30"],
+    [0, "0:00"],
+    [5, "0:05"], // minutos sempre com 2 dígitos
+    [60, "1:00"],
+    [125, "2:05"],
+  ])("%i → '%s'", (input, expected) => {
+    expect(minutesToHHMM(input)).toBe(expected);
+  });
+
+  test("não-numérico vira 0:00", () => {
+    expect(minutesToHHMM("abc")).toBe("0:00");
+  });
+});
+
+test("round-trip HH:MM → minutos → HH:MM preserva o valor", () => {
+  for (const s of ["7:30", "0:05", "12:00", "1:59"]) {
+    expect(minutesToHHMM(hhmmToMinutes(s))).toBe(s);
+  }
+});

--- a/tests/roadmap.test.js
+++ b/tests/roadmap.test.js
@@ -1,0 +1,93 @@
+// @ts-nocheck -- teste; globals do jest não são tipados (ADR-002)
+// Parser do roadmap (M4, #140). É ele que alimenta a tela /roadmap a partir do
+// docs/04-roadmap-milestones.md — se quebrar, a tela mente ou some.
+import { parseRoadmap, cleanText, getDigest } from "../constants/roadmap";
+
+const MD = `
+## M0: Fundamentos ✅ concluído
+
+- ✅ Ambiente configurado
+- ✅ Navegação entre telas
+
+## M1 — Trabalho real
+
+- ✅ Persistência integrada
+- 🟡 Migração de estilo
+- ⬜ Documentação de manutenção
+`;
+
+describe("parseRoadmap", () => {
+  test("extrai milestones na ordem, com id e título limpos", () => {
+    const ms = parseRoadmap(MD);
+    expect(ms.map((m) => m.id)).toEqual(["M0", "M1"]);
+    expect(ms[0].title).toBe("Fundamentos");
+    expect(ms[1].title).toBe("Trabalho real");
+  });
+
+  test("extrai os itens com status", () => {
+    const [, m1] = parseRoadmap(MD);
+    expect(m1.items).toEqual([
+      { status: "done", text: "Persistência integrada" },
+      { status: "partial", text: "Migração de estilo" },
+      { status: "todo", text: "Documentação de manutenção" },
+    ]);
+  });
+
+  test("status da milestone: header manda; senão, infere dos itens", () => {
+    const [m0, m1] = parseRoadmap(MD);
+    expect(m0.status).toBe("done"); // "✅ concluído" no header
+    expect(m1.status).toBe("partial"); // itens mistos → parcial
+  });
+
+  test("tolerante: linhas fora do padrão não quebram nem viram item", () => {
+    const ms = parseRoadmap("## M9 Teste\n\ntexto solto\n- ✅ item real\n");
+    expect(ms).toHaveLength(1);
+    expect(ms[0].items).toEqual([{ status: "done", text: "item real" }]);
+  });
+});
+
+describe("cleanText", () => {
+  test("remove link markdown, mantendo o rótulo", () => {
+    expect(cleanText("Histórico [#63](https://x)")).toBe("Histórico");
+  });
+
+  test("remove `code`, **bold** e parênteses simples", () => {
+    expect(cleanText("Tela `app/index.jsx` (#94)")).toBe("Tela app/index.jsx");
+    expect(cleanText("**Editar** registros")).toBe("Editar registros");
+  });
+
+  test("corta na manchete (primeiro ':' depois do 15º caractere)", () => {
+    expect(
+      cleanText("Histórico navegável por data: tela app/history.jsx"),
+    ).toBe("Histórico navegável por data");
+  });
+
+  test("LIMITAÇÃO conhecida: parênteses aninhados deixam ')' órfão", () => {
+    // O regex remove de '(' até o PRIMEIRO ')', então aninhado sobra lixo.
+    // Documentado de propósito: se alguém consertar o parser, este teste avisa
+    // (é o que motivou reescrever o item do M4 sem parênteses aninhados).
+    expect(cleanText("roda (expect(1+1).toEqual(2)) no CI")).toContain(
+      "toEqual)",
+    );
+  });
+});
+
+describe("getDigest", () => {
+  test("contagem de milestones e milestone atual", () => {
+    const d = getDigest(parseRoadmap(MD));
+    expect(d.milestonesDone).toBe(1);
+    expect(d.milestonesTotal).toBe(2);
+    expect(d.current.id).toBe("M1"); // primeira parcial
+    expect(d.currentProgress).toEqual({ done: 1, total: 3 });
+  });
+
+  test("recentDone completa com a milestone anterior quando há poucos", () => {
+    const d = getDigest(parseRoadmap(MD));
+    // M1 só tem 1 ✅; completa com os 2 ✅ do M0.
+    expect(d.recentDone.map((i) => i.text)).toEqual([
+      "Ambiente configurado",
+      "Navegação entre telas",
+      "Persistência integrada",
+    ]);
+  });
+});


### PR DESCRIPTION
## O que (M4 — fecha o 🟡 dos testes de domínio)

Duas funções puras que sustentam partes visíveis do app:

- **`tests/duration.test.js`** — `hhmmToMinutes`/`minutesToHHMM`: round-trip, padding de minutos (`5 → 0:05`), entradas vazias e lixo. É o que converte `HH:MM ↔ minutos` nas métricas de tempo (sono/exercício/estudo).
- **`tests/roadmap.test.js`** — `parseRoadmap`/`cleanText`/`getDigest`: o parser que alimenta a tela `/roadmap`. Extração de milestones/itens, inferência de status (header manda; senão infere dos itens), tolerância a linhas fora do padrão, e o `cleanText`.

### A armadilha dos parênteses aninhados, agora travada por teste
Um caso documenta de propósito a limitação que a gente já encontrou (o `cleanText` remove de `(` até o **primeiro** `)`, então aninhado deixa `)` órfão):
```js
expect(cleanText("roda (expect(1+1).toEqual(2)) no CI")).toContain("toEqual)");
```
Se alguém consertar o parser, o teste avisa (foi o que motivou reescrever um item do M4 sem parênteses aninhados).

## Verificação
- [x] `npm test` → **44 passando** (5 suites); `tsc`/`eslint`/`prettier` verdes.
- [x] Todas as expectativas foram traçadas do código (bateram de primeira).

## Fora de escopo
Consertar a armadilha dos parênteses aninhados; cobertura de 100% dos ramos.

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)