### PR TITLE
fix(roadmap): current é a primeira milestone não-done, não o primeiro parcial (#147)

### DIFF
--- a/constants/roadmap.js
+++ b/constants/roadmap.js
@@ -119,11 +119,13 @@ export function getDigest(milestones) {
   const total = milestones.length;
   const done = milestones.filter((m) => m.status === "done").length;
 
+  // "Atual" = a próxima milestone que ainda tem trabalho, na ordem do
+  // roadmap. Não usa "primeiro parcial" porque uma dívida pendente lá no fim
+  // (ex: build de produção/loja no M8) apareceria como "atual" mesmo depois
+  // de milestones inteiras ⬜ à frente. #147.
   const currentIndex = (() => {
-    const partial = milestones.findIndex((m) => m.status === "partial");
-    if (partial !== -1) return partial;
-    const todo = milestones.findIndex((m) => m.status === "todo");
-    return todo !== -1 ? todo : Math.max(0, milestones.length - 1);
+    const next = milestones.findIndex((m) => m.status !== "done");
+    return next !== -1 ? next : Math.max(0, milestones.length - 1);
   })();
 
   const current = milestones[currentIndex] ?? null;

--- a/tests/roadmap.test.js
+++ b/tests/roadmap.test.js
@@ -73,12 +73,29 @@ describe("cleanText", () => {
 });
 
 describe("getDigest", () => {
-  test("contagem de milestones e milestone atual", () => {
+  test("contagem de milestones e milestone atual (primeira não-done)", () => {
     const d = getDigest(parseRoadmap(MD));
     expect(d.milestonesDone).toBe(1);
     expect(d.milestonesTotal).toBe(2);
-    expect(d.current.id).toBe("M1"); // primeira parcial
+    expect(d.current.id).toBe("M1"); // primeira não-done
     expect(d.currentProgress).toEqual({ done: 1, total: 3 });
+  });
+
+  test("current pula milestones ⬜ do meio pra pegar a próxima na ordem (#147)", () => {
+    // Cenário do #147: dívida pendente lá no fim (partial) NÃO deve ganhar de
+    // milestones ⬜ que vêm antes. "Atual" = próximo trabalho na ordem.
+    const md = `
+## M0 Feito
+- ✅ x
+## M1 Próximo
+- ⬜ a
+## M2 Também aberto
+- ⬜ b
+## M3 Dívida pendente do fim
+- 🟡 c
+- ⬜ d
+`;
+    expect(getDigest(parseRoadmap(md)).current.id).toBe("M1");
   });
 
   test("recentDone completa com a milestone anterior quando há poucos", () => {


### PR DESCRIPTION
## O que
Apareceu ao fechar o M3 (#145): o painel `/roadmap` passou a apontar `current: M8` em vez de M5. Causa: `getDigest` procurava o **primeiro parcial**, e o M8 tinha 1 item 🟡 (build de produção/loja pendente há muito tempo), então uma **dívida do fim** vencia milestones ⬜ inteiras à frente. Ficava escondido enquanto o M3 era o parcial mais próximo.

## Correção
`current` = **primeira milestone não-done na ordem do roadmap**. Reflete o que "milestone atual" deveria significar — o próximo trabalho que aparece pra fazer, não uma dívida pendente lá no fim.

## Teste que trava o comportamento
Roadmap sintético com um `partial` atrás de todos, `current` deve ser o primeiro `todo`. Provado que morde: contra o código antigo o teste falha (`Expected: M1, Received: M3`).

Isso só pôde ser trancado porque o **M4 acabou de fechar** (a milestone que garantiu que testes rodam no CI e travam regressões). Bom uso da rede de segurança logo na primeira semana.

## Efeito no painel real
Antes: `current: M8 — Estabilização` (esquisito, era pra estar em Design System)
Agora: `current: M5 — Design System & Consistência de UI` ✅

## Verificação
- [x] `npm test` → **45 passando** (era 44, +1 do #147).
- [x] `tsc`/`eslint`/`prettier` verdes; `expo export -p web` compila.
- [x] Roadmap real: `current: M5`.

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)