### PR TITLE
fix(ui): fixa altura do MyHeader pra evitar stretch na transição

### DIFF
--- a/components/MyHeader.jsx
+++ b/components/MyHeader.jsx
@@ -34,11 +34,19 @@ export default function MyHeader() {
   return (
     <ScrollView
       horizontal={true}
-      className="grow-0 bg-light-background p-3 dark:bg-dark-background"
+      // Altura fixa evita o stretch visual durante a transição entre rotas:
+      // sem `h-16`, o ScrollView herdava altura intrínseca dos filhos (chip +
+      // shadow) e reflowava a cada re-render/navigate.
+      // `shrink-0` impede que telas com muito conteúdo (Home) espremam o header
+      // via flex-shrink default e invadam a área dos chips.
+      className="h-16 shrink-0 grow-0 bg-light-background p-3 dark:bg-dark-background"
     >
       {Object.entries(CATEGORY_MAP).map(([index, category]) => (
         <Button
-          className="mx-4"
+          // `h-10` trava a altura do chip: sem isso, o RN Web re-mede o
+          // Pressable ao trocar bg-primary ↔ bg-secondary e o chip pisca de
+          // tamanho a cada seleção. 40px casa com `text-base` + `py-2`.
+          className="mx-4 h-10"
           key={index}
           title={category.displayName}
           isSelected={selectedButton === index}

--- a/docs/08-design-tokens.md
+++ b/docs/08-design-tokens.md
@@ -299,6 +299,14 @@ Faixa horizontal de **chips das 5 métricas** (água, sono, alimentação, exerc
 
 - `app/admin.jsx`, `app/feedback.jsx`, `app/roadmap.jsx` — essas telas ativam o header nativo do Expo Router (`headerShown: true` na `Stack.Screen` do `app/_layout.jsx`) que fornece título + back arrow.
 
+**Altura travada em três camadas:** o `ScrollView` horizontal usa `h-16 shrink-0` (64px, não cede) e o chip usa `h-10` (40px) — os dois casam com o `p-3` (24px) vertical do ScrollView (`64 - 24 = 40`). Sem essas fixações, três bugs visuais aconteciam:
+
+- Sem `h-16` no ScrollView, a faixa herdava a altura intrínseca dos filhos e reflowava a cada re-render/`router.navigate`, esticando visualmente durante a transição de rota.
+- Sem `h-10` no chip, o RN Web re-media o `Pressable` ao trocar `bg-primary ↔ bg-secondary` e o chip piscava de tamanho a cada seleção — mesmo sem qualquer mudança de padding/tipografia.
+- Sem `shrink-0` no ScrollView, telas com muito conteúdo (Home) espremiam o header via `flex-shrink: 1` default do flex column pai, e o padding do primeiro card visualmente invadia a área dos chips. Formulários curtos (MetricScreen) não expunham o bug.
+
+Se um dia mudar o padding do ScrollView ou a tipografia do chip, revisitar os três juntos.
+
 ### `FieldLabel` — [components/FieldLabel.jsx](../components/FieldLabel.jsx)
 
 Rótulo de campo de formulário. Composição:


### PR DESCRIPTION
## Contexto

Bug visual pré-existente que ficou aparente no preview do #179 (não é regressão daquele PR — o `MyHeader` não foi tocado lá). Ao tocar um chip de métrica no `MyHeader`, o cabeçalho exibia um efeito de "esticada" durante a transição de rota.

## Causa

O `<ScrollView horizontal>` do `MyHeader` não tinha altura explícita — herdava a altura intrínseca dos filhos (chip com `py-2` + shadow) e reflowava a cada re-render/`router.navigate`, produzindo o stretch.

## Fix

Altura fixa `h-16` (64px) no `ScrollView`. Cabe exatamente o chip (~40px) + `p-3` vertical (24px), então o visual permanece o mesmo — só ganha estabilidade durante a transição.

## Validação

- Testado no web (dev server) nas 3 telas com `MyHeader`: Home, Histórico e MetricScreen.
- Suite de testes: 45/45 ✅
- Lint local (Prettier, ESLint, tsc): ✅
- Doc `docs/08-design-tokens.md` atualizado com a decisão na seção `MyHeader`.

## Fora de escopo

- `MyMonthHeader` (no mesmo arquivo) tem estrutura similar e provavelmente o mesmo bug latente — deixado pra follow-up caso apareça.