### PR TITLE
fix(ui): resolve os 5 achados funcionais da auditoria

### DIFF
--- a/app/(metrics)/_layout.jsx
+++ b/app/(metrics)/_layout.jsx
@@ -2,34 +2,11 @@
 import "@/global.css";
 
 import { Stack } from "expo-router";
-import { useColorScheme, View } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { Colors } from "@/constants/Colors";
-import MyHeader from "@/components/MyHeader";
 
 export default function RootLayout() {
-  const colorScheme = useColorScheme();
-  const theme = Colors[colorScheme] ?? Colors.light;
-  const insets = useSafeAreaInsets();
-
   return (
-    <View
-      style={{
-        flex: 1,
-        paddingTop: insets.top,
-        backgroundColor: theme.background,
-      }}
-    >
-      <MyHeader />
-      <Stack
-        screenOptions={{
-          headerShown: false,
-          headerStyle: { backgroundColor: theme.background },
-          headerTintColor: theme.text,
-        }}
-      >
-        <Stack.Screen name="[metric]" options={{ headerShown: false }} />
-      </Stack>
-    </View>
+    <Stack screenOptions={{ headerShown: false }}>
+      <Stack.Screen name="[metric]" />
+    </Stack>
   );
 }

--- a/app/_layout.jsx
+++ b/app/_layout.jsx
@@ -2,29 +2,19 @@
 import "@/global.css";
 
 import { Stack } from "expo-router";
-import { useColorScheme, View } from "react-native";
+import { View } from "react-native";
 import { SafeAreaProvider } from "react-native-safe-area-context";
-import { Colors } from "@/constants/Colors";
 import { useRegistrosPersistencia } from "@/infra/persistence";
 import UpdateBanner from "@/components/UpdateBanner";
 
 export default function RootLayout() {
-  const colorScheme = useColorScheme();
-  const theme = Colors[colorScheme] ?? Colors.light;
-
   useRegistrosPersistencia();
 
   return (
     <SafeAreaProvider>
       {/* View de raiz só pra ancorar o UpdateBanner sobre a rota atual. */}
       <View className="flex-1">
-        <Stack
-          screenOptions={{
-            headerShown: false,
-            headerStyle: { backgroundColor: theme.background },
-            headerTintColor: theme.text,
-          }}
-        >
+        <Stack screenOptions={{ headerShown: false }}>
           <Stack.Screen name="index" options={{ title: "Hoje" }} />
           <Stack.Screen name="roadmap" options={{ title: "Roadmap" }} />
           <Stack.Screen name="export" options={{ title: "Exportação" }} />

--- a/components/MyCheckbox.jsx
+++ b/components/MyCheckbox.jsx
@@ -7,7 +7,7 @@ import { Text } from "react-native";
 
 export default function MyCheckbox({ label, onValueChange, value }) {
   return (
-    <MyView className="flex-row items-center gap-1.5">
+    <MyView safe={false} className="flex-row items-center gap-1.5">
       <Checkbox
         color={value ? Colors.primary : "gray"}
         value={value}

--- a/components/MyHistory.jsx
+++ b/components/MyHistory.jsx
@@ -72,7 +72,7 @@ export function HistoryCard({
       className="w-full max-w-[640px] gap-2.5 rounded-md bg-light-backgroundCard p-2.5 dark:bg-dark-backgroundCard"
       style={[cardStyle, shadow]}
     >
-      <Text className="w-full flex-row justify-between">
+      <View className="w-full flex-row items-center justify-between">
         <Text className="font-bold text-lg text-light-text dark:text-dark-text">
           {hideDate ? "" : `${formatDate(obj.date)} `}
           {exercise && obj.trainingTime ? `${obj.trainingTime} ` : ""}
@@ -85,7 +85,7 @@ export function HistoryCard({
         >
           {obj.score}
         </Text>
-      </Text>
+      </View>
 
       {exercise && (
         <MyView safe={false} className="flex-row gap-4">

--- a/components/MyInput.jsx
+++ b/components/MyInput.jsx
@@ -22,7 +22,7 @@ export default function MyInput({
         </Text>
       )}
       <TextInput
-        className={`rounded border border-[#333] px-2 py-1 text-light-text dark:text-dark-text ${
+        className={`rounded border border-[#333] px-2 py-1 text-light-text dark:border-[#888] dark:text-dark-text ${
           className ?? ""
         }`}
         style={style}

--- a/components/Score.jsx
+++ b/components/Score.jsx
@@ -7,7 +7,10 @@ export default function Score({ onPress, value, ...props }) {
   const scoreRange = 5;
 
   return (
-    <MyView className="flex-row flex-wrap items-center justify-start gap-2.5 p-1.5">
+    <MyView
+      safe={false}
+      className="flex-row flex-wrap items-center justify-start gap-2.5 p-1.5"
+    >
       {Array.from({ length: scoreRange + 1 }).map((_, index) => (
         <MyButton
           key={index}

--- a/components/metrics/MetricScreen.jsx
+++ b/components/metrics/MetricScreen.jsx
@@ -12,6 +12,7 @@ import { Snackbar } from "react-native-paper";
 
 import ScoreRaw from "@/components/Score";
 import MyViewRaw from "@/components/MyView";
+import MyHeaderRaw from "@/components/MyHeader";
 
 import { getCategoryInfo } from "@/components/categoryUtils";
 import getDate from "@/constants/getDate";
@@ -20,6 +21,7 @@ import { getMetricConfig } from "./registry";
 
 const MyView = /** @type {any} */ (MyViewRaw);
 const Score = /** @type {any} */ (ScoreRaw);
+const MyHeader = /** @type {any} */ (MyHeaderRaw);
 
 const LABEL = "font-bold text-lg text-light-text dark:text-dark-text";
 
@@ -73,8 +75,9 @@ export default function MetricScreen({ metric, recordId }) {
   return (
     <MyView
       safe={true}
-      className="flex-1 items-center gap-4 bg-light-background p-4 dark:bg-dark-background"
+      className="flex-1 bg-light-background dark:bg-dark-background"
     >
+      <MyHeader />
       <Snackbar
         visible={visible}
         onDismiss={() => setVisible(false)}
@@ -85,8 +88,9 @@ export default function MetricScreen({ metric, recordId }) {
       <ScrollView
         style={{ width: "100%" }}
         contentContainerStyle={{
-          alignItems: "center",
+          padding: 16,
           gap: 16,
+          alignItems: "center",
           paddingBottom: 24,
         }}
         showsVerticalScrollIndicator={false}


### PR DESCRIPTION
Follow-up funcional da auditoria de UI (#149). Fecha #152.

Todos os 5 achados classificados como **funcionais** em `docs/07-auditoria-ui.md` — independentes de tokens/componentização, então dá pra encostar agora e deixar o chão limpo pros próximos itens do M5.

## O que mudou

| # | Arquivo | Fix |
|---|---|---|
| §3 | `components/MyInput.jsx` | Adiciona `dark:border-[#888]`. Antes `border-[#333]` sumia no fundo `#333333` do dark. |
| §5a | `app/_layout.jsx` | Remove `useColorScheme` + `Colors` + `theme` — todo o código era dead sob `headerShown: false` (`headerStyle`/`headerTintColor` nunca renderizavam). |
| §5a+§5b | `app/(metrics)/_layout.jsx` | Vira uma `<Stack>` mínima. O wrapper `<View>` (que causava o padding duplicado) sai; `MyHeader` migra pra `MetricScreen`, alinhando com o padrão das telas topo-nível. |
| §5b | `components/metrics/MetricScreen.jsx` | Recebe o `MyHeader` no topo do `MyView safe={true}`. Padding externo (que era `p-4` no MyView) migra pro `contentContainerStyle` do `ScrollView`, seguindo o mesmo shape de `app/index.jsx`/`history.jsx`. |
| §6 | `components/MyCheckbox.jsx`, `components/Score.jsx` | `safe={false}` no `MyView`. Componentes de formulário não devem herdar padding de safe-area por default. |
| §10 | `components/MyHistory.jsx` | `<Text className="w-full flex-row justify-between">` vira `<View>`. Flex em `Text` no RN não é container e o alinhamento nome/nota não estava acontecendo — agora está, com `items-center`. |

**Saldo:** -26 linhas líquidas (sinal saudável — a maior parte é remoção de dead code de tema/inset).

## Fora de escopo

Tokens canônicos, componentização, revisão do `MyHeader` (o objetivo semântico) — são itens próprios do M5.

## Test plan

- [ ] Web (preview Vercel):
  - [ ] Input do feedback/admin: borda visível no dark
  - [ ] Botão "Alternar tema" na Home muda o `bg` de todas as telas
  - [ ] Cabeçalho da tela de métrica (chips) não tem gap extra
  - [ ] Card do histórico: nome à esquerda, badge de nota à direita, alinhados verticalmente
- [ ] CI verde (Prettier/ESLint/Types/Test/commitlint)