### PR TITLE
docs(roadmap): marca a auditoria de UI como feita

### DIFF
--- a/docs/04-roadmap-milestones.md
+++ b/docs/04-roadmap-milestones.md
@@ -81,7 +81,7 @@ Esta milestone não existia no plano original — ela nasceu do diagnóstico do 
 
 **Objetivo de saída:** telas consistentes em claro/escuro e no web, sobre um conjunto único de tokens e componentes — sem estilo duplicado. É o que separa "funciona" de "parece v1".
 
-- ⬜ Auditar as inconsistências atuais (botões, cards, header, escala tipográfica, responsividade web) e registrar o alvo
+- ✅ Auditar as inconsistências atuais (botões, cards, header, escala tipográfica, responsividade web) e registrar o alvo: `docs/07-auditoria-ui.md` (#149) — 10 achados com arquivo/linha, dos quais 5 funcionais (borda invisível do `MyInput` no dark, divergência `useColorScheme` RN vs NativeWind, padding duplicado nas telas de métrica, `MyView safe` default vazando em `MyCheckbox`/`Score`, `flex-row` num `<Text>`) que servem de entrada pros próximos itens
 - ⬜ Tokens canônicos: espaçamento, tipografia (revisar o truque `font-size: 62.5%`), raio, sombra, cor — fonte única
 - ⬜ Componentizar o que está duplicado (`CARD`/`LABEL` repetidos em 3 telas → componente; padronizar `MyButton`/`HistoryCard`/`MyHeader`)
 - ⬜ Revisar o `MyHeader` (papel de navegação vs. chips de métrica) e o alinhamento no web


### PR DESCRIPTION
Reflete o merge do #150 no roadmap: primeiro item do M5 (auditoria de UI) marca ✅, com um resumo do que foi entregue e link pro `docs/07-auditoria-ui.md`.

Segue o padrão dos updates anteriores de roadmap (#136, #148): só o update, sem issue separada.

## Test plan

- [ ] `constants/roadmap.js` (parser) continua verde — atualiza `current` pro próximo item ⬜ do M5
- [ ] CI verde