### PR TITLE
refactor(ui): padroniza largura dos forms de métrica com <Card>

### DIFF
--- a/components/metrics/MetricScreen.jsx
+++ b/components/metrics/MetricScreen.jsx
@@ -14,10 +14,10 @@ import ScoreRaw from "@/components/Score";
 import MyViewRaw from "@/components/MyView";
 import MyHeaderRaw from "@/components/MyHeader";
 import FieldLabelRaw from "@/components/FieldLabel";
+import CardRaw from "@/components/Card";
 
 import { getCategoryInfo } from "@/components/categoryUtils";
 import getDate from "@/constants/getDate";
-import { shadow } from "@/constants/Colors";
 import { add, getById, update } from "@/infra/database";
 import { getMetricConfig } from "./registry";
 
@@ -25,6 +25,7 @@ const MyView = /** @type {any} */ (MyViewRaw);
 const Score = /** @type {any} */ (ScoreRaw);
 const MyHeader = /** @type {any} */ (MyHeaderRaw);
 const FieldLabel = /** @type {any} */ (FieldLabelRaw);
+const Card = /** @type {any} */ (CardRaw);
 
 /**
  * @param {{ metric: string, recordId?: string }} props
@@ -96,11 +97,7 @@ export default function MetricScreen({ metric, recordId }) {
         }}
         showsVerticalScrollIndicator={false}
       >
-        <MyView
-          safe={false}
-          className={`max-w-[640px] gap-8 rounded-lg bg-light-backgroundCard p-3 dark:bg-dark-backgroundCard ${config.cardClass ?? ""}`}
-          style={shadow}
-        >
+        <Card className={`gap-8 ${config.cardClass ?? ""}`}>
           <FieldLabel>
             {date.displayDate} {displayName}
           </FieldLabel>
@@ -129,7 +126,7 @@ export default function MetricScreen({ metric, recordId }) {
               unit={unit}
             />
           )}
-        </MyView>
+        </Card>
         <History tableName={metric} reload={reloadKey} />
       </ScrollView>
     </MyView>

--- a/components/metrics/fields.jsx
+++ b/components/metrics/fields.jsx
@@ -19,7 +19,7 @@ const FieldLabel = /** @type {any} */ (FieldLabelRaw);
 const INPUT_LG =
   "h-[51px] w-20 max-w-[160px] rounded-md bg-light-backgroundCard dark:bg-dark-backgroundCard p-2 text-center text-2xl font-bold text-light-text dark:text-dark-text";
 const CARD =
-  "items-center gap-8 rounded-lg bg-light-backgroundCard p-3 dark:bg-dark-backgroundCard";
+  "w-full items-center gap-8 rounded-lg bg-light-backgroundCard p-3 dark:bg-dark-backgroundCard";
 
 /**
  * Bloco MIN / MAX / IDEAL (água, sono). Os três campos são editáveis — isso
@@ -123,7 +123,7 @@ export function QuantityField({ label, value, unit, onChange }) {
   return (
     <MyView
       safe={false}
-      className="w-1/2 grow flex-row items-center justify-center gap-8 rounded-lg bg-light-backgroundCard p-3 dark:bg-dark-backgroundCard"
+      className="w-full flex-row items-center justify-center gap-8 rounded-lg bg-light-backgroundCard p-3 dark:bg-dark-backgroundCard"
     >
       <Text className="font-bold text-2xl text-light-text dark:text-dark-text">
         {label} hoje

--- a/components/metrics/registry.jsx
+++ b/components/metrics/registry.jsx
@@ -84,7 +84,7 @@ const REGISTRY = {
     }),
     Top: MinMaxIdealTop,
     Bottom: ({ extra, setField, onSubmit, displayName, unit }) => (
-      <MyView safe={false} className="flex-row flex-wrap items-center gap-4">
+      <MyView safe={false} className="gap-4">
         <QuantityField
           label={displayName ?? ""}
           value={extra.quantity}
@@ -118,13 +118,10 @@ const REGISTRY = {
     }),
     Top: MinMaxIdealTop,
     Bottom: ({ extra, setField, onSubmit, displayName }) => (
-      <MyView
-        safe={false}
-        className="flex-row flex-wrap items-center justify-center gap-4"
-      >
+      <MyView safe={false} className="gap-4">
         <MyView
           safe={false}
-          className="w-full grow flex-row items-center justify-center gap-4 rounded-lg bg-light-backgroundCard p-3 dark:bg-dark-backgroundCard"
+          className="w-full flex-row items-center justify-center gap-4 rounded-lg bg-light-backgroundCard p-3 dark:bg-dark-backgroundCard"
         >
           <Text className="font-bold text-2xl text-light-text dark:text-dark-text">
             {displayName} hoje
@@ -210,42 +207,40 @@ const REGISTRY = {
       </MyView>
     ),
     Bottom: ({ extra, setField, onSubmit }) => (
-      <>
-        <MyView safe={false} className="flex-row flex-wrap items-center gap-4">
+      <MyView safe={false} className="gap-4">
+        <MyView
+          safe={false}
+          className="w-full items-center gap-8 rounded-lg bg-light-backgroundCard p-3 dark:bg-dark-backgroundCard"
+        >
+          <FieldLabel>Hora do treino</FieldLabel>
           <MyView
             safe={false}
-            className="items-center gap-8 rounded-lg bg-light-backgroundCard p-3 dark:bg-dark-backgroundCard"
+            className="flex-row items-center justify-center gap-1"
           >
-            <FieldLabel>Hora do treino</FieldLabel>
-            <MyView
-              safe={false}
-              className="flex-row items-center justify-center gap-1"
-            >
-              <TextInput
-                className={INPUT_LG}
-                placeholder="--"
-                value={extra.timeHour}
-                onChangeText={(v) => setField("timeHour", v)}
-              />
-              <FieldLabel>:</FieldLabel>
-              <TextInput
-                className={INPUT_LG}
-                placeholder="--"
-                value={extra.timeMinute}
-                onChangeText={(v) => setField("timeMinute", v)}
-              />
-            </MyView>
+            <TextInput
+              className={INPUT_LG}
+              placeholder="--"
+              value={extra.timeHour}
+              onChangeText={(v) => setField("timeHour", v)}
+            />
+            <FieldLabel>:</FieldLabel>
+            <TextInput
+              className={INPUT_LG}
+              placeholder="--"
+              value={extra.timeMinute}
+              onChangeText={(v) => setField("timeMinute", v)}
+            />
           </MyView>
-          <DurationField
-            label="Tempo de treino"
-            hour={extra.durHour}
-            minute={extra.durMinute}
-            onHour={(v) => setField("durHour", v)}
-            onMinute={(v) => setField("durMinute", v)}
-          />
         </MyView>
+        <DurationField
+          label="Tempo de treino"
+          hour={extra.durHour}
+          minute={extra.durMinute}
+          onHour={(v) => setField("durHour", v)}
+          onMinute={(v) => setField("durMinute", v)}
+        />
         <MyButton title="Salvar" onPress={onSubmit} />
-      </>
+      </MyView>
     ),
   },
 
@@ -271,7 +266,7 @@ const REGISTRY = {
       </MyView>
     ),
     Bottom: ({ extra, setField, onSubmit }) => (
-      <MyView safe={false} className="flex-row items-end justify-between gap-4">
+      <MyView safe={false} className="gap-4">
         <DurationField
           label="Tempo de estudo"
           hour={extra.durHour}

--- a/docs/08-design-tokens.md
+++ b/docs/08-design-tokens.md
@@ -269,7 +269,9 @@ Container top-level das telas topo-nível. Composição:
 - Sombra: `style={shadow}` embutida (regra top-level card → shadow)
 - Wrapper: `<MyView safe={false}>`
 
-Aceita `className` (pra `gap-N` interno) e `style` (mesclado com `shadow`). Nested cards do form de métrica NÃO usam `Card` — são estruturas próprias, sem shadow, fora do papel canônico.
+Aceita `className` (pra `gap-N` interno) e `style` (mesclado com `shadow`). Também é o card outer do form de métrica (`MetricScreen`), que passa `cardClass` custom (ex.: `overflow-hidden` pra alimentação) via `className`.
+
+**Cards nested** (dentro de outro `Card` — o form de métrica é o único caso hoje): usam a mesma superfície + raio, mas sem shadow (regra 2 da fatia sombra: evita dupla elevação) e **sempre com `w-full`** — assim o filho estica pra largura do outer e o ritmo visual fecha entre as 5 telas de métrica. Não são componentizados porque ainda são poucos e a composição interna varia (input + label × card com múltiplos inputs); se aparecerem 3+ variantes iguais, vira `<CardNested>`.
 
 ### `SectionLabel` — [components/SectionLabel.jsx](../components/SectionLabel.jsx)
 


### PR DESCRIPTION
Fatia 3 (final) do item \"Componentizar\" do M5. Fecha #175 e o 🟡 do item.

Antes: as 5 telas de métrica montavam o card do form com combinações diferentes de flex/w-*/grow — largura visual diferente por métrica (água+sono iguais entre si, exercício com largura própria, alimentação+estudo iguais entre si mas ≠).

## O que muda

- **\`MetricScreen.jsx:100\`** — o card outer vira \`<Card>\` canônico. Ganha \`w-full\` + \`p-4\` (era \`p-3\`) + shadow embutido. \`cardClass\` (\`overflow-hidden\` do \`feeding\`) segue passando via \`className\`.
- **\`registry.jsx\` Bottom slots** — remove \`flex-row flex-wrap\` que dava largura própria por card:
  - \`water.Bottom\` — empilha \`QuantityField\` + botão
  - \`sleep.Bottom\` — card interno + botão empilhados; card interno agora \`w-full\` (era \`w-full grow flex-row flex-wrap\`)
  - \`exercise.Bottom\` — dois cards (\"Hora do treino\" + \`DurationField\`) + botão empilhados; card interno \`w-full\`
  - \`study.Bottom\` — \`DurationField\` + botão empilhados
  - \`feeding\` — sem mudança
- **\`fields.jsx\`** — \`CARD\` (usado por \`DurationField\`) e \`QuantityField\` ganham \`w-full\` — não colapsam mais pra largura do conteúdo.

## Doc

\`docs/08-design-tokens.md\` — nota nova em \`Card\` sobre cards nested seguirem \`w-full\` pra preservar ritmo visual, e por que não são componentizados ainda (composição interna varia).

## Fora de escopo

- Extrair \`<CardNested>\` — só 2 usos hoje com composições diferentes; segundo o princípio \"3 usos iguais → componente\" fica pra depois.
- Revisar \`MyHeader\` (papel navegação vs. chips) — item próprio do M5.

## Test plan (crítico — muda o layout das 5 telas)

- [ ] Web (preview Vercel), navegar pelas 5 métricas:
  - [ ] Água — form com mesma largura das outras telas topo-nível (Home/Histórico/Feedback)
  - [ ] Sono — mesma largura, card interno de horas estica full-width
  - [ ] Alimentação — sem mudança visual notável
  - [ ] Exercício — não mais dois cards side-by-side; empilhados, cada um w-full
  - [ ] Estudo — \`DurationField\` + botão empilhados
- [ ] Todas as 5 com card do form com mesma largura visual
- [ ] Salvar registro em cada uma funcionando
- [ ] CI verde