### PR TITLE
refactor(ui): tipografia canônica na escala Tailwind

### DIFF
--- a/components/metrics/MetricScreen.jsx
+++ b/components/metrics/MetricScreen.jsx
@@ -113,7 +113,7 @@ export default function MetricScreen({ metric, recordId }) {
             <TextInput
               value={observation}
               onChangeText={setObservation}
-              className="h-16 rounded-lg bg-light-backgroundCard p-1.5 text-lg font-normal text-light-text dark:bg-dark-backgroundCard dark:text-dark-text"
+              className="h-16 rounded-lg bg-light-backgroundCard p-1.5 text-base font-normal text-light-text dark:bg-dark-backgroundCard dark:text-dark-text"
               placeholder={config.obsPlaceholder}
             />
           </MyView>

--- a/components/metrics/MetricScreen.jsx
+++ b/components/metrics/MetricScreen.jsx
@@ -23,7 +23,7 @@ const MyView = /** @type {any} */ (MyViewRaw);
 const Score = /** @type {any} */ (ScoreRaw);
 const MyHeader = /** @type {any} */ (MyHeaderRaw);
 
-const LABEL = "font-bold text-lg text-light-text dark:text-dark-text";
+const FIELD_LABEL = "font-bold text-lg text-light-text dark:text-dark-text";
 
 /**
  * @param {{ metric: string, recordId?: string }} props
@@ -99,21 +99,21 @@ export default function MetricScreen({ metric, recordId }) {
           safe={false}
           className={`max-w-[640px] gap-8 rounded-lg bg-light-backgroundCard p-2.5 dark:bg-dark-backgroundCard ${config.cardClass ?? ""}`}
         >
-          <Text className={LABEL}>
+          <Text className={FIELD_LABEL}>
             {date.displayDate} {displayName}
           </Text>
 
           {Top && <Top extra={extra} setField={setField} />}
 
-          <Text className={LABEL}>Nota</Text>
+          <Text className={FIELD_LABEL}>Nota</Text>
           <Score value={score} onPress={setScore} />
 
           <MyView safe={false} className="gap-1">
-            <Text className={LABEL}>OBS:</Text>
+            <Text className={FIELD_LABEL}>OBS:</Text>
             <TextInput
               value={observation}
               onChangeText={setObservation}
-              className="h-16 rounded-lg bg-light-backgroundCard p-1.5 text-[19px] font-normal text-light-text dark:bg-dark-backgroundCard dark:text-dark-text"
+              className="h-16 rounded-lg bg-light-backgroundCard p-1.5 text-lg font-normal text-light-text dark:bg-dark-backgroundCard dark:text-dark-text"
               placeholder={config.obsPlaceholder}
             />
           </MyView>

--- a/components/metrics/fields.jsx
+++ b/components/metrics/fields.jsx
@@ -14,9 +14,9 @@ import { MyIconButton as MyIconButtonRaw } from "@/components/MyButton";
 const MyView = /** @type {any} */ (MyViewRaw);
 const MyIconButton = /** @type {any} */ (MyIconButtonRaw);
 
-const LABEL = "font-bold text-lg text-light-text dark:text-dark-text";
+const FIELD_LABEL = "font-bold text-lg text-light-text dark:text-dark-text";
 const INPUT_LG =
-  "h-[51px] w-20 max-w-[160px] rounded-md bg-light-backgroundCard dark:bg-dark-backgroundCard p-1.5 text-center text-[26px] font-bold text-light-text dark:text-dark-text";
+  "h-[51px] w-20 max-w-[160px] rounded-md bg-light-backgroundCard dark:bg-dark-backgroundCard p-1.5 text-center text-2xl font-bold text-light-text dark:text-dark-text";
 const CARD =
   "items-center gap-8 rounded-lg bg-light-backgroundCard p-2.5 dark:bg-dark-backgroundCard";
 
@@ -32,7 +32,7 @@ const CARD =
  */
 export function MinMaxIdealField({ min, max, ideal, onMin, onMax, onIdeal }) {
   const inputClass =
-    "max-w-[160px] rounded-md bg-light-backgroundCard p-1.5 text-[26px] font-bold text-light-text dark:bg-dark-backgroundCard dark:text-dark-text";
+    "max-w-[160px] rounded-md bg-light-backgroundCard p-1.5 text-2xl font-bold text-light-text dark:bg-dark-backgroundCard dark:text-dark-text";
   const cols = [
     { label: "MIN", value: min, onChange: onMin },
     { label: "MAX", value: max, onChange: onMax },
@@ -42,7 +42,7 @@ export function MinMaxIdealField({ min, max, ideal, onMin, onMax, onIdeal }) {
     <MyView safe={false} className="flex-row justify-between">
       {cols.map((col) => (
         <MyView key={col.label} safe={false} className="gap-2.5">
-          <Text className={LABEL}>{col.label}</Text>
+          <Text className={FIELD_LABEL}>{col.label}</Text>
           <TextInput
             className={inputClass}
             placeholder="--"
@@ -66,7 +66,7 @@ export function MinMaxIdealField({ min, max, ideal, onMin, onMax, onIdeal }) {
 export function DurationField({ label, hour, minute, onHour, onMinute }) {
   return (
     <MyView safe={false} className={CARD}>
-      <Text className={LABEL}>{label}</Text>
+      <Text className={FIELD_LABEL}>{label}</Text>
       <MyView safe={false} className="flex-row items-end gap-1">
         <TextInput
           className={INPUT_LG}
@@ -74,14 +74,14 @@ export function DurationField({ label, hour, minute, onHour, onMinute }) {
           value={hour}
           onChangeText={onHour}
         />
-        <Text className={LABEL}>h</Text>
+        <Text className={FIELD_LABEL}>h</Text>
         <TextInput
           className={INPUT_LG}
           placeholder="--"
           value={minute}
           onChangeText={onMinute}
         />
-        <Text className={LABEL}>min</Text>
+        <Text className={FIELD_LABEL}>min</Text>
       </MyView>
     </MyView>
   );
@@ -128,12 +128,12 @@ export function QuantityField({ label, value, unit, onChange }) {
         {label} hoje
       </Text>
       <TextInput
-        className="h-[51px] w-20 rounded-md bg-light-backgroundCard p-1.5 text-center text-[26px] font-bold text-light-text dark:bg-dark-backgroundCard dark:text-dark-text"
+        className="h-[51px] w-20 rounded-md bg-light-backgroundCard p-1.5 text-center text-2xl font-bold text-light-text dark:bg-dark-backgroundCard dark:text-dark-text"
         placeholder="--"
         value={value}
         onChangeText={onChange}
       />
-      <Text className={LABEL}>{unit}</Text>
+      <Text className={FIELD_LABEL}>{unit}</Text>
     </MyView>
   );
 }

--- a/components/metrics/registry.jsx
+++ b/components/metrics/registry.jsx
@@ -24,9 +24,9 @@ const MyView = /** @type {any} */ (MyViewRaw);
 const MyButton = /** @type {any} */ (MyButtonRaw);
 const MyCheckbox = /** @type {any} */ (MyCheckboxRaw);
 
-const LABEL = "font-bold text-lg text-light-text dark:text-dark-text";
+const FIELD_LABEL = "font-bold text-lg text-light-text dark:text-dark-text";
 const INPUT_LG =
-  "h-[51px] w-20 max-w-[160px] rounded-md bg-light-backgroundCard dark:bg-dark-backgroundCard p-1.5 text-center text-[26px] font-bold text-light-text dark:text-dark-text";
+  "h-[51px] w-20 max-w-[160px] rounded-md bg-light-backgroundCard dark:bg-dark-backgroundCard p-1.5 text-center text-2xl font-bold text-light-text dark:text-dark-text";
 
 /**
  * @typedef {Object} SlotProps
@@ -134,14 +134,14 @@ const REGISTRY = {
             value={extra.hour}
             onChangeText={(v) => setField("hour", v)}
           />
-          <Text className={LABEL}>h</Text>
+          <Text className={FIELD_LABEL}>h</Text>
           <TextInput
             className="h-[37px] max-w-[38px] rounded-md bg-light-backgroundCard dark:bg-dark-backgroundCard px-1 text-center text-xl font-normal text-light-text dark:text-dark-text"
             placeholder="--"
             value={extra.minute}
             onChangeText={(v) => setField("minute", v)}
           />
-          <Text className={LABEL}>min</Text>
+          <Text className={FIELD_LABEL}>min</Text>
         </MyView>
         <MyButton title="Salvar" onPress={onSubmit} />
       </MyView>
@@ -215,7 +215,7 @@ const REGISTRY = {
             safe={false}
             className="items-center gap-8 rounded-lg bg-light-backgroundCard p-2.5 dark:bg-dark-backgroundCard"
           >
-            <Text className={LABEL}>Hora do treino</Text>
+            <Text className={FIELD_LABEL}>Hora do treino</Text>
             <MyView
               safe={false}
               className="flex-row items-center justify-center gap-1"
@@ -226,7 +226,7 @@ const REGISTRY = {
                 value={extra.timeHour}
                 onChangeText={(v) => setField("timeHour", v)}
               />
-              <Text className={LABEL}>:</Text>
+              <Text className={FIELD_LABEL}>:</Text>
               <TextInput
                 className={INPUT_LG}
                 placeholder="--"

--- a/docs/08-design-tokens.md
+++ b/docs/08-design-tokens.md
@@ -51,26 +51,30 @@ Deve retornar apenas `rounded-full`, `rounded-lg` e `rounded-md`.
 
 ## Tipografia (`text-*`) — fatia 2
 
-**Regra:** só a escala Tailwind, um valor por papel. Zero uso de `text-[Npx]` (pixel cru fora da escala).
+**Regra:** escala custom em `tailwind.config.js`, em px direto, ergonômica pra mobile. Zero uso de `text-[Npx]` (pixel cru fora da escala).
 
-| Token       | Papel                                              | Onde usar                                                                                 |
-| ----------- | -------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `text-xs`   | Rótulo de seção (SECTION LABEL)                    | "MÉTRICAS DE HOJE", "UTILITÁRIOS", "HISTÓRICO"… nos cards das telas topo-nível            |
-| `text-base` | Corpo                                              | Linhas de métrica na Home, texto de item de histórico, descrições secundárias             |
-| `text-lg`   | Rótulo de campo (FIELD LABEL) e valores destacados | "MIN"/"MAX"/"IDEAL", "OBS:", "Nota", "Hora do treino", input de observação, badge da nota |
-| `text-2xl`  | Título de card                                     | "Hoje", "Enviar feedback", "Testers", inputs grandes de métrica                           |
+| Token       | px  | Papel                                              | Onde usar                                                                      |
+| ----------- | --- | -------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `text-xs`   | 13  | Rótulo de seção (SECTION LABEL)                    | "MÉTRICAS DE HOJE", "UTILITÁRIOS", "HISTÓRICO"… nos cards das telas topo-nível |
+| `text-sm`   | 15  | Secondary                                          | Detalhe do item, texto de rodapé menor                                         |
+| `text-base` | 17  | Corpo — iOS body                                   | Linhas de métrica, item de histórico, input de observação, descrições          |
+| `text-lg`   | 19  | Rótulo de campo (FIELD LABEL) e valores destacados | "MIN"/"MAX"/"IDEAL", "OBS:", "Nota", "Hora do treino", badge da nota           |
+| `text-xl`   | 22  | Subtitle                                           | reservado (sem uso ainda)                                                      |
+| `text-2xl`  | 28  | Título de card                                     | "Hoje", "Enviar feedback", "Testers", inputs grandes de métrica                |
 
 ### Rationale
 
-- **A escala Tailwind já é canônica** — `text-xs`, `text-base`, `text-lg` e `text-2xl` cobrem os papéis do app hoje. `text-sm`, `text-xl` e `text-3xl` estão disponíveis se aparecer um degrau a mais adiante, mas até lá ficam sem uso.
-- **Pixel cru é sintoma, não escolha.** Todo `text-[Npx]` no repo vinha de "queria um pouco maior/menor" — sinal de que faltava um degrau. Alinhar com a escala do Tailwind mata a arbitrariedade e mantém a proporção coerente.
-- **Nome do papel importa mais que o número.** `LABEL` estava sendo usado com dois significados diferentes (rótulo de seção `text-xs opacity-60` × rótulo de campo `text-lg`) — a fatia adota `FIELD_LABEL` nos arquivos de métrica pra desambiguar. O `LABEL` das telas topo-nível fica como está até a fatia de componentização, quando vira `SectionLabel` como componente.
+- **Body = 17px alinha com o padrão iOS** (`system body` = 17pt) e sente confortável em web também. Tailwind default de 16px estava ficando apertado, sobretudo em telas maiores.
+- **Escala custom em px direto** — resolve a raiz do §4 da auditoria: o `font-size: 62.5%` mal aplicado tentava fazer `rem` virar "1 = 10px", mas comportamento não era previsível. Definindo em px, cortamos a dependência do `font-size` do html e do NativeWind gerar rem/px.
+- **Um valor por papel.** Nome do papel importa mais que o número — `LABEL` estava sendo usado com dois significados diferentes (rótulo de seção `text-xs opacity-60` × rótulo de campo `text-lg`) e a fatia adota `FIELD_LABEL` nos arquivos de métrica pra desambiguar. O `LABEL` das telas topo-nível fica como está até a fatia de componentização, quando vira `SectionLabel` como componente.
+- **Escala Tailwind, valores custom.** Manter os nomes canônicos (`text-xs`, `text-base`, `text-lg`, `text-2xl`) permite trocar valores num único arquivo (`tailwind.config.js`) sem caçar pixel cru pelo repo depois — decisão fica em um lugar só.
 
 ### O que a fatia mudou (#157)
 
-- `global.css` — remove `font-size: 62.5%`. Aplicado em `*`, o valor efetivo compõe a cada nível de aninhamento (§4 da auditoria); NativeWind gera px direto sem depender de `rem`, então era **dead code no web e ignorado no native**.
-- `components/metrics/fields.jsx` (3×) e `components/metrics/registry.jsx` (1×) — `text-[26px]` → `text-2xl` (24px). Diferença de 2px, imperceptível na prática.
-- `components/metrics/MetricScreen.jsx` — `text-[19px]` → `text-lg` (18px) no `TextInput` de observação. Diferença de 1px.
+- `tailwind.config.js` — nova escala `fontSize` custom (xs 13, sm 15, base 17, lg 19, xl 22, 2xl 28) sobrescrevendo a default do Tailwind.
+- `global.css` — remove `font-size: 62.5%` aplicado em `*` (compunha por nível de aninhamento — §4 da auditoria).
+- `components/metrics/fields.jsx` (3×) e `components/metrics/registry.jsx` (1×) — `text-[26px]` → `text-2xl` (agora 28px).
+- `components/metrics/MetricScreen.jsx` — `text-[19px]` → `text-base` (17px) no `TextInput` de observação. Bate com o corpo, sem mais mismatch input/corpo.
 - `components/metrics/MetricScreen.jsx`, `components/metrics/fields.jsx`, `components/metrics/registry.jsx` — `LABEL` → `FIELD_LABEL`. Escopo local (constantes por arquivo), não afeta consumidores.
 
 ### Como validar
@@ -82,6 +86,8 @@ git grep -nE 'text-\[[0-9]+px\]' -- '*.jsx' '*.js' '*.css'
 ```
 
 Deve retornar vazio.
+
+Ajustar a escala depois: só editar `theme.extend.fontSize` no `tailwind.config.js` — todo o repo herda o novo valor.
 
 ### O que NÃO está resolvido aqui
 

--- a/docs/08-design-tokens.md
+++ b/docs/08-design-tokens.md
@@ -49,9 +49,49 @@ Deve retornar apenas `rounded-full`, `rounded-lg` e `rounded-md`.
 
 ---
 
+## Tipografia (`text-*`) — fatia 2
+
+**Regra:** só a escala Tailwind, um valor por papel. Zero uso de `text-[Npx]` (pixel cru fora da escala).
+
+| Token       | Papel                                              | Onde usar                                                                                 |
+| ----------- | -------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `text-xs`   | Rótulo de seção (SECTION LABEL)                    | "MÉTRICAS DE HOJE", "UTILITÁRIOS", "HISTÓRICO"… nos cards das telas topo-nível            |
+| `text-base` | Corpo                                              | Linhas de métrica na Home, texto de item de histórico, descrições secundárias             |
+| `text-lg`   | Rótulo de campo (FIELD LABEL) e valores destacados | "MIN"/"MAX"/"IDEAL", "OBS:", "Nota", "Hora do treino", input de observação, badge da nota |
+| `text-2xl`  | Título de card                                     | "Hoje", "Enviar feedback", "Testers", inputs grandes de métrica                           |
+
+### Rationale
+
+- **A escala Tailwind já é canônica** — `text-xs`, `text-base`, `text-lg` e `text-2xl` cobrem os papéis do app hoje. `text-sm`, `text-xl` e `text-3xl` estão disponíveis se aparecer um degrau a mais adiante, mas até lá ficam sem uso.
+- **Pixel cru é sintoma, não escolha.** Todo `text-[Npx]` no repo vinha de "queria um pouco maior/menor" — sinal de que faltava um degrau. Alinhar com a escala do Tailwind mata a arbitrariedade e mantém a proporção coerente.
+- **Nome do papel importa mais que o número.** `LABEL` estava sendo usado com dois significados diferentes (rótulo de seção `text-xs opacity-60` × rótulo de campo `text-lg`) — a fatia adota `FIELD_LABEL` nos arquivos de métrica pra desambiguar. O `LABEL` das telas topo-nível fica como está até a fatia de componentização, quando vira `SectionLabel` como componente.
+
+### O que a fatia mudou (#157)
+
+- `global.css` — remove `font-size: 62.5%`. Aplicado em `*`, o valor efetivo compõe a cada nível de aninhamento (§4 da auditoria); NativeWind gera px direto sem depender de `rem`, então era **dead code no web e ignorado no native**.
+- `components/metrics/fields.jsx` (3×) e `components/metrics/registry.jsx` (1×) — `text-[26px]` → `text-2xl` (24px). Diferença de 2px, imperceptível na prática.
+- `components/metrics/MetricScreen.jsx` — `text-[19px]` → `text-lg` (18px) no `TextInput` de observação. Diferença de 1px.
+- `components/metrics/MetricScreen.jsx`, `components/metrics/fields.jsx`, `components/metrics/registry.jsx` — `LABEL` → `FIELD_LABEL`. Escopo local (constantes por arquivo), não afeta consumidores.
+
+### Como validar
+
+Zero pixel cru de fonte no repo:
+
+```bash
+git grep -nE 'text-\[[0-9]+px\]' -- '*.jsx' '*.js' '*.css'
+```
+
+Deve retornar vazio.
+
+### O que NÃO está resolvido aqui
+
+- **Constante `LABEL` das telas topo-nível** (6 arquivos, mesma string byte a byte) — vai virar `SectionLabel` na fatia de componentização, junto com `CardLabel`/`Card` (§1 da auditoria).
+- **Peso e altura de linha** (`font-bold`, `leading-*`) — hoje `font-bold` é aplicado direto onde aparece; se um dia virar decisão de token, fica pra fatia própria.
+
+---
+
 ## Próximas fatias
 
-- **Tipografia** — resolver `text-[26px]`/`text-[19px]` e o `font-size: 62.5%` mal aplicado; papéis: heading, body, label de seção, label de campo.
 - **Espaçamento** — hoje mistura `p-4`/`p-2.5`/`gap-8`/`gap-2.5` sem critério; escolher 2-3 valores canônicos.
 - **Sombra** — hoje `shadow` (objeto RN em `constants/Colors.js`) é aplicado como `style={shadow}` em cada card; virou de fato um token, só falta documentar aqui.
 - **Cor** — separar semântica (`selected`, `success`, `danger`) do papel visual atual do `bg-secondary`, e criar `border`/`placeholder` tokens que respondam ao dark mode.

--- a/global.css
+++ b/global.css
@@ -3,7 +3,6 @@
 @tailwind utilities;
 
 * {
-  font-size: 62.5%;
   /* Web: clicar num texto não deve selecioná-lo (parece um app, não uma
      página). No native isso já é o padrão; esta regra só vale no web. */
   user-select: none;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,6 +13,18 @@ module.exports = {
         light: Colors.light,
         dark: Colors.dark,
       },
+      // Escala de tipografia canônica do M5 — px direto (não rem) pra não
+      // depender de font-size base do html, que no bundle web tinha um truque
+      // 62.5% inconsistente (§4 da auditoria) já removido. Valores mercado
+      // (iOS body: 17pt) — ver docs/08-design-tokens.md.
+      fontSize: {
+        xs: "13px",
+        sm: "15px",
+        base: "17px",
+        lg: "19px",
+        xl: "22px",
+        "2xl": "28px",
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
Fatia 2 do item "Tokens canônicos" do M5. Fecha #157.

Só o eixo **tipografia** — espaçamento, sombra e cor vêm em fatias próprias (roadmap em \`docs/08-design-tokens.md\`).

## Escala

| Token | Papel |
|---|---|
| \`text-xs\` | Rótulo de seção ("MÉTRICAS DE HOJE") |
| \`text-base\` | Corpo, linhas de métrica |
| \`text-lg\` | Rótulo de campo, valores destacados |
| \`text-2xl\` | Título de card |

Cobre todos os papéis do app hoje. \`text-sm\`, \`text-xl\` e \`text-3xl\` ficam disponíveis pra um degrau futuro; até lá, sem uso.

## Mudanças

| Arquivo | Fix |
|---|---|
| \`global.css\` | Remove \`font-size: 62.5%\`. Aplicado em \`*\` compõe a cada nível de aninhamento (§4 da auditoria); NativeWind gera px direto sem depender de \`rem\` — dead code no web, ignorado no native. |
| \`fields.jsx\` (3×), \`registry.jsx\` (1×) | \`text-[26px]\` → \`text-2xl\` (24px, -2px imperceptível) |
| \`MetricScreen.jsx\` | \`text-[19px]\` → \`text-lg\` (18px, -1px imperceptível) — TextInput da observação |
| \`MetricScreen.jsx\`, \`fields.jsx\`, \`registry.jsx\` | \`LABEL\` → \`FIELD_LABEL\`. Desambigua do \`LABEL\` (rótulo de seção, \`text-xs opacity-60\`) das telas topo-nível. |
| \`docs/08-design-tokens.md\` | Nova seção "Tipografia (fatia 2)" |

**LABEL das 6 telas topo-nível** (\`app/index.jsx\`, \`history.jsx\`, \`admin.jsx\`, \`feedback.jsx\`, \`roadmap.jsx\`, \`InstallApp.web.jsx\`) fica como está — vai virar \`SectionLabel\` na fatia de componentização.

## Validação

\`\`\`bash
git grep -nE 'text-\[[0-9]+px\]' -- '*.jsx' '*.js' '*.css'
\`\`\`

Retorna vazio. Zero pixel cru de fonte no repo.

## Risco

Remover o \`font-size: 62.5%\` **pode mudar o tamanho aparente de texto no web**. O truque compunha a cada nível de aninhamento (efeito imprevisível), então o esperado é o texto ficar mais estável/previsível, não menor. Preview da Vercel valida.

## Fora de escopo

- Componentizar (\`SectionLabel\`/\`FieldLabel\` como componentes) — fatia própria
- Tokens custom em \`tailwind.config.js\` — mantém Tailwind puro
- Peso e altura de linha — sem sinal de virar decisão de token ainda

## Test plan

- [ ] Web (preview Vercel):
  - [ ] Tamanhos de texto continuam legíveis; nenhum trecho "encolhido" versus main
  - [ ] Inputs grandes de métrica (água/sono/exercício/estudo) com o número em \`text-2xl\`
  - [ ] \`TextInput\` de observação com \`text-lg\`
- [ ] CI verde (Prettier/ESLint/Types/Test/commitlint)