### PR TITLE
chore(cleanup): remove MyMonthHeader (dead code órfão)

### DIFF
--- a/components/MyHeader.jsx
+++ b/components/MyHeader.jsx
@@ -56,31 +56,3 @@ export default function MyHeader() {
     </ScrollView>
   );
 }
-export function MyMonthHeader({ onMonthSelect }) {
-  const [selectedMonth, setSelectedMonth] = useState(new Date().getMonth());
-
-  const months = new Array(12).fill(0).map((_, i) => {
-    return new Date(`${i + 1}/1`).toLocaleDateString(undefined, {
-      month: "long",
-    });
-  });
-
-  function handleButtonSelection(index) {
-    setSelectedMonth(index);
-    onMonthSelect?.(index);
-  }
-
-  return (
-    <ScrollView horizontal={true} className="w-full grow-0 bg-transparent p-3">
-      {months.map((month, index) => (
-        <Button
-          className="mx-4"
-          key={index}
-          title={month.toUpperCase().substring(0, 3)}
-          isSelected={selectedMonth === index}
-          onPress={() => handleButtonSelection(index)}
-        />
-      ))}
-    </ScrollView>
-  );
-}


### PR DESCRIPTION
Fecha #185.

## Contexto

`MyMonthHeader` era exportado por `components/MyHeader.jsx` mas não tinha nenhum importer no repo (grep confirmou). Foi introduzido em 176a0a1 (setembro/2025) junto com a arquitetura antiga de histórico por métrica (`app/(history)/water.jsx` etc.), que depois foi substituída por `app/history.jsx` (histórico único por data) — e o componente ficou órfão.

## Por que remover em vez de consertar

O #184 fixou 3 travas de altura no `MyHeader` pra evitar pisca visual. O `MyMonthHeader` tem estrutura idêntica e sofreria dos mesmos bugs, mas como ninguém o usa, aplicar o fix é pura fricção. Manter o padrão bugado no repo convida cópia por copiar-colar.

## Validação

- `MyHeader` default preservado intacto.
- Grep pós-remoção: nenhuma referência restante a `MyMonthHeader` no repo.
- Prettier, ESLint, tsc, jest 45/45 ✅ local.

## Delta

- `components/MyHeader.jsx`: −28 linhas (remoção do `export function MyMonthHeader`).