### PR TITLE
test(sync): smoke multi-client (valida sync A↔B via server público)

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,8 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "smoke": "node smoke-client.js"
+    "smoke": "node smoke-client.js",
+    "smoke:multi": "node smoke-two-clients.js"
   },
   "engines": {
     "node": ">=20"

--- a/server/smoke-two-clients.js
+++ b/server/smoke-two-clients.js
@@ -1,0 +1,81 @@
+// @ts-nocheck -- código Node do server, fora do tsc do app (ADR-002).
+// Smoke test de sync entre 2 clients (M6 fatia 3, #202).
+//
+// Diferente do smoke-client.js (self round-trip: escreve → desconecta →
+// reconecta → lê próprio valor), aqui abrimos 2 clients SIMULTANEAMENTE no
+// mesmo room e provamos que um vê a escrita do outro via server. É o teste
+// que responde "sync funciona entre dois devices?" — sem depender do app RN.
+//
+//   ROOM=<uuid-de-testes> URL=wss://backontrack-sync.mhdn.com.br node smoke-two-clients.js
+//
+// Sai 0 se A→B e B→A propagaram; 1 se qualquer direção falhou.
+// SEMPRE passar ROOM único (não usar o roomId de nenhum tester real!).
+
+import { createMergeableStore } from "tinybase";
+import { createWsSynchronizer } from "tinybase/synchronizers/synchronizer-ws-client";
+import { WebSocket } from "ws";
+
+const URL = process.env.URL ?? "ws://localhost:8787";
+const ROOM = process.env.ROOM ?? `smoke-multi-${Date.now()}`;
+const PROPAGATION_MS = Number(process.env.PROPAGATION_MS ?? 2000);
+
+const wsUrl = `${URL.replace(/\/+$/, "")}/${ROOM}`;
+
+function log(who, ...args) {
+  console.log(`[smoke-multi ${who}]`, ...args);
+}
+function fail(msg) {
+  console.error("[smoke-multi] ✖", msg);
+  process.exit(1);
+}
+
+async function connect(label) {
+  const store = createMergeableStore();
+  const sync = await createWsSynchronizer(store, new WebSocket(wsUrl));
+  await sync.startSync();
+  log(label, "connected");
+  return [store, sync];
+}
+
+log("root", `URL=${wsUrl}`);
+log("root", `ROOM=${ROOM}`);
+
+// Abrir A e B ao mesmo tempo, no mesmo room.
+const [[aStore, aSync], [bStore, bSync]] = await Promise.all([
+  connect("A"),
+  connect("B"),
+]);
+
+// Deixar A e B trocarem estado inicial antes de qualquer escrita.
+await new Promise((r) => setTimeout(r, PROPAGATION_MS));
+
+// A escreve; B deve ver.
+const fromA = `A@${Date.now()}`;
+aStore.setCell("sync-test", "row-A", "value", fromA);
+log("A", `wrote ${fromA}`);
+await new Promise((r) => setTimeout(r, PROPAGATION_MS));
+const seenByB = bStore.getCell("sync-test", "row-A", "value");
+log("B", `sees row-A = ${JSON.stringify(seenByB)}`);
+if (seenByB !== fromA) {
+  await aSync.destroy();
+  await bSync.destroy();
+  fail(`A→B falhou: B esperava ${fromA}, recebeu ${JSON.stringify(seenByB)}`);
+}
+
+// B escreve; A deve ver. Prova bidirecionalidade.
+const fromB = `B@${Date.now()}`;
+bStore.setCell("sync-test", "row-B", "value", fromB);
+log("B", `wrote ${fromB}`);
+await new Promise((r) => setTimeout(r, PROPAGATION_MS));
+const seenByA = aStore.getCell("sync-test", "row-B", "value");
+log("A", `sees row-B = ${JSON.stringify(seenByA)}`);
+if (seenByA !== fromB) {
+  await aSync.destroy();
+  await bSync.destroy();
+  fail(`B→A falhou: A esperava ${fromB}, recebeu ${JSON.stringify(seenByA)}`);
+}
+
+await aSync.destroy();
+await bSync.destroy();
+log("root", "✓ A↔B sync OK");
+process.exit(0);


### PR DESCRIPTION
Adiciona `server/smoke-two-clients.js` (npm `smoke:multi`), que abre 2 clients TinyBase SIMULTANEAMENTE no mesmo room via TLS público e valida propagação bidirecional (A→B e B→A). Preenche a validação "sync entre 2 devices" do M6 sem depender do app RN.

## Diferença do `smoke-client.js` atual

O `smoke-client.js` é self round-trip (escreve → desconecta → reconecta → lê próprio valor). Prova persistência server-side mas NÃO propagação entre clients. `smoke:multi` fecha esse gap: 2 conexões concorrentes no mesmo room, cada uma escreve um valor, cada uma lê o do outro.

## Rodado agora contra produção

```
[smoke-multi root] URL=wss://backontrack-sync.mhdn.com.br/smoke-multi-1785368604885
[smoke-multi A] connected
[smoke-multi B] connected
[smoke-multi A] wrote A@1785368608274
[smoke-multi B] sees row-A = "A@1785368608274"
[smoke-multi B] wrote B@1785368610281
[smoke-multi A] sees row-B = "B@1785368610281"
[smoke-multi root] ✓ A↔B sync OK
```

## Uso

```bash
cd server
URL=wss://backontrack-sync.mhdn.com.br npm run smoke:multi
```

Room default é `smoke-multi-${Date.now()}` (throw-away, isolado). NUNCA passar o roomId de tester real.

## Escopo

- **Não roda no CI** (sob demanda; depende de rede externa).
- **Não** substitui a validação com o app RN em cenários reais (offline→online, reinstall) — esse item continua no M6.

## Test plan

- [x] Rodado contra `wss://backontrack-sync.mhdn.com.br` — passou.
- [x] Prettier limpo.
- [x] Eslint limpo (novo arquivo tem `@ts-nocheck` como o resto do `server/`).