### PR TITLE
refactor(ui): espaçamento canônico no grid 4px

### DIFF
--- a/app/feedback.jsx
+++ b/app/feedback.jsx
@@ -119,7 +119,7 @@ export default function Feedback() {
 
             <MyView safe={false} className={`${CARD} gap-4`} style={shadow}>
               {/* Categoria (opcional) */}
-              <MyView safe={false} className="gap-1.5">
+              <MyView safe={false} className="gap-2">
                 <Text className={LABEL}>CATEGORIA (OPCIONAL)</Text>
                 <View className="flex-row flex-wrap gap-2">
                   {CATEGORIES.map((c) => (

--- a/app/history.jsx
+++ b/app/history.jsx
@@ -119,7 +119,7 @@ export default function History() {
               <MyView
                 key={type}
                 safe={false}
-                className="w-full items-center gap-2.5"
+                className="w-full items-center gap-3"
               >
                 {day[type].map((obj) => (
                   <HistoryCard

--- a/components/MyCheckbox.jsx
+++ b/components/MyCheckbox.jsx
@@ -7,7 +7,7 @@ import { Text } from "react-native";
 
 export default function MyCheckbox({ label, onValueChange, value }) {
   return (
-    <MyView safe={false} className="flex-row items-center gap-1.5">
+    <MyView safe={false} className="flex-row items-center gap-2">
       <Checkbox
         color={value ? Colors.primary : "gray"}
         value={value}

--- a/components/MyHistory.jsx
+++ b/components/MyHistory.jsx
@@ -69,7 +69,7 @@ export function HistoryCard({
   return (
     <MyView
       safe={false}
-      className="w-full max-w-[640px] gap-2.5 rounded-lg bg-light-backgroundCard p-2.5 dark:bg-dark-backgroundCard"
+      className="w-full max-w-[640px] gap-3 rounded-lg bg-light-backgroundCard p-3 dark:bg-dark-backgroundCard"
       style={[cardStyle, shadow]}
     >
       <View className="w-full flex-row items-center justify-between">
@@ -89,13 +89,13 @@ export function HistoryCard({
 
       {exercise && (
         <MyView safe={false} className="flex-row gap-4">
-          <MyView safe={false} className="flex-row items-center gap-1.5">
+          <MyView safe={false} className="flex-row items-center gap-2">
             <Checkbox color={Colors.primary} value={!!obj.training} />
             <Text className="font-bold text-lg text-light-text dark:text-dark-text">
               Treino
             </Text>
           </MyView>
-          <MyView safe={false} className="flex-row items-center gap-1.5">
+          <MyView safe={false} className="flex-row items-center gap-2">
             <Checkbox color={Colors.primary} value={!!obj.cardio} />
             <Text className="font-bold text-lg text-light-text dark:text-dark-text">
               Cardio
@@ -135,7 +135,7 @@ function HistoryList({
   onChanged,
 }) {
   return (
-    <MyView safe={false} className="w-full items-center gap-2.5">
+    <MyView safe={false} className="w-full items-center gap-3">
       {Object.values(data).map((obj) => (
         <HistoryCard
           key={obj.id}

--- a/components/MyInput.jsx
+++ b/components/MyInput.jsx
@@ -15,7 +15,7 @@ export default function MyInput({
   ...props
 }) {
   return (
-    <MyView safe={false} className={`gap-1.5 ${containerClassName}`}>
+    <MyView safe={false} className={`gap-2 ${containerClassName}`}>
       {label != null && (
         <Text className="font-bold text-base text-light-text dark:text-dark-text">
           {label}

--- a/components/Score.jsx
+++ b/components/Score.jsx
@@ -9,7 +9,7 @@ export default function Score({ onPress, value, ...props }) {
   return (
     <MyView
       safe={false}
-      className="flex-row flex-wrap items-center justify-start gap-2.5 p-1.5"
+      className="flex-row flex-wrap items-center justify-start gap-3 p-2"
     >
       {Array.from({ length: scoreRange + 1 }).map((_, index) => (
         <MyButton

--- a/components/metrics/MetricScreen.jsx
+++ b/components/metrics/MetricScreen.jsx
@@ -97,7 +97,7 @@ export default function MetricScreen({ metric, recordId }) {
       >
         <MyView
           safe={false}
-          className={`max-w-[640px] gap-8 rounded-lg bg-light-backgroundCard p-2.5 dark:bg-dark-backgroundCard ${config.cardClass ?? ""}`}
+          className={`max-w-[640px] gap-8 rounded-lg bg-light-backgroundCard p-3 dark:bg-dark-backgroundCard ${config.cardClass ?? ""}`}
         >
           <Text className={FIELD_LABEL}>
             {date.displayDate} {displayName}
@@ -113,7 +113,7 @@ export default function MetricScreen({ metric, recordId }) {
             <TextInput
               value={observation}
               onChangeText={setObservation}
-              className="h-16 rounded-lg bg-light-backgroundCard p-1.5 text-base font-normal text-light-text dark:bg-dark-backgroundCard dark:text-dark-text"
+              className="h-16 rounded-lg bg-light-backgroundCard p-2 text-base font-normal text-light-text dark:bg-dark-backgroundCard dark:text-dark-text"
               placeholder={config.obsPlaceholder}
             />
           </MyView>

--- a/components/metrics/fields.jsx
+++ b/components/metrics/fields.jsx
@@ -16,9 +16,9 @@ const MyIconButton = /** @type {any} */ (MyIconButtonRaw);
 
 const FIELD_LABEL = "font-bold text-lg text-light-text dark:text-dark-text";
 const INPUT_LG =
-  "h-[51px] w-20 max-w-[160px] rounded-md bg-light-backgroundCard dark:bg-dark-backgroundCard p-1.5 text-center text-2xl font-bold text-light-text dark:text-dark-text";
+  "h-[51px] w-20 max-w-[160px] rounded-md bg-light-backgroundCard dark:bg-dark-backgroundCard p-2 text-center text-2xl font-bold text-light-text dark:text-dark-text";
 const CARD =
-  "items-center gap-8 rounded-lg bg-light-backgroundCard p-2.5 dark:bg-dark-backgroundCard";
+  "items-center gap-8 rounded-lg bg-light-backgroundCard p-3 dark:bg-dark-backgroundCard";
 
 /**
  * Bloco MIN / MAX / IDEAL (água, sono). Os três campos são editáveis — isso
@@ -32,7 +32,7 @@ const CARD =
  */
 export function MinMaxIdealField({ min, max, ideal, onMin, onMax, onIdeal }) {
   const inputClass =
-    "max-w-[160px] rounded-md bg-light-backgroundCard p-1.5 text-2xl font-bold text-light-text dark:bg-dark-backgroundCard dark:text-dark-text";
+    "max-w-[160px] rounded-md bg-light-backgroundCard p-2 text-2xl font-bold text-light-text dark:bg-dark-backgroundCard dark:text-dark-text";
   const cols = [
     { label: "MIN", value: min, onChange: onMin },
     { label: "MAX", value: max, onChange: onMax },
@@ -41,7 +41,7 @@ export function MinMaxIdealField({ min, max, ideal, onMin, onMax, onIdeal }) {
   return (
     <MyView safe={false} className="flex-row justify-between">
       {cols.map((col) => (
-        <MyView key={col.label} safe={false} className="gap-2.5">
+        <MyView key={col.label} safe={false} className="gap-3">
           <Text className={FIELD_LABEL}>{col.label}</Text>
           <TextInput
             className={inputClass}
@@ -95,7 +95,7 @@ export function DurationField({ label, hour, minute, onHour, onMinute }) {
 export function CounterField({ count, onAdd, onRemove }) {
   return (
     <MyView safe={false} className="gap-4">
-      <MyView safe={false} className="flex-row gap-5">
+      <MyView safe={false} className="flex-row gap-4">
         {Array.from({ length: count }).map((_, index) => (
           <MyIconButton
             key={index}
@@ -122,13 +122,13 @@ export function QuantityField({ label, value, unit, onChange }) {
   return (
     <MyView
       safe={false}
-      className="w-1/2 grow flex-row items-center justify-center gap-8 rounded-lg bg-light-backgroundCard p-2.5 dark:bg-dark-backgroundCard"
+      className="w-1/2 grow flex-row items-center justify-center gap-8 rounded-lg bg-light-backgroundCard p-3 dark:bg-dark-backgroundCard"
     >
       <Text className="font-bold text-2xl text-light-text dark:text-dark-text">
         {label} hoje
       </Text>
       <TextInput
-        className="h-[51px] w-20 rounded-md bg-light-backgroundCard p-1.5 text-center text-2xl font-bold text-light-text dark:bg-dark-backgroundCard dark:text-dark-text"
+        className="h-[51px] w-20 rounded-md bg-light-backgroundCard p-2 text-center text-2xl font-bold text-light-text dark:bg-dark-backgroundCard dark:text-dark-text"
         placeholder="--"
         value={value}
         onChangeText={onChange}

--- a/components/metrics/registry.jsx
+++ b/components/metrics/registry.jsx
@@ -26,7 +26,7 @@ const MyCheckbox = /** @type {any} */ (MyCheckboxRaw);
 
 const FIELD_LABEL = "font-bold text-lg text-light-text dark:text-dark-text";
 const INPUT_LG =
-  "h-[51px] w-20 max-w-[160px] rounded-md bg-light-backgroundCard dark:bg-dark-backgroundCard p-1.5 text-center text-2xl font-bold text-light-text dark:text-dark-text";
+  "h-[51px] w-20 max-w-[160px] rounded-md bg-light-backgroundCard dark:bg-dark-backgroundCard p-2 text-center text-2xl font-bold text-light-text dark:text-dark-text";
 
 /**
  * @typedef {Object} SlotProps
@@ -123,7 +123,7 @@ const REGISTRY = {
       >
         <MyView
           safe={false}
-          className="w-full grow flex-row items-center justify-center gap-4 rounded-lg bg-light-backgroundCard p-2.5 dark:bg-dark-backgroundCard"
+          className="w-full grow flex-row items-center justify-center gap-4 rounded-lg bg-light-backgroundCard p-3 dark:bg-dark-backgroundCard"
         >
           <Text className="font-bold text-2xl text-light-text dark:text-dark-text">
             {displayName} hoje
@@ -213,7 +213,7 @@ const REGISTRY = {
         <MyView safe={false} className="flex-row flex-wrap items-center gap-4">
           <MyView
             safe={false}
-            className="items-center gap-8 rounded-lg bg-light-backgroundCard p-2.5 dark:bg-dark-backgroundCard"
+            className="items-center gap-8 rounded-lg bg-light-backgroundCard p-3 dark:bg-dark-backgroundCard"
           >
             <Text className={FIELD_LABEL}>Hora do treino</Text>
             <MyView

--- a/docs/08-design-tokens.md
+++ b/docs/08-design-tokens.md
@@ -96,8 +96,59 @@ Ajustar a escala depois: só editar `theme.extend.fontSize` no `tailwind.config.
 
 ---
 
+## Espaçamento (`gap-*` / `p-*`) — fatia 3
+
+**Regra:** escala default do Tailwind (grid de 4px), zero fracionários. Um valor por papel.
+
+| Token | px  | Papel                                                                 |
+| ----- | --- | --------------------------------------------------------------------- |
+| `-1`  | 4   | tight — só quando `-2` sente exagerado (raro)                         |
+| `-2`  | 8   | dense — itens adjacentes numa linha (checkbox + label, ícone + texto) |
+| `-3`  | 12  | medium — cards compactos, gap entre itens numa lista                  |
+| `-4`  | 16  | comfortable — padding padrão de card, gap entre linhas de seção       |
+| `-6`  | 24  | spacious — reservado; sem uso hoje, disponível se aparecer o degrau   |
+| `-8`  | 32  | big — separação vertical entre seções grandes de form                 |
+
+Serve pra `gap-*` (entre filhos) e `p-*` (dentro do container). `gap-*` e `p-*` **usam a mesma escala** — se dois cards vizinhos estão com padding `p-3` e o espaço entre eles é `gap-3`, o ritmo visual fecha.
+
+### Rationale
+
+- **Grid de 4px é padrão de mercado** (iOS 8pt/4pt subgrid, Material 4dp/8dp). Todo múltiplo de 4 fica alinhado a qualquer coisa que a plataforma render em cima; múltiplos de 2 (`gap-1.5`, `gap-2.5`) quebram esse alinhamento sem ganhar nada.
+- **Escala do Tailwind default já é o grid** — `-1`/`-2`/`-3`/`-4`/`-6`/`-8` mapeiam pra 4/8/12/16/24/32px. Não vale customizar em `tailwind.config.js` como fizemos com tipografia; aqui a default já é a decisão.
+- **Um valor por papel.** A auditoria pegou `p-4`/`p-2.5`/`gap-8`/`gap-2.5` misturados sem critério — a diferença entre `p-3` (12px) e `p-2.5` (10px) não é uma decisão de design, é um pixel arbitrário.
+
+### O que a fatia mudou (#160)
+
+Substituições em ~10 arquivos (`app/*.jsx`, `components/*.jsx`, `components/metrics/*.jsx`):
+
+- `gap-1.5` → `gap-2` (6×)
+- `gap-2.5` → `gap-3` (5×)
+- `gap-5` → `gap-4` (1×, CounterField — único off-grid)
+- `p-1.5` → `p-2` (5×)
+- `p-2.5` → `p-3` (6×)
+
+Efeito visual: +2px na maioria dos casos (imperceptível), -4px no CounterField.
+
+Nada muda no `tailwind.config.js` — a decisão é usar a escala default como-é. O `px-*`/`py-*` assimétrico de botões e inputs (`px-2 py-1`, `px-4 py-2`) fica como está — a assimetria horizontal/vertical é intencional pra esse tipo de controle.
+
+### Como validar
+
+Zero valor off-grid no repo:
+
+```bash
+git grep -nE '\b(gap|p|px|py|pt|pb|pl|pr)-(1\.5|2\.5|5|7|9|10)\b' -- '*.jsx' '*.js'
+```
+
+Deve retornar vazio.
+
+### O que NÃO está resolvido aqui
+
+- **`px-*`/`py-*` de botões/inputs** — hoje `MyButton` usa `px-4 py-2`, `MyInput` usa `px-2 py-1`. São decisões de forma do controle, não de layout — ficam pra fatia de componentização, quando componentes ganharem forma canônica.
+- **Marginação por classe** (`mx-`, `my-`, `mt-`, `mb-`) — o repo mal usa margin (o layout é quase todo `gap-*` em flex). Se aparecer, cai na mesma escala.
+
+---
+
 ## Próximas fatias
 
-- **Espaçamento** — hoje mistura `p-4`/`p-2.5`/`gap-8`/`gap-2.5` sem critério; escolher 2-3 valores canônicos.
 - **Sombra** — hoje `shadow` (objeto RN em `constants/Colors.js`) é aplicado como `style={shadow}` em cada card; virou de fato um token, só falta documentar aqui.
 - **Cor** — separar semântica (`selected`, `success`, `danger`) do papel visual atual do `bg-secondary`, e criar `border`/`placeholder` tokens que respondam ao dark mode.


### PR DESCRIPTION
Fatia 3 do item \"Tokens canônicos\" do M5. Fecha #160.

Só o eixo **espaçamento** — sombra e cor vêm em fatias próprias.

## Escala

Grid de 4px do Tailwind default, sem custom em \`tailwind.config.js\`.

| Token | px | Papel |
|---|---|---|
| \`-1\` | 4 | tight (raro) |
| \`-2\` | 8 | dense — itens adjacentes numa linha |
| \`-3\` | 12 | medium — cards compactos, gap entre itens |
| \`-4\` | 16 | comfortable — padding padrão de card |
| \`-6\` | 24 | spacious (reservado) |
| \`-8\` | 32 | big — separação entre seções de form |

Mesma escala pra \`gap-*\` e \`p-*\` — ritmo visual fecha entre padding do container e gap entre filhos.

## Mudanças (23 substituições, 9 arquivos)

| De → Para | # |
|---|---|
| \`gap-1.5\` → \`gap-2\` | 6× |
| \`gap-2.5\` → \`gap-3\` | 5× |
| \`gap-5\` → \`gap-4\` | 1× (CounterField, único off-grid) |
| \`p-1.5\` → \`p-2\` | 5× |
| \`p-2.5\` → \`p-3\` | 6× |

**Arquivos:** \`app/{feedback,history}.jsx\`, \`components/{MyCheckbox,MyHistory,MyInput,Score}.jsx\`, \`components/metrics/{MetricScreen,fields,registry}.jsx\`, \`docs/08-design-tokens.md\`.

Efeito visual: +2px na maioria (imperceptível), -4px no CounterField.

## Validação

\`\`\`bash
git grep -nE '\b(gap|p|px|py|pt|pb|pl|pr)-(1\.5|2\.5|5|7|9|10)\b' -- '*.jsx' '*.js'
\`\`\`

Retorna vazio. Distribuição atual: \`gap\` em 1/2/3/4/8, \`p\` em 2/3/4 — todos no grid 4px.

## Fora de escopo

- \`px-2 py-1\`, \`px-4 py-2\` de botões/inputs — assimetria intencional, fica pra fatia de componentização
- \`tailwind.config.js\` — não muda (escala default já é canônica pra espaçamento; ao contrário de tipografia, aqui não vale customizar)

## Test plan

- [ ] Web (preview Vercel):
  - [ ] Cards do topo das telas (Home, Histórico, Feedback, Admin, Roadmap) — respiração natural, sem mudança brusca
  - [ ] \`HistoryCard\` — internos com gap-3, padding p-3
  - [ ] Tela de métrica — inputs grandes com p-2, cards internos com p-3
  - [ ] Checkbox+label (exercise Treino/Cardio) — gap-2 confortável
- [ ] CI verde (Prettier/ESLint/Types/Test/commitlint)