### PR TITLE
refactor(store): migra Store → MergeableStore (pré-req do M6)

### DIFF
--- a/infra/database.js
+++ b/infra/database.js
@@ -1,10 +1,14 @@
 // @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
-import { createStore } from "tinybase";
+import { createMergeableStore } from "tinybase";
 
 const TABLE = "records";
 const TESTERS = "testers";
 
-export const store = createStore().setTablesSchema({
+// MergeableStore em vez de Store puro: pré-requisito de qualquer sync (M6,
+// ADR-009). Carrega metadata de CRDT pra merge determinístico entre devices.
+// Persisters atuais (expo-sqlite em modo JSON, browser localStorage) já
+// suportam MergeableStore sem mudar. Ver docs/03-decisoes-tecnicas.md.
+export const store = createMergeableStore().setTablesSchema({
   [TABLE]: {
     type: { type: "string" },
     date: { type: "string" },


### PR DESCRIPTION
Fatia 1 da implementação do M6. Fecha #195.

Depois da ADR-009 (#193) travar a escolha do transporte (WebSocket próprio no homeserver), esta fatia migra só o client — sem server, sem sync real ainda, mas com o pré-requisito de qualquer synchronizer no lugar.

## O que muda

- \`infra/database.js\` — \`createStore()\` → \`createMergeableStore()\` (import + call, +6/-2 linhas incluindo o comentário do porquê)

Nenhum outro arquivo muda. Nem consumidores (\`useTable\`, \`add\`, \`get\`, etc.), nem persister nativo, nem persister web.

## Por que os persisters continuam funcionando

Ambos suportam \`MergeableStore\` no modo JSON:

- \`persister-expo-sqlite\` — modo JSON é o default quando o 3º arg do \`createExpoSqlitePersister\` é uma string (\`\"back_on_track\"\` no nosso caso)
- \`persister-browser\` (\`createLocalPersister\`) — sempre JSON

Fonte: [createExpoSqlitePersister docs](https://tinybase.org/api/persister-expo-sqlite/functions/creation/createexposqlitepersister/).

## Migração de dados dos testers

Testers com o app instalado recebem esta migração via OTA. No primeiro load pós-update, \`MergeableStore.startAutoLoad()\` lê o JSON escrito pelo \`Store\` regular e trata os dados existentes como estado pré-existente, dando CRDT metadata default (timestamps atuais). **Sem perda de dados.** O histórico de merge começa desse ponto.

## Fora de escopo

- Server WS (próxima fatia)
- Client conecta no server (fatia seguinte)
- Auth (fatia própria)

## Test plan

- [ ] CI verde (todos os 45 testes, incluindo o de corrida da persistência #108 que exercita \`startAutoLoad\`)
- [ ] Web (preview Vercel):
  - [ ] App abre normalmente
  - [ ] Registrar métrica funciona
  - [ ] Excluir do histórico funciona
  - [ ] Reload preserva os dados
- [ ] Nenhuma regressão visual (nada muda na UI)