### PR TITLE
docs: adicionar CONTRIBUTING.md com convenções de idioma

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Contribuindo — Back on Track
+
+Guia curto pra manter consistência entre contribuidores (humanos e agentes).
+
+## Convenções de idioma
+
+O repositório usa **dois idiomas** de forma deliberada. A regra de qual vai onde:
+
+### Inglês
+
+- **Nome de branch:** `<tipo>/<N>-<descrição-em-inglês>`
+  - Exemplos: `feat/80-metric-screen-base`, `fix/72-water-history-crash`, `refactor/154-tokens-radius`, `docs/187-contributing-conventions`
+- **Mensagem de commit:** conventional commits em inglês.
+  - Exemplos: `fix(ui): shorten dark border`, `refactor(ui): canonical radius scale`, `docs(readme): fix typo`
+  - `commitlint` valida o formato (`.commitlintrc.*` / husky). O `subject` deve começar em **minúsculo** — evite começar com nome de componente (`MyButton`, `MetricScreen`); parafraseie (`disabled state on MyButton` em vez de `MyButton disabled`).
+- **Identificadores de código novos:** inglês como API exportada (`get`, `add`, `getToday`, `useRegistrosPersistencia`). Se um arquivo legado usa PT (`hidratar`, `linhas`), respeite o estilo local até que ele seja refatorado.
+
+### Português
+
+- **Título de issue / PR:** português.
+- **Corpo/descrição de PR:** português.
+- **Comentários no código:** português.
+- **Strings de UI:** português (o app é PT-BR).
+- **Documentação em `docs/`:** português.
+
+### Rationale
+
+Branch e commit são a **interface técnica do repo** — aparecem em qualquer plataforma (GitHub UI, `git log`, notificações, releases) e ficam expostos a qualquer contribuidor futuro, incluindo ferramentas automatizadas. O restante (issue, PR, comentário, UI, doc) é conteúdo do **produto** ou da **discussão**, e mantém a voz PT-BR do projeto.
+
+## Fluxo de trabalho
+
+Cada mudança deveria passar pelo ciclo:
+
+1. **Issue** — registrar o trabalho antes de codar (título/corpo em português)
+2. **Branch** — criar a partir de `main` atualizada; nome em inglês
+3. **Implementar** — código, testes, doc
+4. **Commit** — conventional commits em inglês
+5. **PR** — abrir contra `main` (título/corpo em português); aguardar CI verde
+6. **Merge** — squash + delete branch depois que o CI passar (e revisão visual, quando aplicável)
+7. **Fechar issue** — com um comentário do que foi entregue
+
+`main` tem proteção: sem push direto, exige PR e CI verde. Não use `--force` sem alinhar antes.
+
+## Rodando local
+
+```bash
+npm install
+npm start          # Expo dev server (mobile via QR + web)
+npm test           # jest-expo
+npm run lint:eslint:check
+npm run lint:prettier:check
+npm run lint:types:check
+```
+
+## Onde encontrar mais
+
+- Visão do produto, escopo, ADRs e roadmap: [`docs/`](docs/)
+- Design system (tokens, componentes): [`docs/08-design-tokens.md`](docs/08-design-tokens.md)
+- Estratégia de testes: [`docs/06-guia-testes.md`](docs/06-guia-testes.md)


### PR DESCRIPTION
Fecha #187.

Formaliza a convenção de idiomas do repo num \`CONTRIBUTING.md\` na raiz. A regra existia só no conhecimento tribal (memory local, cabeça dos contribuidores) e por isso derivou: todo o histórico recente de commits acabou em português quando o padrão era inglês.

## O que entra

\`CONTRIBUTING.md\` na raiz com:

- **Convenções de idioma** — inglês pra branch e commit; português pra issue/PR/comentário/UI/docs. Com exemplos e rationale (branch/commit = interface técnica do repo; resto = voz do produto).
- **Fluxo de trabalho** resumido (issue → branch → PR → merge).
- **Comandos locais** essenciais + links pros docs.

## Meta

Este é o **primeiro commit em inglês** pós-formalização — o próprio PR já segue a nova regra (branch \`docs/187-contributing-conventions\` em inglês; commit \`docs: add CONTRIBUTING.md ...\` em inglês; título/corpo do PR em português).

## Fora de escopo

- Reescrever histórico de commits — commits mergeados na main são imutáveis; a regra só vale daqui pra frente.
- Escrever guia completo de contribuição (setup detalhado, code review, etc.) — só a parte de idioma + fluxo básico agora.

## Test plan

- [ ] \`CONTRIBUTING.md\` renderiza legível no GitHub (aparece na aba \"Contributing\" e no link do sidebar)
- [ ] CI verde (Prettier/ESLint/Types/Test/commitlint) — o próprio commitlint valida que o commit deste PR segue o formato inglês