### PR TITLE
refactor(ui): usa MyHeader só em telas metric-adjacent

### DIFF
--- a/app/_layout.jsx
+++ b/app/_layout.jsx
@@ -16,12 +16,24 @@ export default function RootLayout() {
       <View className="flex-1">
         <Stack screenOptions={{ headerShown: false }}>
           <Stack.Screen name="index" options={{ title: "Hoje" }} />
-          <Stack.Screen name="roadmap" options={{ title: "Roadmap" }} />
+          {/* Roadmap/Feedback/Admin não têm relação com registro de métrica,
+              então não usam o MyHeader (faixa de chips). Ativam o header
+              nativo do Expo Router pra ganhar título + back arrow (#178). */}
+          <Stack.Screen
+            name="roadmap"
+            options={{ title: "Roadmap", headerShown: true }}
+          />
           <Stack.Screen name="export" options={{ title: "Exportação" }} />
           <Stack.Screen name="history" options={{ title: "Histórico" }} />
-          <Stack.Screen name="feedback" options={{ title: "Feedback" }} />
+          <Stack.Screen
+            name="feedback"
+            options={{ title: "Feedback", headerShown: true }}
+          />
           {/* Rota de admin (testers) — acesso só por deep link backontrack://admin */}
-          <Stack.Screen name="admin" options={{ title: "Admin" }} />
+          <Stack.Screen
+            name="admin"
+            options={{ title: "Admin", headerShown: true }}
+          />
           <Stack.Screen name="(metrics)" />
         </Stack>
         <UpdateBanner />

--- a/app/admin.jsx
+++ b/app/admin.jsx
@@ -10,7 +10,6 @@ import { Platform, ScrollView, Share, Text, View } from "react-native";
 import { useTable } from "tinybase/ui-react";
 
 import MyView from "@/components/MyView";
-import MyHeader from "@/components/MyHeader";
 import MyButton from "@/components/MyButton";
 import MyInput from "@/components/MyInput";
 import Card from "@/components/Card";
@@ -82,7 +81,6 @@ export default function Admin() {
       safe={true}
       className="flex-1 bg-light-background dark:bg-dark-background"
     >
-      <MyHeader />
       <ScrollView
         contentContainerStyle={{ padding: 16, gap: 16, alignItems: "center" }}
         showsVerticalScrollIndicator={false}

--- a/app/feedback.jsx
+++ b/app/feedback.jsx
@@ -5,7 +5,6 @@ import { Linking, ScrollView, Text, View } from "react-native";
 import { router } from "expo-router";
 
 import MyView from "@/components/MyView";
-import MyHeader from "@/components/MyHeader";
 import MyButton from "@/components/MyButton";
 import MyInput from "@/components/MyInput";
 import Card from "@/components/Card";
@@ -75,7 +74,6 @@ export default function Feedback() {
       safe={true}
       className="flex-1 bg-light-background dark:bg-dark-background"
     >
-      <MyHeader />
       <ScrollView
         contentContainerStyle={{ padding: 16, gap: 16, alignItems: "center" }}
         showsVerticalScrollIndicator={false}

--- a/app/roadmap.jsx
+++ b/app/roadmap.jsx
@@ -3,7 +3,6 @@
 import { ScrollView, Text, View } from "react-native";
 
 import MyView from "@/components/MyView";
-import MyHeader from "@/components/MyHeader";
 import Card from "@/components/Card";
 import SectionLabel from "@/components/SectionLabel";
 
@@ -44,7 +43,6 @@ export default function Roadmap() {
       safe={true}
       className="flex-1 bg-light-background dark:bg-dark-background"
     >
-      <MyHeader />
       <ScrollView
         contentContainerStyle={{ padding: 16, gap: 16, alignItems: "center" }}
         showsVerticalScrollIndicator={false}

--- a/docs/08-design-tokens.md
+++ b/docs/08-design-tokens.md
@@ -283,6 +283,22 @@ Rótulo de seção dentro de card. Composição:
 
 Uso: "MÉTRICAS DE HOJE", "UTILITÁRIOS", "HISTÓRICO", "CATEGORIA (OPCIONAL)"…
 
+### `MyHeader` — [components/MyHeader.jsx](../components/MyHeader.jsx)
+
+Faixa horizontal de **chips das 5 métricas** (água, sono, alimentação, exercício, estudo). Clicar num chip navega pra tela de registro daquela métrica; clicar num chip já selecionado volta pra Home.
+
+**Papel semântico:** atalho pra registrar métrica. Só faz sentido em contextos onde o usuário está prestes a registrar uma métrica ou já registrou uma.
+
+**Onde usar:**
+
+- `app/index.jsx` (Home — hub de acesso rápido)
+- `app/history.jsx` (do histórico se pula direto pra registrar)
+- `components/metrics/MetricScreen.jsx` (switch entre métricas)
+
+**Onde NÃO usar** (chips seriam ruído sem contexto):
+
+- `app/admin.jsx`, `app/feedback.jsx`, `app/roadmap.jsx` — essas telas ativam o header nativo do Expo Router (`headerShown: true` na `Stack.Screen` do `app/_layout.jsx`) que fornece título + back arrow.
+
 ### `FieldLabel` — [components/FieldLabel.jsx](../components/FieldLabel.jsx)
 
 Rótulo de campo de formulário. Composição:


### PR DESCRIPTION
Item **\"Revisar o \`MyHeader\`\"** do M5. Fecha #178.

Resolve o papel do §5 da auditoria: \`MyHeader\` (faixa de chips das 5 métricas) aparecia em telas onde chips seriam ruído.

## Escopo

**Mantém \`<MyHeader />\` em:**
- \`app/index.jsx\` (Home — hub)
- \`app/history.jsx\` (metric-adjacent)
- \`components/metrics/MetricScreen.jsx\` (switch entre métricas)

**Remove \`<MyHeader />\` de:**
- \`app/admin.jsx\`, \`app/feedback.jsx\`, \`app/roadmap.jsx\`

Essas 3 telas ganham o header nativo do Expo Router (\`headerShown: true\` na \`Stack.Screen\` do \`app/_layout.jsx\`) com **título** (já definido: \"Roadmap\", \"Feedback\", \"Admin\") + **back arrow** — resolve o gap de navegação que o \`headerShown: false\` global criava sem introduzir componente novo.

## Doc

\`docs/08-design-tokens.md\` — nova seção \`MyHeader\` na \"Componentes derivados\" com o papel semântico (metric chips), onde usar, onde NÃO usar, e a política do Stack header nativo pras telas do segundo grupo.

## Saldo

5 arquivos, +31/-9 (a maior parte é doc).

## Fora de escopo

- Rota 1 (dividir \`MyHeader\` em \`MetricChips\` + \`AppHeader\`) — sem sinal claro de que precisa
- Identidade visual (tema/ícones) — item próprio do M5
- Estilizar o Stack header além do default — se aparecer regressão visual, ajusta pontualmente

## Test plan

- [ ] Web (preview Vercel):
  - [ ] Home / Histórico / Métrica (qualquer): MyHeader (chips) presente igual ao main
  - [ ] Admin (\`/admin\`): sem chips, com header nativo do Expo Router mostrando \"Admin\" e back arrow que retorna pra Home
  - [ ] Feedback: sem chips, header nativo com \"Feedback\" + back arrow
  - [ ] Roadmap: sem chips, header nativo com \"Roadmap\" + back arrow
- [ ] Dark mode: header nativo responde ao tema
- [ ] CI verde