### PR TITLE
refactor(ui): raio canônico (rounded-full/lg/md por papel)

### DIFF
--- a/components/MyHistory.jsx
+++ b/components/MyHistory.jsx
@@ -69,7 +69,7 @@ export function HistoryCard({
   return (
     <MyView
       safe={false}
-      className="w-full max-w-[640px] gap-2.5 rounded-md bg-light-backgroundCard p-2.5 dark:bg-dark-backgroundCard"
+      className="w-full max-w-[640px] gap-2.5 rounded-lg bg-light-backgroundCard p-2.5 dark:bg-dark-backgroundCard"
       style={[cardStyle, shadow]}
     >
       <View className="w-full flex-row items-center justify-between">

--- a/components/MyInput.jsx
+++ b/components/MyInput.jsx
@@ -22,7 +22,7 @@ export default function MyInput({
         </Text>
       )}
       <TextInput
-        className={`rounded border border-[#333] px-2 py-1 text-light-text dark:border-[#888] dark:text-dark-text ${
+        className={`rounded-md border border-[#333] px-2 py-1 text-light-text dark:border-[#888] dark:text-dark-text ${
           className ?? ""
         }`}
         style={style}

--- a/components/metrics/fields.jsx
+++ b/components/metrics/fields.jsx
@@ -16,7 +16,7 @@ const MyIconButton = /** @type {any} */ (MyIconButtonRaw);
 
 const LABEL = "font-bold text-lg text-light-text dark:text-dark-text";
 const INPUT_LG =
-  "h-[51px] w-20 max-w-[160px] rounded-lg bg-light-backgroundCard dark:bg-dark-backgroundCard p-1.5 text-center text-[26px] font-bold text-light-text dark:text-dark-text";
+  "h-[51px] w-20 max-w-[160px] rounded-md bg-light-backgroundCard dark:bg-dark-backgroundCard p-1.5 text-center text-[26px] font-bold text-light-text dark:text-dark-text";
 const CARD =
   "items-center gap-8 rounded-lg bg-light-backgroundCard p-2.5 dark:bg-dark-backgroundCard";
 
@@ -32,7 +32,7 @@ const CARD =
  */
 export function MinMaxIdealField({ min, max, ideal, onMin, onMax, onIdeal }) {
   const inputClass =
-    "max-w-[160px] rounded-lg bg-light-backgroundCard p-1.5 text-[26px] font-bold text-light-text dark:bg-dark-backgroundCard dark:text-dark-text";
+    "max-w-[160px] rounded-md bg-light-backgroundCard p-1.5 text-[26px] font-bold text-light-text dark:bg-dark-backgroundCard dark:text-dark-text";
   const cols = [
     { label: "MIN", value: min, onChange: onMin },
     { label: "MAX", value: max, onChange: onMax },
@@ -128,7 +128,7 @@ export function QuantityField({ label, value, unit, onChange }) {
         {label} hoje
       </Text>
       <TextInput
-        className="h-[51px] w-20 rounded-lg bg-light-backgroundCard p-1.5 text-center text-[26px] font-bold text-light-text dark:bg-dark-backgroundCard dark:text-dark-text"
+        className="h-[51px] w-20 rounded-md bg-light-backgroundCard p-1.5 text-center text-[26px] font-bold text-light-text dark:bg-dark-backgroundCard dark:text-dark-text"
         placeholder="--"
         value={value}
         onChangeText={onChange}

--- a/components/metrics/registry.jsx
+++ b/components/metrics/registry.jsx
@@ -26,7 +26,7 @@ const MyCheckbox = /** @type {any} */ (MyCheckboxRaw);
 
 const LABEL = "font-bold text-lg text-light-text dark:text-dark-text";
 const INPUT_LG =
-  "h-[51px] w-20 max-w-[160px] rounded-lg bg-light-backgroundCard dark:bg-dark-backgroundCard p-1.5 text-center text-[26px] font-bold text-light-text dark:text-dark-text";
+  "h-[51px] w-20 max-w-[160px] rounded-md bg-light-backgroundCard dark:bg-dark-backgroundCard p-1.5 text-center text-[26px] font-bold text-light-text dark:text-dark-text";
 
 /**
  * @typedef {Object} SlotProps

--- a/docs/08-design-tokens.md
+++ b/docs/08-design-tokens.md
@@ -1,0 +1,57 @@
+# Design Tokens — Back on Track
+
+Referência viva do design system do M5. Cada seção fecha uma decisão sobre um **eixo** (raio, tipografia, espaçamento, cor…) e mostra onde ela vale. O objetivo é matar as escolhas ad-hoc que a auditoria pegou em [docs/07-auditoria-ui.md](07-auditoria-ui.md) — de forma que "qual valor uso aqui?" tenha uma resposta óbvia em cada eixo.
+
+O doc cresce em fatias: começa com raio (fatia 1); tipografia, espaçamento, sombra e cor entram conforme a milestone avança. Cada fatia deve ter um PR próprio e um item ✅ no roadmap.
+
+---
+
+## Raio (`rounded-*`) — fatia 1
+
+**Regra:** três valores canônicos, um papel cada. Zero uso do `rounded` (default) ou de raio ad-hoc (`rounded-[Npx]`).
+
+| Token          | Papel                                     | Onde usar                                                              |
+| -------------- | ----------------------------------------- | ---------------------------------------------------------------------- |
+| `rounded-full` | Pills — o "elemento é circular / cápsula" | Botões, chips de métrica, badge de nota                                |
+| `rounded-lg`   | Cards — containers de conteúdo            | Card do topo das telas, `HistoryCard`, card do form da tela de métrica |
+| `rounded-md`   | Controles — inputs e caixas pequenas      | `MyInput`, inputs de duração/quantidade, inputs pequenos do `registry` |
+
+### Rationale
+
+- **Escolher pelo papel, não pelo tamanho.** Um card grande e um card pequeno usam o mesmo raio; um input grande e um input pequeno também. Assim `qual raio?` fica em função de `o que é isso?`, e a mudança futura de token (`rounded-lg` → `rounded-xl`, se um dia) muda tudo consistente.
+- **Três valores é o mínimo útil.** Menos que isso mata a diferença card × control (fica tudo uniforme, sem hierarquia visual); mais que isso volta ao problema de escolha ad-hoc.
+- **Alinha com o Tailwind default**, sem tokens custom no `tailwind.config.js` — barato de manter, sem camada de indireção.
+
+### O que a fatia mudou (#154)
+
+- `MyInput.jsx` — `rounded` → `rounded-md` (mata o default órfão)
+- `MyHistory.jsx` `HistoryCard` — `rounded-md` → `rounded-lg` (é card, não control)
+- `fields.jsx` inputs de duração / MIN-MAX-IDEAL / QuantityField — `rounded-lg` → `rounded-md`
+- `registry.jsx` `INPUT_LG` — `rounded-lg` → `rounded-md`
+
+Cards que já estavam em `rounded-lg` (as 6 telas topo-nível, `InstallApp.web`, `MetricScreen`, `fields.jsx` CARD, `registry.jsx` linhas 126/216) ficaram como estavam — eles já seguiam o token do papel deles.
+
+### Como validar
+
+Grep no repo só encontra os 3 valores canônicos:
+
+```bash
+git grep -oE 'rounded(-[a-z0-9]+)?' -- '*.jsx' '*.js' | sort | uniq -c
+```
+
+Deve retornar apenas `rounded-full`, `rounded-lg` e `rounded-md`.
+
+### O que NÃO está resolvido aqui
+
+- **Card duplicado como string constante** em 6 telas (§1 da auditoria) — vem no item "Componentizar" do M5, não aqui.
+- **Tokens semânticos de cor**, incluindo o `bg-secondary` reciclado pra 3 papéis (§3.1) — vem numa fatia própria de cor.
+- **Escala tipográfica**, incluindo os `text-[26px]`/`text-[19px]` fora da escala e o truque `font-size: 62.5%` (§4) — fatia própria.
+
+---
+
+## Próximas fatias
+
+- **Tipografia** — resolver `text-[26px]`/`text-[19px]` e o `font-size: 62.5%` mal aplicado; papéis: heading, body, label de seção, label de campo.
+- **Espaçamento** — hoje mistura `p-4`/`p-2.5`/`gap-8`/`gap-2.5` sem critério; escolher 2-3 valores canônicos.
+- **Sombra** — hoje `shadow` (objeto RN em `constants/Colors.js`) é aplicado como `style={shadow}` em cada card; virou de fato um token, só falta documentar aqui.
+- **Cor** — separar semântica (`selected`, `success`, `danger`) do papel visual atual do `bg-secondary`, e criar `border`/`placeholder` tokens que respondam ao dark mode.


### PR DESCRIPTION
Fatia 1 do item "Tokens canônicos" do M5. Fecha #154.

Só o eixo **raio** — tipografia, espaçamento, sombra e cor vêm em fatias próprias (todas listadas em `docs/08-design-tokens.md`).

## Escala

| Token | Papel | Onde |
|---|---|---|
| \`rounded-full\` | Pills | Botões, chips de métrica, badge de nota |
| \`rounded-lg\` | Cards | Containers de conteúdo |
| \`rounded-md\` | Controles | Inputs e caixas pequenas |

Mata o \`rounded\` (default, 4px) órfão do \`MyInput\` e dá papel claro pra cada valor. Regra é **pelo papel, não pelo tamanho**.

## Mudanças

| Arquivo | De → Para | Papel |
|---|---|---|
| \`components/MyInput.jsx\` | \`rounded\` → \`rounded-md\` | control |
| \`components/MyHistory.jsx\` (HistoryCard) | \`rounded-md\` → \`rounded-lg\` | card |
| \`components/metrics/fields.jsx\` (INPUT_LG, MinMaxIdeal input, Quantity input) | \`rounded-lg\` → \`rounded-md\` | control |
| \`components/metrics/registry.jsx\` (INPUT_LG) | \`rounded-lg\` → \`rounded-md\` | control |
| \`docs/08-design-tokens.md\` | novo | referência viva do design system do M5 |

**Cards que já estavam em \`rounded-lg\`** (6 telas topo-nível, InstallApp.web, MetricScreen, fields.jsx CARD, registry.jsx linhas 126/216) **ficam como estão** — já seguiam o token do papel deles.

## Validação

\`\`\`bash
git grep -oE 'rounded(-[a-z0-9]+)?' -- '*.jsx' '*.js' | sort | uniq -c
\`\`\`

Retorna só: \`rounded-full\` (8×), \`rounded-lg\` (14×), \`rounded-md\` (7×). Zero \`rounded\` órfão, zero raio ad-hoc.

## Fora de escopo

- Componentizar \`Card\`/\`CardLabel\` (§1 da auditoria) — item separado do M5
- Tokens semânticos de cor / \`bg-secondary\` reciclado (§3.1) — fatia própria
- Escala tipográfica / \`font-size: 62.5%\` (§4) — fatia própria

## Test plan

- [ ] Web (preview Vercel):
  - [ ] Cards mantêm o mesmo visual (o raio dos que mudaram é maior)
  - [ ] Inputs de métrica com raio ligeiramente menor — leitura mais coesa entre os inputs
  - [ ] \`HistoryCard\` no histórico: raio mais suave
  - [ ] Input do feedback/admin: raio agora bate com os inputs de métrica
- [ ] CI verde (Prettier/ESLint/Types/Test/commitlint)