### PR TITLE
refactor(ui): sombra canônica + fix no MetricScreen

### DIFF
--- a/components/metrics/MetricScreen.jsx
+++ b/components/metrics/MetricScreen.jsx
@@ -16,6 +16,7 @@ import MyHeaderRaw from "@/components/MyHeader";
 
 import { getCategoryInfo } from "@/components/categoryUtils";
 import getDate from "@/constants/getDate";
+import { shadow } from "@/constants/Colors";
 import { add, getById, update } from "@/infra/database";
 import { getMetricConfig } from "./registry";
 
@@ -98,6 +99,7 @@ export default function MetricScreen({ metric, recordId }) {
         <MyView
           safe={false}
           className={`max-w-[640px] gap-8 rounded-lg bg-light-backgroundCard p-3 dark:bg-dark-backgroundCard ${config.cardClass ?? ""}`}
+          style={shadow}
         >
           <Text className={FIELD_LABEL}>
             {date.displayDate} {displayName}

--- a/docs/08-design-tokens.md
+++ b/docs/08-design-tokens.md
@@ -148,7 +148,49 @@ Deve retornar vazio.
 
 ---
 
+## Sombra (`shadow`) — fatia 4
+
+**Regra:** um único nível de elevação, aplicado por `style`. Não há hierarquia de sombra hoje.
+
+| Token                                         | Definição                                                                                               | Papel                                        |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| `shadow` (objeto RN em `constants/Colors.js`) | `elevation: 4`, `shadowColor: "#000"`, `shadowOffset: {0, 4}`, `shadowOpacity: 0.25`, `shadowRadius: 4` | Elevação padrão: top-level cards e controles |
+
+Uso: `style={shadow}` ou `style={[shadow, otherStyle]}`.
+
+### Regras de aplicação
+
+1. **Top-level card** (direto no `ScrollView`, topo do conteúdo da tela) → aplica `shadow`.
+2. **Nested card** (dentro de outro card, tipo `DurationField` dentro do form) → **sem** shadow. Evita dupla elevação.
+3. **Controle** (`MyButton`, `MyIconButton`) → shadow embutido no componente — quem usa não precisa lembrar.
+
+### Rationale
+
+- **Um nível é o mínimo útil hoje.** O app não tem modal, dropdown, popover ou drawer flutuante — o único plano acima do fundo é "card + botão". Adicionar níveis (ex: `shadow-sm`, `shadow-lg`) só ganha valor quando houver hierarquia visual pedindo.
+- **Objeto RN, não Tailwind class.** `shadow-*` do Tailwind gera `box-shadow` CSS — no web funciona, no native o NativeWind traduz mas com semântica diferente (elevation Android vs shadowX iOS). Manter em objeto RN é explícito e portável entre plataformas.
+- **`style={shadow}` como pattern.** Consistente com `Snackbar`/inputs que já usam `style` inline pra props RN puras.
+
+### O que a fatia mudou (#163)
+
+- `components/metrics/MetricScreen.jsx` — adiciona `import { shadow }` e aplica `style={shadow}` no card top-level do form. Alinha com as 6 telas topo-nível que já tinham (index, history, admin, feedback, roadmap, InstallApp.web). Miss de quando `MetricScreen` foi montado (M2, #80).
+
+### Como validar
+
+Todos os cards top-level do repo têm `style={shadow}`:
+
+```bash
+git grep -B1 -A2 '${CARD}\|max-w-\[640px\].*rounded-lg' -- '*.jsx'
+```
+
+Deve mostrar `style={shadow}` acompanhando cada card top-level (com exceção dos cards nested como `DurationField` — regra 2).
+
+### O que NÃO está resolvido aqui
+
+- **Migrar pra `tailwind.config.js` `boxShadow`** — requer validar NativeWind renderizando igual em native (elevation/shadowX). Fora de escopo; hoje o objeto RN é a fonte da verdade.
+- **Segundo nível de elevação** (`shadow-lg` pra modal, `shadow-sm` pra chip) — só faz sentido quando o app ganhar esses componentes; fatia própria.
+
+---
+
 ## Próximas fatias
 
-- **Sombra** — hoje `shadow` (objeto RN em `constants/Colors.js`) é aplicado como `style={shadow}` em cada card; virou de fato um token, só falta documentar aqui.
 - **Cor** — separar semântica (`selected`, `success`, `danger`) do papel visual atual do `bg-secondary`, e criar `border`/`placeholder` tokens que respondam ao dark mode.


### PR DESCRIPTION
Fatia 4 do item \"Tokens canônicos\" do M5. Fecha #163.

Só o eixo **sombra** — cor é a próxima e última fatia dos tokens.

## Token

| Token | Definição | Papel |
|---|---|---|
| \`shadow\` (objeto RN em \`constants/Colors.js\`) | elevation 4, offset y=4, opacity 0.25, radius 4 | Elevação padrão |

Um nível só. Regras:
1. **Top-level card** → \`style={shadow}\`
2. **Nested card** → SEM shadow (evita dupla elevação)
3. **Controle** (\`MyButton\`) → shadow embutido no componente

## Mudanças

- \`components/metrics/MetricScreen.jsx\` — adiciona \`import { shadow }\` e \`style={shadow}\` no card top-level do form. Alinha com as 6 telas topo-nível que já têm (index, history, admin, feedback, roadmap, InstallApp.web). Oversight de quando \`MetricScreen\` foi montado no M2 (#80).
- \`docs/08-design-tokens.md\` — nova seção \"Sombra\" com regras, rationale e mapeamento.

## Fora de escopo

- Migrar pra \`tailwind.config.js\` \`boxShadow\` ou pra className \`shadow-*\` — requer validar NativeWind renderizando igual em native (elevation Android vs shadowX iOS); mudança maior sem ganho claro
- Segundo nível de elevação — sem modal/dropdown/popover pedindo

## Test plan

- [ ] Web (preview Vercel): tela de métrica (água, sono, exercício, etc.) — card do form com sombra igual aos cards da Home/Histórico
- [ ] CI verde