### PR TITLE
docs(roadmap): marca escolha do transporte de sync no M6 (ADR-009)

### DIFF
--- a/docs/04-roadmap-milestones.md
+++ b/docs/04-roadmap-milestones.md
@@ -94,7 +94,7 @@ Esta milestone não existia no plano original — ela nasceu do diagnóstico do 
 
 **Objetivo de saída:** os dados sobrevivem a perda/troca de aparelho.
 
-- ⬜ Escolher e configurar o Synchronizer do TinyBase (WebSocket próprio, PowerSync, ou outro transporte)
+- 🟡 Escolher e configurar o Synchronizer do TinyBase (WebSocket próprio, PowerSync, ou outro transporte). **Escolha feita** na ADR-009 (#192, `docs/03-decisoes-tecnicas.md`): WebSocket próprio no homeserver via `createWsSynchronizer` + `createWsServer` (Node/Docker), cliente migra `Store` → `MergeableStore`. Alternativas (PowerSync, Yjs, só backup, Cloudflare Durable Objects) descartadas com motivo. **Configurar** vira próxima fatia
 - ⬜ Autenticação/identificação mínima do dispositivo, se o transporte exigir
 - ⬜ Validar sync em cenários reais: offline → online, dois dispositivos, reinstalação
 - ⬜ Ajustar regras/permissões do lado do transporte escolhido


### PR DESCRIPTION
Reflete o merge do #193 no roadmap: item de "escolher e configurar Synchronizer" do M6 vira 🟡 — escolha feita na ADR-009, configurar vira próxima fatia.

## Test plan

- [ ] Parser do roadmap continua verde
- [ ] CI verde