### PR TITLE
refactor(ui): extrai Card, SectionLabel e FieldLabel

### DIFF
--- a/app/admin.jsx
+++ b/app/admin.jsx
@@ -13,16 +13,12 @@ import MyView from "@/components/MyView";
 import MyHeader from "@/components/MyHeader";
 import MyButton from "@/components/MyButton";
 import MyInput from "@/components/MyInput";
+import Card from "@/components/Card";
+import SectionLabel from "@/components/SectionLabel";
 
-import { shadow } from "@/constants/Colors";
 import { confirmAction, notify } from "@/constants/dialogs";
 import { getTesters, addTester, removeTester, store } from "@/infra/database";
 //#endregion
-
-const CARD =
-  "w-full max-w-[640px] rounded-lg bg-light-backgroundCard p-4 dark:bg-dark-backgroundCard";
-const LABEL =
-  "font-bold text-xs text-light-text opacity-60 dark:text-dark-text";
 
 export default function Admin() {
   const [name, setName] = useState("");
@@ -93,7 +89,7 @@ export default function Admin() {
         keyboardShouldPersistTaps="handled"
       >
         {/* Adicionar tester */}
-        <MyView safe={false} className={`${CARD} gap-4`} style={shadow}>
+        <Card className="gap-4">
           <Text className="font-bold text-2xl text-light-text dark:text-dark-text">
             Testers
           </Text>
@@ -121,11 +117,11 @@ export default function Admin() {
             disabled={!canAdd}
             className={canAdd ? "" : "opacity-50"}
           />
-        </MyView>
+        </Card>
 
         {/* Lista */}
-        <MyView safe={false} className={`${CARD} gap-3`} style={shadow}>
-          <Text className={LABEL}>NA LISTA ({testers.length})</Text>
+        <Card className="gap-3">
+          <SectionLabel>NA LISTA ({testers.length})</SectionLabel>
           {testers.length === 0 ? (
             <Text className="text-base text-light-text opacity-60 dark:text-dark-text">
               Nenhum tester ainda.
@@ -151,16 +147,16 @@ export default function Admin() {
               ))}
             </MyView>
           )}
-        </MyView>
+        </Card>
 
         {/* Exportar */}
-        <MyView safe={false} className={`${CARD} gap-2`} style={shadow}>
-          <Text className={LABEL}>SENDER</Text>
+        <Card className="gap-2">
+          <SectionLabel>SENDER</SectionLabel>
           <Text className="text-sm text-light-text opacity-70 dark:text-dark-text">
             Exporta a lista em JSON pra colar em `scripts/testers.json`.
           </Text>
           <MyButton title="Exportar lista" onPress={handleExport} />
-        </MyView>
+        </Card>
       </ScrollView>
     </MyView>
   );

--- a/app/feedback.jsx
+++ b/app/feedback.jsx
@@ -8,16 +8,13 @@ import MyView from "@/components/MyView";
 import MyHeader from "@/components/MyHeader";
 import MyButton from "@/components/MyButton";
 import MyInput from "@/components/MyInput";
+import Card from "@/components/Card";
+import SectionLabel from "@/components/SectionLabel";
 
-import { shadow } from "@/constants/Colors";
 import { FEEDBACK_ENDPOINT, FEEDBACK_KEY } from "@/constants/feedback";
 import { getEnvironmentInfo } from "@/constants/environment";
 //#endregion
 
-const CARD =
-  "w-full max-w-[640px] rounded-lg bg-light-backgroundCard p-4 dark:bg-dark-backgroundCard";
-const LABEL =
-  "font-bold text-xs text-light-text opacity-60 dark:text-dark-text";
 const INPUT = "w-full";
 
 const CATEGORIES = ["Bug", "Sugestão", "Outro"];
@@ -85,7 +82,7 @@ export default function Feedback() {
         keyboardShouldPersistTaps="handled"
       >
         {status === "ok" ? (
-          <MyView safe={false} className={`${CARD} gap-3`} style={shadow}>
+          <Card className="gap-3">
             <Text className="font-bold text-2xl text-light-text dark:text-dark-text">
               Recebido! 🙌
             </Text>
@@ -104,10 +101,10 @@ export default function Feedback() {
               title="Voltar ao início"
               onPress={() => router.navigate("/")}
             />
-          </MyView>
+          </Card>
         ) : (
           <>
-            <MyView safe={false} className={`${CARD} gap-1`} style={shadow}>
+            <Card className="gap-1">
               <Text className="font-bold text-2xl text-light-text dark:text-dark-text">
                 Enviar feedback
               </Text>
@@ -115,12 +112,12 @@ export default function Feedback() {
                 Achou um problema ou tem uma sugestão? Conta aqui — abrimos o
                 chamado pra você automaticamente.
               </Text>
-            </MyView>
+            </Card>
 
-            <MyView safe={false} className={`${CARD} gap-4`} style={shadow}>
+            <Card className="gap-4">
               {/* Categoria (opcional) */}
               <MyView safe={false} className="gap-2">
-                <Text className={LABEL}>CATEGORIA (OPCIONAL)</Text>
+                <SectionLabel>CATEGORIA (OPCIONAL)</SectionLabel>
                 <View className="flex-row flex-wrap gap-2">
                   {CATEGORIES.map((c) => (
                     <MyButton
@@ -167,7 +164,7 @@ export default function Feedback() {
                 disabled={!canSend}
                 className={canSend ? "" : "opacity-50"}
               />
-            </MyView>
+            </Card>
           </>
         )}
       </ScrollView>

--- a/app/history.jsx
+++ b/app/history.jsx
@@ -7,17 +7,13 @@ import { useTable } from "tinybase/ui-react";
 import MyView from "@/components/MyView";
 import MyHeader from "@/components/MyHeader";
 import MyButton from "@/components/MyButton";
+import Card from "@/components/Card";
+import SectionLabel from "@/components/SectionLabel";
 import { HistoryCard } from "@/components/MyHistory";
 
 import { getByDate, store } from "@/infra/database";
 import { CATEGORY_MAP, getCategoryInfo } from "@/components/categoryUtils";
-import { shadow } from "@/constants/Colors";
 //#endregion
-
-const CARD =
-  "w-full max-w-[640px] rounded-lg bg-light-backgroundCard p-4 dark:bg-dark-backgroundCard";
-const LABEL =
-  "font-bold text-xs text-light-text opacity-60 dark:text-dark-text";
 
 // Ordem canônica das métricas (mesma da tela "hoje").
 const METRICS = Object.keys(CATEGORY_MAP);
@@ -76,8 +72,8 @@ export default function History() {
         showsVerticalScrollIndicator={false}
       >
         {/* Navegação por data */}
-        <MyView safe={false} className={`${CARD} gap-3`} style={shadow}>
-          <Text className={LABEL}>HISTÓRICO</Text>
+        <Card className="gap-3">
+          <SectionLabel>HISTÓRICO</SectionLabel>
           <View className="flex-row items-center justify-between gap-2">
             <MyButton
               title="◀"
@@ -99,19 +95,15 @@ export default function History() {
               onPress={() => setDate(startOfDay(new Date()))}
             />
           )}
-        </MyView>
+        </Card>
 
         {/* Registros do dia, agrupados por métrica */}
         {sections.length === 0 ? (
-          <MyView
-            safe={false}
-            className={`${CARD} items-center`}
-            style={shadow}
-          >
+          <Card className="items-center">
             <Text className="text-base text-light-text opacity-60 dark:text-dark-text">
               Nenhum registro neste dia.
             </Text>
-          </MyView>
+          </Card>
         ) : (
           sections.map((type) => {
             const { displayName, unit } = getCategoryInfo(type);

--- a/app/index.jsx
+++ b/app/index.jsx
@@ -10,19 +10,15 @@ import MyButton from "@/components/MyButton";
 import MyView from "@/components/MyView";
 import MyHeader from "@/components/MyHeader";
 import InstallApp from "@/components/InstallApp";
+import Card from "@/components/Card";
+import SectionLabel from "@/components/SectionLabel";
 
 import { clearAll, getToday, store } from "@/infra/database";
 import { confirmAction } from "@/constants/dialogs";
 import { getEnvironmentInfo } from "@/constants/environment";
 import { CATEGORY_MAP } from "@/components/categoryUtils";
 import { minutesToHHMM } from "@/constants/duration";
-import { shadow } from "@/constants/Colors";
 //#endregion
-
-const CARD =
-  "w-full max-w-[640px] rounded-lg bg-light-backgroundCard p-4 dark:bg-dark-backgroundCard";
-const LABEL =
-  "font-bold text-xs text-light-text opacity-60 dark:text-dark-text";
 
 // Versão/bundle exibidos nos Utilitários (#131).
 const ENV = getEnvironmentInfo();
@@ -106,7 +102,7 @@ export default function Home() {
         showsVerticalScrollIndicator={false}
       >
         {/* Resumo do dia */}
-        <MyView safe={false} className={`${CARD} gap-2`} style={shadow}>
+        <Card className="gap-2">
           <Text className="font-bold text-2xl text-light-text dark:text-dark-text">
             Hoje
           </Text>
@@ -119,11 +115,11 @@ export default function Home() {
               style={{ width: `${pct}%` }}
             />
           </View>
-        </MyView>
+        </Card>
 
         {/* Métricas do dia */}
-        <MyView safe={false} className={`${CARD} gap-3`} style={shadow}>
-          <Text className={LABEL}>MÉTRICAS DE HOJE</Text>
+        <Card className="gap-3">
+          <SectionLabel>MÉTRICAS DE HOJE</SectionLabel>
           <MyView safe={false} className="gap-2">
             {rows.map((r) => (
               <MetricRow
@@ -134,14 +130,14 @@ export default function Home() {
               />
             ))}
           </MyView>
-        </MyView>
+        </Card>
 
         {/* Obter o app (só web: QR no desktop, download no celular) */}
         <InstallApp />
 
         {/* Utilitários */}
-        <MyView safe={false} className={`${CARD} gap-2`} style={shadow}>
-          <Text className={LABEL}>UTILITÁRIOS</Text>
+        <Card className="gap-2">
+          <SectionLabel>UTILITÁRIOS</SectionLabel>
           <MyButton title="Alternar tema" onPress={() => toggleColorScheme()} />
           <MyButton
             title="Histórico"
@@ -162,7 +158,7 @@ export default function Home() {
             v{ENV.appVersion}
             {ENV.bundle ? ` · ${ENV.bundle}` : ""}
           </Text>
-        </MyView>
+        </Card>
       </ScrollView>
     </MyView>
   );

--- a/app/roadmap.jsx
+++ b/app/roadmap.jsx
@@ -4,8 +4,9 @@ import { ScrollView, Text, View } from "react-native";
 
 import MyView from "@/components/MyView";
 import MyHeader from "@/components/MyHeader";
+import Card from "@/components/Card";
+import SectionLabel from "@/components/SectionLabel";
 
-import { shadow } from "@/constants/Colors";
 import { parseRoadmap, getDigest } from "@/constants/roadmap";
 // Caminho relativo de propósito: o babel-plugin-inline-import resolve pelo
 // arquivo, não pelo alias @/. Editar o roadmap exige reiniciar com --clear.
@@ -15,10 +16,6 @@ import roadmapMd from "../docs/04-roadmap-milestones.md";
 const STATUS_ICON = { done: "✅", partial: "🟡", todo: "⬜" };
 const digest = getDigest(parseRoadmap(roadmapMd));
 
-const CARD =
-  "w-full max-w-[640px] rounded-lg bg-light-backgroundCard p-4 dark:bg-dark-backgroundCard";
-const LABEL =
-  "font-bold text-xs text-light-text opacity-60 dark:text-dark-text";
 const ITEM_TEXT = "flex-1 text-base text-light-text dark:text-dark-text";
 
 function ItemRow({ status, text }) {
@@ -53,7 +50,7 @@ export default function Roadmap() {
         showsVerticalScrollIndicator={false}
       >
         {/* Progresso geral */}
-        <MyView safe={false} className={`${CARD} gap-2`} style={shadow}>
+        <Card className="gap-2">
           <Text className="font-bold text-2xl text-light-text dark:text-dark-text">
             Back on Track
           </Text>
@@ -69,12 +66,12 @@ export default function Roadmap() {
               style={{ width: `${pct}%` }}
             />
           </View>
-        </MyView>
+        </Card>
 
         {/* Milestone atual */}
         {current && (
-          <MyView safe={false} className={`${CARD} gap-3`} style={shadow}>
-            <Text className={LABEL}>EM ANDAMENTO</Text>
+          <Card className="gap-3">
+            <SectionLabel>EM ANDAMENTO</SectionLabel>
             <Text className="font-bold text-lg text-light-text dark:text-dark-text">
               {current.id} · {current.title} ({currentProgress.done}/
               {currentProgress.total})
@@ -84,19 +81,19 @@ export default function Roadmap() {
                 <ItemRow key={i} status={item.status} text={item.text} />
               ))}
             </MyView>
-          </MyView>
+          </Card>
         )}
 
         {/* Concluído recentemente */}
         {recentDone.length > 0 && (
-          <MyView safe={false} className={`${CARD} gap-3`} style={shadow}>
-            <Text className={LABEL}>CONCLUÍDO RECENTEMENTE</Text>
+          <Card className="gap-3">
+            <SectionLabel>CONCLUÍDO RECENTEMENTE</SectionLabel>
             <MyView safe={false} className="gap-2">
               {recentDone.map((item, i) => (
                 <ItemRow key={i} status="done" text={item.text} />
               ))}
             </MyView>
-          </MyView>
+          </Card>
         )}
       </ScrollView>
     </MyView>

--- a/components/Card.jsx
+++ b/components/Card.jsx
@@ -1,0 +1,20 @@
+// @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
+//
+// Componente-base "card" — outer container das telas topo-nível.
+// Encapsula os tokens do M5: raio lg (papel "card"), bg surface por tema,
+// max-w 640 (o único breakpoint do app), padding p-4 canônico e a sombra
+// padrão (regra "top-level card → shadow"). Ver docs/08-design-tokens.md.
+
+import MyView from "./MyView";
+import { shadow } from "@/constants/Colors";
+
+export default function Card({ className, style, ...props }) {
+  return (
+    <MyView
+      safe={false}
+      className={`w-full max-w-[640px] rounded-lg bg-light-backgroundCard p-4 dark:bg-dark-backgroundCard ${className ?? ""}`}
+      style={[shadow, style]}
+      {...props}
+    />
+  );
+}

--- a/components/FieldLabel.jsx
+++ b/components/FieldLabel.jsx
@@ -1,0 +1,18 @@
+// @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
+//
+// Rótulo de campo de formulário (FIELD LABEL). "MIN"/"MAX"/"IDEAL",
+// "OBS:", "Nota", "Hora do treino"… Papel diferente do SectionLabel — ver
+// docs/08-design-tokens.md.
+
+import { Text } from "react-native";
+
+export default function FieldLabel({ className, children, ...props }) {
+  return (
+    <Text
+      className={`font-bold text-lg text-light-text dark:text-dark-text ${className ?? ""}`}
+      {...props}
+    >
+      {children}
+    </Text>
+  );
+}

--- a/components/InstallApp.web.jsx
+++ b/components/InstallApp.web.jsx
@@ -14,20 +14,18 @@ import { useEffect, useState } from "react";
 import { Linking, Text, View } from "react-native";
 import QRCode from "react-native-qrcode-svg";
 
-import MyView from "@/components/MyView";
 import MyButtonRaw from "@/components/MyButton";
-import { shadow } from "@/constants/Colors";
+import CardRaw from "@/components/Card";
+import SectionLabelRaw from "@/components/SectionLabel";
 import { EAS_INSTALL_URL } from "@/constants/distribution";
 
 // MyButton é legado (@ts-nocheck, ADR-002): sua assinatura inferida marca as
 // props como obrigatórias, o que quebra consumidores tipados. Tratamos como
 // any até ele ser tipado de fato.
 const MyButton = /** @type {any} */ (MyButtonRaw);
+const Card = /** @type {any} */ (CardRaw);
+const SectionLabel = /** @type {any} */ (SectionLabelRaw);
 
-const CARD =
-  "w-full max-w-[640px] rounded-lg bg-light-backgroundCard p-4 dark:bg-dark-backgroundCard";
-const LABEL =
-  "font-bold text-xs text-light-text opacity-60 dark:text-dark-text";
 const TEXT = "text-center text-base text-light-text dark:text-dark-text";
 
 function isMobileBrowser() {
@@ -42,12 +40,8 @@ export default function InstallApp() {
   useEffect(() => setMobile(isMobileBrowser()), []);
 
   return (
-    <MyView
-      safe={false}
-      className={`${CARD} items-center gap-3`}
-      style={shadow}
-    >
-      <Text className={`${LABEL} self-start`}>OBTER O APP</Text>
+    <Card className="items-center gap-3">
+      <SectionLabel className="self-start">OBTER O APP</SectionLabel>
       {mobile ? (
         <>
           <Text className={TEXT}>
@@ -73,6 +67,6 @@ export default function InstallApp() {
           </View>
         </>
       )}
-    </MyView>
+    </Card>
   );
 }

--- a/components/SectionLabel.jsx
+++ b/components/SectionLabel.jsx
@@ -1,0 +1,18 @@
+// @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
+//
+// Rótulo de seção (SECTION LABEL). Aparece como cabeçalho de bloco dentro
+// dos cards ("MÉTRICAS DE HOJE", "UTILITÁRIOS", "HISTÓRICO"…). Papel
+// tipográfico diferente do FieldLabel — ver docs/08-design-tokens.md.
+
+import { Text } from "react-native";
+
+export default function SectionLabel({ className, children, ...props }) {
+  return (
+    <Text
+      className={`font-bold text-xs text-light-text opacity-60 dark:text-dark-text ${className ?? ""}`}
+      {...props}
+    >
+      {children}
+    </Text>
+  );
+}

--- a/components/metrics/MetricScreen.jsx
+++ b/components/metrics/MetricScreen.jsx
@@ -7,12 +7,13 @@
 // (loadExtra). Adicionar uma métrica = adicionar uma config.
 
 import { useEffect, useState } from "react";
-import { ScrollView, Text, TextInput } from "react-native";
+import { ScrollView, TextInput } from "react-native";
 import { Snackbar } from "react-native-paper";
 
 import ScoreRaw from "@/components/Score";
 import MyViewRaw from "@/components/MyView";
 import MyHeaderRaw from "@/components/MyHeader";
+import FieldLabelRaw from "@/components/FieldLabel";
 
 import { getCategoryInfo } from "@/components/categoryUtils";
 import getDate from "@/constants/getDate";
@@ -23,8 +24,7 @@ import { getMetricConfig } from "./registry";
 const MyView = /** @type {any} */ (MyViewRaw);
 const Score = /** @type {any} */ (ScoreRaw);
 const MyHeader = /** @type {any} */ (MyHeaderRaw);
-
-const FIELD_LABEL = "font-bold text-lg text-light-text dark:text-dark-text";
+const FieldLabel = /** @type {any} */ (FieldLabelRaw);
 
 /**
  * @param {{ metric: string, recordId?: string }} props
@@ -101,17 +101,17 @@ export default function MetricScreen({ metric, recordId }) {
           className={`max-w-[640px] gap-8 rounded-lg bg-light-backgroundCard p-3 dark:bg-dark-backgroundCard ${config.cardClass ?? ""}`}
           style={shadow}
         >
-          <Text className={FIELD_LABEL}>
+          <FieldLabel>
             {date.displayDate} {displayName}
-          </Text>
+          </FieldLabel>
 
           {Top && <Top extra={extra} setField={setField} />}
 
-          <Text className={FIELD_LABEL}>Nota</Text>
+          <FieldLabel>Nota</FieldLabel>
           <Score value={score} onPress={setScore} />
 
           <MyView safe={false} className="gap-1">
-            <Text className={FIELD_LABEL}>OBS:</Text>
+            <FieldLabel>OBS:</FieldLabel>
             <TextInput
               value={observation}
               onChangeText={setObservation}

--- a/components/metrics/fields.jsx
+++ b/components/metrics/fields.jsx
@@ -9,12 +9,13 @@
 import { Text, TextInput } from "react-native";
 
 import MyViewRaw from "@/components/MyView";
+import FieldLabelRaw from "@/components/FieldLabel";
 import { MyIconButton as MyIconButtonRaw } from "@/components/MyButton";
 
 const MyView = /** @type {any} */ (MyViewRaw);
 const MyIconButton = /** @type {any} */ (MyIconButtonRaw);
+const FieldLabel = /** @type {any} */ (FieldLabelRaw);
 
-const FIELD_LABEL = "font-bold text-lg text-light-text dark:text-dark-text";
 const INPUT_LG =
   "h-[51px] w-20 max-w-[160px] rounded-md bg-light-backgroundCard dark:bg-dark-backgroundCard p-2 text-center text-2xl font-bold text-light-text dark:text-dark-text";
 const CARD =
@@ -42,7 +43,7 @@ export function MinMaxIdealField({ min, max, ideal, onMin, onMax, onIdeal }) {
     <MyView safe={false} className="flex-row justify-between">
       {cols.map((col) => (
         <MyView key={col.label} safe={false} className="gap-3">
-          <Text className={FIELD_LABEL}>{col.label}</Text>
+          <FieldLabel>{col.label}</FieldLabel>
           <TextInput
             className={inputClass}
             placeholder="--"
@@ -66,7 +67,7 @@ export function MinMaxIdealField({ min, max, ideal, onMin, onMax, onIdeal }) {
 export function DurationField({ label, hour, minute, onHour, onMinute }) {
   return (
     <MyView safe={false} className={CARD}>
-      <Text className={FIELD_LABEL}>{label}</Text>
+      <FieldLabel>{label}</FieldLabel>
       <MyView safe={false} className="flex-row items-end gap-1">
         <TextInput
           className={INPUT_LG}
@@ -74,14 +75,14 @@ export function DurationField({ label, hour, minute, onHour, onMinute }) {
           value={hour}
           onChangeText={onHour}
         />
-        <Text className={FIELD_LABEL}>h</Text>
+        <FieldLabel>h</FieldLabel>
         <TextInput
           className={INPUT_LG}
           placeholder="--"
           value={minute}
           onChangeText={onMinute}
         />
-        <Text className={FIELD_LABEL}>min</Text>
+        <FieldLabel>min</FieldLabel>
       </MyView>
     </MyView>
   );
@@ -133,7 +134,7 @@ export function QuantityField({ label, value, unit, onChange }) {
         value={value}
         onChangeText={onChange}
       />
-      <Text className={FIELD_LABEL}>{unit}</Text>
+      <FieldLabel>{unit}</FieldLabel>
     </MyView>
   );
 }

--- a/components/metrics/registry.jsx
+++ b/components/metrics/registry.jsx
@@ -10,6 +10,7 @@ import { Text, TextInput } from "react-native";
 import MyViewRaw from "@/components/MyView";
 import MyButtonRaw from "@/components/MyButton";
 import MyCheckboxRaw from "@/components/MyCheckbox";
+import FieldLabelRaw from "@/components/FieldLabel";
 import MyHistory, { MyExerciseHistory } from "@/components/MyHistory";
 
 import { hhmmToMinutes, minutesToHHMM } from "@/constants/duration";
@@ -23,8 +24,8 @@ import {
 const MyView = /** @type {any} */ (MyViewRaw);
 const MyButton = /** @type {any} */ (MyButtonRaw);
 const MyCheckbox = /** @type {any} */ (MyCheckboxRaw);
+const FieldLabel = /** @type {any} */ (FieldLabelRaw);
 
-const FIELD_LABEL = "font-bold text-lg text-light-text dark:text-dark-text";
 const INPUT_LG =
   "h-[51px] w-20 max-w-[160px] rounded-md bg-light-backgroundCard dark:bg-dark-backgroundCard p-2 text-center text-2xl font-bold text-light-text dark:text-dark-text";
 
@@ -134,14 +135,14 @@ const REGISTRY = {
             value={extra.hour}
             onChangeText={(v) => setField("hour", v)}
           />
-          <Text className={FIELD_LABEL}>h</Text>
+          <FieldLabel>h</FieldLabel>
           <TextInput
             className="h-[37px] max-w-[38px] rounded-md bg-light-backgroundCard dark:bg-dark-backgroundCard px-1 text-center text-xl font-normal text-light-text dark:text-dark-text"
             placeholder="--"
             value={extra.minute}
             onChangeText={(v) => setField("minute", v)}
           />
-          <Text className={FIELD_LABEL}>min</Text>
+          <FieldLabel>min</FieldLabel>
         </MyView>
         <MyButton title="Salvar" onPress={onSubmit} />
       </MyView>
@@ -215,7 +216,7 @@ const REGISTRY = {
             safe={false}
             className="items-center gap-8 rounded-lg bg-light-backgroundCard p-3 dark:bg-dark-backgroundCard"
           >
-            <Text className={FIELD_LABEL}>Hora do treino</Text>
+            <FieldLabel>Hora do treino</FieldLabel>
             <MyView
               safe={false}
               className="flex-row items-center justify-center gap-1"
@@ -226,7 +227,7 @@ const REGISTRY = {
                 value={extra.timeHour}
                 onChangeText={(v) => setField("timeHour", v)}
               />
-              <Text className={FIELD_LABEL}>:</Text>
+              <FieldLabel>:</FieldLabel>
               <TextInput
                 className={INPUT_LG}
                 placeholder="--"

--- a/docs/08-design-tokens.md
+++ b/docs/08-design-tokens.md
@@ -251,3 +251,55 @@ Deve retornar vazio.
 - **Cor de placeholder** (`placeholderTextColor="#888"` em `MyInput`) — hex cru mas funcional em ambos os temas. Vira token quando componentizarmos `MyInput`.
 - **Ícone hex fixo** (`color="#333"` em `MyButton`) — cosmético, sem trigger claro.
 - **Cor de ripple** (`android_ripple={{ color: "#00000022" }}`) — detalhe de plataforma Android, não vira token.
+
+---
+
+## Componentes derivados dos tokens
+
+Não são tokens em si; são **componentes-base** que juntam vários tokens num único uso comum. Ficam em `components/*.jsx` e servem pra três coisas: (a) matar a duplicação byte a byte que a auditoria (§1, §4) pegou; (b) transformar a decisão "qual token nesse papel?" em "importa o componente certo"; (c) barrar drift — mexer no token muda todo o app, não só o arquivo aberto.
+
+### `Card` — [components/Card.jsx](../components/Card.jsx)
+
+Container top-level das telas topo-nível. Composição:
+
+- Raio: `rounded-lg` (papel "card")
+- Superfície: `bg-light-backgroundCard dark:bg-dark-backgroundCard`
+- Padding: `p-4` (comfortable)
+- Largura: `w-full max-w-[640px]` (único breakpoint do app)
+- Sombra: `style={shadow}` embutida (regra top-level card → shadow)
+- Wrapper: `<MyView safe={false}>`
+
+Aceita `className` (pra `gap-N` interno) e `style` (mesclado com `shadow`). Nested cards do form de métrica NÃO usam `Card` — são estruturas próprias, sem shadow, fora do papel canônico.
+
+### `SectionLabel` — [components/SectionLabel.jsx](../components/SectionLabel.jsx)
+
+Rótulo de seção dentro de card. Composição:
+
+- Tipografia: `text-xs` (13px)
+- Peso: `font-bold`
+- Cor: `text-light-text dark:text-dark-text` com `opacity-60`
+
+Uso: "MÉTRICAS DE HOJE", "UTILITÁRIOS", "HISTÓRICO", "CATEGORIA (OPCIONAL)"…
+
+### `FieldLabel` — [components/FieldLabel.jsx](../components/FieldLabel.jsx)
+
+Rótulo de campo de formulário. Composição:
+
+- Tipografia: `text-lg` (19px)
+- Peso: `font-bold`
+- Cor: `text-light-text dark:text-dark-text` (sem opacity)
+
+Uso: "MIN"/"MAX"/"IDEAL", "OBS:", "Nota", "Hora do treino", `h`/`min` de duração, unidade em `QuantityField`.
+
+### O que a fatia mudou (#169)
+
+- Cria `components/Card.jsx`, `components/SectionLabel.jsx`, `components/FieldLabel.jsx`.
+- Migra 6 telas topo-nível — `app/{index,history,admin,feedback,roadmap}.jsx` e `components/InstallApp.web.jsx` — pra usar `Card` + `SectionLabel`. Remove os constantes locais `CARD` e `LABEL` (que estavam byte a byte iguais em cada arquivo).
+- Migra `components/metrics/{MetricScreen,fields,registry}.jsx` pra usar `FieldLabel`. Remove os constantes locais `FIELD_LABEL`.
+
+### O que NÃO está resolvido aqui
+
+- **Card do form de métrica** (`MetricScreen.jsx:100`) + cards nested em `fields.jsx` e `registry.jsx` — largura, padding e estrutura diferentes; casam com o follow-up "padronizar largura dos forms de métrica" e viram fatia própria.
+- **`HistoryCard`** — já é componente próprio com estrutura interna própria (badge de nota, botões editar/excluir, exercício); segue como está.
+- **`MyButton` disabled state** (§7 da auditoria) — cada tela reinventa `opacity-40` vs `opacity-50` na mão; fatia própria.
+- **Revisar `MyHeader`** (papel de navegação vs. chips) — item próprio do M5.


### PR DESCRIPTION
Fatia 1 do item **\"Componentizar o que está duplicado\"** do M5. Fecha #169.

Ataca §1 e §4 da auditoria: \`CARD\`/\`LABEL\` duplicados byte a byte em 6 arquivos, \`FIELD_LABEL\` em 3. Substituição por componentes-base que consomem os tokens já documentados em \`docs/08-design-tokens.md\`.

## Componentes novos

| Componente | Composição |
|---|---|
| \`Card\` | \`MyView safe={false}\` + \`w-full max-w-[640px] rounded-lg bg-light-backgroundCard p-4 dark:bg-dark-backgroundCard\` + \`style={shadow}\` embutido |
| \`SectionLabel\` | \`<Text className=\"font-bold text-xs text-light-text opacity-60 dark:text-dark-text\">\` |
| \`FieldLabel\` | \`<Text className=\"font-bold text-lg text-light-text dark:text-dark-text\">\` |

Cada um documentado em \`docs/08-design-tokens.md\` (nova seção \"Componentes derivados\") mostrando quais tokens consome.

## Migrações

- **6 telas topo-nível**: \`app/{index,history,admin,feedback,roadmap}.jsx\`, \`components/InstallApp.web.jsx\` — removem \`CARD\` e \`LABEL\` constants; usam \`<Card>\` e \`<SectionLabel>\`. \`shadow\` deixa de ser importado nesses arquivos (embutido no \`Card\`).
- **3 arquivos de métrica**: \`MetricScreen.jsx\`, \`fields.jsx\`, \`registry.jsx\` — removem \`FIELD_LABEL\` constants; usam \`<FieldLabel>\`.

## Saldo

13 arquivos, +181/-99 líquido. A maior parte da adição é doc + 3 componentes novos; o saldo do restante é -26 linhas (remoção de constantes duplicadas).

## Validação

\`\`\`bash
# Zero constantes locais das strings duplicadas nas 6+3 telas
git grep -nE \"^const (CARD|LABEL|FIELD_LABEL)\\b\" -- '*.jsx'
\`\`\`

Retorna apenas \`components/metrics/fields.jsx:21 const CARD = ...\` — que é o card **nested** do form de métrica (papel diferente, fora de escopo).

## Fora de escopo

- **Card do form de métrica** (\`MetricScreen\`) + cards nested em \`fields.jsx\`/\`registry.jsx\` — casam com o follow-up \"padronizar largura dos forms de métrica\" e viram fatia própria
- \`HistoryCard\` — já é componente próprio com estrutura interna própria
- \`MyButton\` disabled state (§7 da auditoria) — cada tela reinventa \`opacity-40\` vs \`opacity-50\`; fatia própria
- Revisar \`MyHeader\` — item próprio do M5

## Test plan

- [ ] Web (preview Vercel):
  - [ ] 5 telas topo-nível (Home, Histórico, Feedback, Admin via deep link, Roadmap) sem regressão visual — mesmos cards, mesmas sombras, mesmos labels
  - [ ] Tela de métrica (água/sono/exercício/etc): \`FieldLabel\` de \"MIN\"/\"MAX\"/\"IDEAL\", \"OBS:\", \"Nota\", \"Hora do treino\", \"h\"/\"min\" sem regressão
- [ ] CI verde (Prettier/ESLint/Types/Test/commitlint)