### PR TITLE
docs(roadmap): marca os testes de domínio como feitos (#140)

### DIFF
--- a/docs/04-roadmap-milestones.md
+++ b/docs/04-roadmap-milestones.md
@@ -70,7 +70,7 @@ Esta milestone não existia no plano original — ela nasceu do diagnóstico do 
 
 - ✅ Infra: `jest-expo` + `@testing-library/react-native` configurados, script `test` e job `Test` no CI (#134). jest fixado no 29 (jest-expo 57 não roda no 30)
 - ✅ Fazer o eslint enxergar o app (#128): cobre `.jsx` com `no-undef` como erro (teria barrado o #126) + `eslint-plugin-react-hooks`
-- 🟡 Testes das funções de domínio: `infra/database.js` coberto (add/getToday/getByDate/remove/testers, #134); falta `constants/duration.js` e o parser do roadmap
+- ✅ Testes das funções de domínio: `infra/database.js` (#134), `constants/duration.js` e o parser do roadmap `constants/roadmap.js` (#140) — a armadilha dos parênteses aninhados travada por teste
 - ✅ Teste da corrida da persistência (#108): monta vazio, a store enche depois do mount, o consumidor via `useTable` atualiza sozinho — provado que falha contra o padrão antigo (#134)
 - ✅ Teste da função serverless `api/feedback.js` (#137): guardas, montagem do corpo e compat do #116 (payload legado `device` vs novo `environment`), com o `fetch` mockado — provado que pega a regressão
 - ⬜ Registrar o alvo: o que exige teste e o que não, pra evitar teatro de cobertura


### PR DESCRIPTION
Sincroniza a fonte única com o entregue: `duration.js` e o parser do roadmap agora estão cobertos (#140), somando ao `database.js` (#134). O item de testes de domínio do M4 passa de 🟡 → ✅.

M4 agora com **5 de 6** itens ✅ — só sobra "Registrar o alvo".

Refs #140