### PR TITLE
feat(brand): identidade visual — Parte A (nome, tagline, splash)

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
   "expo": {
-    "name": "backOnTrack",
+    "name": "Back on Track",
     "slug": "backOnTrack",
     "scheme": "backontrack",
     "version": "1.0.0",
@@ -18,7 +18,7 @@
     "splash": {
       "image": "./assets/splash-icon.png",
       "resizeMode": "contain",
-      "backgroundColor": "#ffffff"
+      "backgroundColor": "#F8F9FA"
     },
     "ios": {
       "supportsTablet": true,

--- a/app/index.jsx
+++ b/app/index.jsx
@@ -159,6 +159,12 @@ export default function Home() {
             {ENV.bundle ? ` · ${ENV.bundle}` : ""}
           </Text>
         </Card>
+
+        {/* Wordmark discreto — marca presente na tela principal sem competir
+            com o conteúdo. Ver docs/08-design-tokens.md § Identidade visual. */}
+        <Text className="text-center text-xs text-light-text opacity-50 dark:text-dark-text">
+          Back on Track · de volta aos trilhos, um registro por vez
+        </Text>
       </ScrollView>
     </MyView>
   );

--- a/docs/08-design-tokens.md
+++ b/docs/08-design-tokens.md
@@ -338,3 +338,60 @@ Uso:
 ```
 
 Rationale: `opacity-40` (0.4) alinha com convenção iOS e resolve §7 da auditoria — antes cada tela reinventava (`0.4` vs `opacity-50`), com o visual e o bloqueio de `onPress` desconectados. Agora é um contrato só.
+
+---
+
+## Identidade visual
+
+O sistema até aqui é técnico (tokens de raio, tipografia, cor por papel). Esta seção fecha a parte **de marca**: nome, tagline, metáfora, tom de voz — e como esses tokens já são também escolhas de identidade.
+
+### Nome e slug
+
+- **Nome (display):** "Back on Track" — o que aparece no launcher/browser tab, no wordmark da UI, na documentação e na comunicação com testers.
+- **Slug técnico:** `backOnTrack` — identificador interno do Expo/EAS (`app.json`, `bundleIdentifier`, `package`, `projectId`). **Não mexer** — mudar quebra deploy/OTA/store.
+
+### Tagline
+
+> **De volta aos trilhos, um registro por vez.**
+
+A promessa é a **retomada**: o app é pra quem já saiu da rotina e quer voltar, não pra quem quer otimizar. Usado no wordmark do rodapé da Home e no Roadmap. Quando aparecer em novo contexto, essa é a versão canônica.
+
+### Metáfora
+
+**Trilhos, estrada, sinalização de trânsito.** O nome sugere caminho de volta; `assets/trecho-em-obras.png` (placa laranja de "trecho em obras") já sinaliza a direção. Qualquer ilustração/ícone/motivo gráfico futuro deve conversar com esse universo — sem forçar (não precisa de trilhos literais em tudo).
+
+### Tom de voz
+
+- **Gentileza da retomada**, não exigência. "Registrado", "hoje", "métricas do dia". Nunca "meta cumprida", "falhou", "streak quebrado".
+- Verbos no infinitivo pra ação do usuário ("Alternar tema", "Limpar todos os dados", "Enviar feedback") — não imperativo pesado ("ALTERE TUDO").
+- Erro é conversado, não julgado: "Não consegui enviar (…). Tenta de novo em instantes." (feedback.jsx).
+
+### Paleta como marca
+
+Os tokens de cor já são decisões semânticas ([seção Cor](#cor-bg--text----fatia-5)); ganham aqui também um significado de identidade:
+
+| Token       | Hex       | Marca                                                            |
+| ----------- | --------- | ---------------------------------------------------------------- |
+| `primary`   | `#2E5A88` | Navy da **confiança/estabilidade** — o "chão firme" da retomada  |
+| `secondary` | `#4CAF50` | Verde da **retomada positiva** — selecionado, ativo, nota máxima |
+| `danger`    | `#F44336` | Vermelho da **exceção** — só destrutivo/erro, reservado          |
+
+Superfícies (`light-background`, `dark-background`) são neutras por design — o protagonismo visual fica pros dados, não pra decoração.
+
+### Onde a marca aparece na UI
+
+- Launcher / browser tab: nome "Back on Track" (`app.json`)
+- Splash: fundo `#F8F9FA` (mesmo do app light) + splash-icon (Parte B — placeholder do Expo hoje)
+- **Home:** wordmark discreto no rodapé da tela ("Back on Track · de volta aos trilhos, um registro por vez"), abaixo do card Utilitários
+- **Roadmap:** título + tagline no primeiro card ("Back on Track" + "De volta aos trilhos, um registro por vez.")
+
+### Parte B — pendente
+
+Assets visuais ainda são template default do Expo:
+
+- `assets/icon.png` — ícone do app (iOS, launcher)
+- `assets/adaptive-icon.png` — foreground do adaptive icon Android
+- `assets/splash-icon.png` — logo/ícone do splash
+- `assets/favicon.png` — favicon web
+
+Substituir cada um exige arte real (design tool / IA generativa consciente / designer). Card no ambiente rastreia. Enquanto Parte B não pousa, o splash mostra o template Expo sobre fundo `#F8F9FA` — legível, sem estranheza, mas ainda não é a marca.


### PR DESCRIPTION
Item **\"Identidade visual do Back on Track\"** do M5, **Parte A** (o que dá pra fazer sem design tool). Fecha #181.

Parte B (assets — icon/adaptive/splash/favicon) fica como card no ambiente, sem bloquear o item de virar ✅ na Parte A.

## O que muda

- **\`app.json\`** — \`name: \"Back on Track\"\` (display no launcher/browser tab). Slug/bundleId/package/projectId **intactos** (mudar quebra deploy/OTA/store). \`splash.backgroundColor\` de \`#ffffff\` → \`#F8F9FA\` (mesmo do \`Colors.light.background\`) — cor intencional, sem se comprometer com paleta forte antes do icon real.
- **\`app/index.jsx\`** — wordmark discreto no rodapé da Home, abaixo do card Utilitários: \`Back on Track · de volta aos trilhos, um registro por vez\` em \`text-xs opacity-50\`. Marca presente na tela principal sem competir com o conteúdo.
- **\`docs/08-design-tokens.md\`** — nova seção \"Identidade visual\" com:
  - Nome (display) + slug técnico (não mexer)
  - Tagline canônica (\"De volta aos trilhos, um registro por vez.\")
  - Metáfora — trilhos/estrada/sinalização, alinhado com \`assets/trecho-em-obras.png\`
  - Tom de voz — gentileza da retomada, não exigência
  - Paleta como marca — cada token de cor ganha nota de identidade além do papel semântico
  - Onde a marca aparece na UI
  - Parte B pendente listada com cada asset

## Saldo

3 arquivos, +65/-2 (a maior parte é doc).

## Fora de escopo

- **Parte B** — arte visual (icon.png, adaptive-icon.png, splash-icon.png, favicon.png). Card no ambiente.
- Mexer no slug ou IDs de infra — quebra deploy/OTA.
- Refatorar Colors.js — os valores já são canônicos.

## Test plan

- [ ] Web (preview Vercel):
  - [ ] Home: wordmark visível abaixo do card Utilitários, discreto e centralizado
  - [ ] Dark mode: wordmark legível também
- [ ] \`app.json\`:
  - [ ] EAS/OTA deploy ainda funcionam (Vercel build passa == 90% de garantia; \`slug\`/IDs não mudaram)
- [ ] CI verde