### PR TITLE
refactor(ui): estado disabled canônico do MyButton

### DIFF
--- a/app/admin.jsx
+++ b/app/admin.jsx
@@ -111,12 +111,7 @@ export default function Admin() {
             className="w-full"
             keyboardType="phone-pad"
           />
-          <MyButton
-            title="Adicionar"
-            onPress={handleAdd}
-            disabled={!canAdd}
-            className={canAdd ? "" : "opacity-50"}
-          />
+          <MyButton title="Adicionar" onPress={handleAdd} disabled={!canAdd} />
         </Card>
 
         {/* Lista */}

--- a/app/feedback.jsx
+++ b/app/feedback.jsx
@@ -162,7 +162,6 @@ export default function Feedback() {
                 title={status === "sending" ? "Enviando…" : "Enviar"}
                 onPress={handleSend}
                 disabled={!canSend}
-                className={canSend ? "" : "opacity-50"}
               />
             </Card>
           </>

--- a/app/history.jsx
+++ b/app/history.jsx
@@ -85,7 +85,6 @@ export default function History() {
             <MyButton
               title="▶"
               disabled={isToday}
-              style={isToday ? { opacity: 0.4 } : undefined}
               onPress={() => setDate((d) => addDays(d, 1))}
             />
           </View>

--- a/components/MyButton.jsx
+++ b/components/MyButton.jsx
@@ -5,6 +5,7 @@ import { Pressable, Text } from "react-native";
 
 export default function MyButton({
   isSelected = false,
+  disabled = false,
   title,
   Icon,
   titleClassName,
@@ -16,9 +17,10 @@ export default function MyButton({
     <Pressable
       className={`flex-row items-center justify-center rounded-full px-4 py-2 ${
         isSelected ? "bg-secondary" : "bg-primary"
-      } ${className ?? ""}`}
+      } ${disabled ? "opacity-40" : ""} ${className ?? ""}`}
       style={[shadow, style]}
       android_ripple={{ color: "#00000022" }}
+      disabled={disabled}
       {...props}
     >
       {title != null && (
@@ -38,6 +40,7 @@ export default function MyButton({
 export function MyIconButton({
   Icon,
   isSelected = false,
+  disabled = false,
   className,
   style,
   ...props
@@ -52,9 +55,10 @@ export function MyIconButton({
         isSelected
           ? "border-0 bg-secondary"
           : "border border-[#333] bg-transparent"
-      } ${className ?? ""}`}
+      } ${disabled ? "opacity-40" : ""} ${className ?? ""}`}
       style={[shadow, style]}
       android_ripple={{ color: "#00000022" }}
+      disabled={disabled}
       {...props}
     >
       {Icon && (

--- a/docs/08-design-tokens.md
+++ b/docs/08-design-tokens.md
@@ -301,5 +301,22 @@ Uso: "MIN"/"MAX"/"IDEAL", "OBS:", "Nota", "Hora do treino", `h`/`min` de duraç�
 
 - **Card do form de métrica** (`MetricScreen.jsx:100`) + cards nested em `fields.jsx` e `registry.jsx` — largura, padding e estrutura diferentes; casam com o follow-up "padronizar largura dos forms de métrica" e viram fatia própria.
 - **`HistoryCard`** — já é componente próprio com estrutura interna própria (badge de nota, botões editar/excluir, exercício); segue como está.
-- **`MyButton` disabled state** (§7 da auditoria) — cada tela reinventa `opacity-40` vs `opacity-50` na mão; fatia própria.
 - **Revisar `MyHeader`** (papel de navegação vs. chips) — item próprio do M5.
+
+## Estados canônicos
+
+Contratos de estado embutidos nos componentes-base — o consumidor passa a **intenção** (`disabled`, `isSelected`, etc.), não a implementação visual.
+
+### `disabled` — [`MyButton`](../components/MyButton.jsx) / `MyIconButton`
+
+- **Prop:** `disabled` (boolean, default `false`).
+- **Visual:** aplica `opacity-40` internamente.
+- **Comportamento:** `Pressable` recebe `disabled` explícito e bloqueia `onPress` nativamente.
+
+Uso:
+
+```jsx
+<MyButton title="Enviar" onPress={send} disabled={!canSend} />
+```
+
+Rationale: `opacity-40` (0.4) alinha com convenção iOS e resolve §7 da auditoria — antes cada tela reinventava (`0.4` vs `opacity-50`), com o visual e o bloqueio de `onPress` desconectados. Agora é um contrato só.


### PR DESCRIPTION
Fatia 2 do item \"Componentizar\" do M5. Fecha #172.

Resolve §7 da auditoria: cada tela reinventava a opacidade do \`disabled\` (0.4 vs 0.5) e o visual estava desconectado do bloqueio de \`onPress\`.

## O que muda

- **\`MyButton\`/\`MyIconButton\`** — extraem \`disabled\` das props, aplicam \`opacity-40\` internamente, e passam \`disabled={disabled}\` explícito pra \`Pressable\` (mantém o bloqueio nativo).
- **3 callsites migrados**:
  - \`app/history.jsx\` — sem \`style={isToday ? { opacity: 0.4 } : undefined}\`
  - \`app/admin.jsx\` — sem \`className={canAdd ? \"\" : \"opacity-50\"}\`
  - \`app/feedback.jsx\` — sem \`className={canSend ? \"\" : \"opacity-50\"}\`
- **\`docs/08-design-tokens.md\`** — nova seção \"Estados canônicos\" com o contrato \`disabled → opacity-40\`.

## Valor canônico

\`opacity-40\` (0.4) — matches iOS convention e é o valor que \`history.jsx\` já usava.

## Saldo

5 arquivos, +25/-11 líquido.

## Validação

Callsite passa só \`disabled={cond}\` — o componente cuida do visual. \`opacity-50\` restante no repo é só em \`<Text>\` muted (versão do app, timestamp, OBS label), sem relação com disabled.

## Fora de escopo

- Revisar \`MyHeader\` (papel navegação vs. chips) — item próprio do M5
- Padronizar largura do card do form de métrica — casa com o follow-up

## Test plan

- [ ] Web (preview Vercel):
  - [ ] Histórico: seta ▶ desabilitada em \"Hoje\" fica com opacidade 40% e não navega
  - [ ] Admin: botão \"Adicionar\" com campos vazios fica com opacidade 40% e não envia
  - [ ] Feedback: botão \"Enviar\" com título/descrição vazios fica com opacidade 40% e não envia
- [ ] CI verde (Prettier/ESLint/Types/Test/commitlint)