### PR TITLE
feat(auth): magic link login via Supabase (M6 fatia A, #207)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,24 @@
+# Env vars usadas fora do Docker (o server WS de sync tem próprio ambiente).
+# Copie pra `.env` (gitignored) e preencha. Reinicie Metro após mudar.
+
+# --- Evolution API (sender de notificação dos testers) ---
+# Ver docs/memoria: evolution-api-testers-stack. Só o admin usa.
+EVO_URL=http://localhost:8085
+EVO_INSTANCE="backontrack"
+EVO_APIKEY=
+
+# --- Supabase Auth (M6 auth fatia A, ADR-010) ---
+# Dashboard: https://app.supabase.com/project/<seu-projeto>/settings/api
+# EXPO_PUBLIC_* vai pro bundle do app; anon key é public por design, sem
+# problema. NÃO cole aqui o JWT Secret (esse vive no server WS na fatia B).
+EXPO_PUBLIC_SUPABASE_URL=
+EXPO_PUBLIC_SUPABASE_ANON_KEY=
+
+# --- Feedback screen (M3-5 Track B, #101) ---
+# Segredo compartilhado semi-público pra deter abuso casual do endpoint.
+# O PAT real da Vercel fica lá, não aqui.
+EXPO_PUBLIC_FEEDBACK_KEY=
+
+# --- Sync (M6 fatia 3, #202) — opcional ---
+# Padrão é wss://backontrack-sync.mhdn.com.br. String vazia desliga o sync.
+# EXPO_PUBLIC_SYNC_URL=

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,5 @@
 /.expo
 /node_modules
 /dist
+.env
+.env.*

--- a/app/_layout.jsx
+++ b/app/_layout.jsx
@@ -5,6 +5,7 @@ import { Stack } from "expo-router";
 import { View } from "react-native";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { useRegistrosPersistencia } from "@/infra/persistence";
+import { SessionProvider } from "@/infra/session";
 import { useRegistrosSync } from "@/infra/sync";
 import UpdateBanner from "@/components/UpdateBanner";
 
@@ -16,32 +17,46 @@ export default function RootLayout() {
 
   return (
     <SafeAreaProvider>
-      {/* View de raiz só pra ancorar o UpdateBanner sobre a rota atual. */}
-      <View className="flex-1">
-        <Stack screenOptions={{ headerShown: false }}>
-          <Stack.Screen name="index" options={{ title: "Hoje" }} />
-          {/* Roadmap/Feedback/Admin não têm relação com registro de métrica,
-              então não usam o MyHeader (faixa de chips). Ativam o header
-              nativo do Expo Router pra ganhar título + back arrow (#178). */}
-          <Stack.Screen
-            name="roadmap"
-            options={{ title: "Roadmap", headerShown: true }}
-          />
-          <Stack.Screen name="export" options={{ title: "Exportação" }} />
-          <Stack.Screen name="history" options={{ title: "Histórico" }} />
-          <Stack.Screen
-            name="feedback"
-            options={{ title: "Feedback", headerShown: true }}
-          />
-          {/* Rota de admin (testers) — acesso só por deep link backontrack://admin */}
-          <Stack.Screen
-            name="admin"
-            options={{ title: "Admin", headerShown: true }}
-          />
-          <Stack.Screen name="(metrics)" />
-        </Stack>
-        <UpdateBanner />
-      </View>
+      {/* SessionProvider envolve tudo (M6 auth fatia A, #207) — expõe a
+          sessão do Supabase pros filhos via useSession. Sync ainda anônimo
+          nesta fatia; JWT só vira gate na fatia B. */}
+      <SessionProvider>
+        {/* View de raiz só pra ancorar o UpdateBanner sobre a rota atual. */}
+        <View className="flex-1">
+          <Stack screenOptions={{ headerShown: false }}>
+            <Stack.Screen name="index" options={{ title: "Hoje" }} />
+            {/* Roadmap/Feedback/Admin não têm relação com registro de métrica,
+                então não usam o MyHeader (faixa de chips). Ativam o header
+                nativo do Expo Router pra ganhar título + back arrow (#178). */}
+            <Stack.Screen
+              name="roadmap"
+              options={{ title: "Roadmap", headerShown: true }}
+            />
+            <Stack.Screen name="export" options={{ title: "Exportação" }} />
+            <Stack.Screen name="history" options={{ title: "Histórico" }} />
+            <Stack.Screen
+              name="feedback"
+              options={{ title: "Feedback", headerShown: true }}
+            />
+            {/* Rota de admin (testers) — acesso só por deep link backontrack://admin */}
+            <Stack.Screen
+              name="admin"
+              options={{ title: "Admin", headerShown: true }}
+            />
+            <Stack.Screen
+              name="login"
+              options={{ title: "Entrar", headerShown: true }}
+            />
+            {/* Callback do magic link — headless, autopropulsão pra /. */}
+            <Stack.Screen
+              name="auth/callback"
+              options={{ title: "Autenticando", headerShown: false }}
+            />
+            <Stack.Screen name="(metrics)" />
+          </Stack>
+          <UpdateBanner />
+        </View>
+      </SessionProvider>
     </SafeAreaProvider>
   );
 }

--- a/app/auth/callback.jsx
+++ b/app/auth/callback.jsx
@@ -1,0 +1,78 @@
+// @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
+import { useEffect, useState } from "react";
+import { ActivityIndicator, ScrollView, Text } from "react-native";
+import { router, useLocalSearchParams } from "expo-router";
+
+import MyView from "@/components/MyView";
+import MyButton from "@/components/MyButton";
+import Card from "@/components/Card";
+
+import { supabase } from "@/infra/supabase";
+
+// Callback do magic link do Supabase (M6 auth fatia A, #207, ADR-010).
+// Deep link `backontrack://auth/callback?code=...` (native) OU
+// `https://<host>/auth/callback?code=...` (web) cai aqui — troca o code por
+// sessão via PKCE, redireciona pra /.
+
+export default function AuthCallback() {
+  const { code, error, error_description } = useLocalSearchParams();
+  const [status, setStatus] = useState("exchanging");
+  const [errorMsg, setErrorMsg] = useState("");
+
+  useEffect(() => {
+    // Supabase pode redirecionar com `?error=...` em vez de `?code=...`
+    // (ex: link expirado, config errada) — surface direto.
+    if (error) {
+      setErrorMsg(String(error_description ?? error));
+      setStatus("error");
+      return;
+    }
+    if (!code || !supabase) {
+      setErrorMsg("Link inválido ou sem código de autenticação.");
+      setStatus("error");
+      return;
+    }
+    supabase.auth
+      .exchangeCodeForSession(String(code))
+      .then(({ error: exchangeErr }) => {
+        if (exchangeErr) throw exchangeErr;
+        // SessionProvider vai pegar via onAuthStateChange — só voltar pra home.
+        router.replace("/");
+      })
+      .catch((e) => {
+        setErrorMsg(String(e?.message ?? e));
+        setStatus("error");
+      });
+  }, [code, error, error_description]);
+
+  return (
+    <MyView
+      safe={true}
+      className="flex-1 bg-light-background dark:bg-dark-background"
+    >
+      <ScrollView
+        contentContainerStyle={{ padding: 16, gap: 16, alignItems: "center" }}
+      >
+        {status === "exchanging" ? (
+          <Card className="gap-3 items-center">
+            <ActivityIndicator />
+            <Text className="text-base text-light-text dark:text-dark-text">
+              Autenticando…
+            </Text>
+          </Card>
+        ) : (
+          <Card className="gap-3">
+            <Text className="font-bold text-xl text-light-text dark:text-dark-text">
+              Não deu certo
+            </Text>
+            <Text className="text-sm text-danger">{errorMsg}</Text>
+            <MyButton
+              title="Tentar de novo"
+              onPress={() => router.replace("/login")}
+            />
+          </Card>
+        )}
+      </ScrollView>
+    </MyView>
+  );
+}

--- a/app/auth/callback.jsx
+++ b/app/auth/callback.jsx
@@ -27,22 +27,44 @@ export default function AuthCallback() {
       setStatus("error");
       return;
     }
-    if (!code || !supabase) {
-      setErrorMsg("Link inválido ou sem código de autenticação.");
+    if (!supabase) {
+      setErrorMsg("Auth não configurada.");
       setStatus("error");
       return;
     }
-    supabase.auth
-      .exchangeCodeForSession(String(code))
-      .then(({ error: exchangeErr }) => {
-        if (exchangeErr) throw exchangeErr;
-        // SessionProvider vai pegar via onAuthStateChange — só voltar pra home.
+    // Caminho A (PKCE): magic link veio com `?code=` — troca por sessão.
+    if (code) {
+      supabase.auth
+        .exchangeCodeForSession(String(code))
+        .then(({ error: exchangeErr }) => {
+          if (exchangeErr) throw exchangeErr;
+          router.replace("/");
+        })
+        .catch((e) => {
+          setErrorMsg(String(e?.message ?? e));
+          setStatus("error");
+        });
+      return;
+    }
+    // Caminho B (implícito, `#access_token=...`): o client parseia sozinho na
+    // init (detectSessionInUrl no web). Ouve o próximo evento de auth; se cair
+    // com sessão em até 3s, redireciona. Senão, o link mesmo era ruim.
+    const { data: sub } = supabase.auth.onAuthStateChange((_evt, session) => {
+      if (session) {
+        clearTimeout(timeoutId);
+        sub.subscription.unsubscribe();
         router.replace("/");
-      })
-      .catch((e) => {
-        setErrorMsg(String(e?.message ?? e));
-        setStatus("error");
-      });
+      }
+    });
+    const timeoutId = setTimeout(() => {
+      sub.subscription.unsubscribe();
+      setErrorMsg("Link inválido ou sem código de autenticação.");
+      setStatus("error");
+    }, 3000);
+    return () => {
+      clearTimeout(timeoutId);
+      sub.subscription.unsubscribe();
+    };
   }, [code, error, error_description]);
 
   return (

--- a/app/index.jsx
+++ b/app/index.jsx
@@ -14,6 +14,8 @@ import Card from "@/components/Card";
 import SectionLabel from "@/components/SectionLabel";
 
 import { clearAll, getToday, store } from "@/infra/database";
+import { useSession } from "@/infra/session";
+import { AUTH_ENABLED } from "@/infra/supabase";
 import { confirmAction } from "@/constants/dialogs";
 import { getEnvironmentInfo } from "@/constants/environment";
 import { CATEGORY_MAP } from "@/components/categoryUtils";
@@ -51,6 +53,7 @@ function MetricRow({ done, name, detail }) {
 
 export default function Home() {
   const { toggleColorScheme } = useColorScheme();
+  const { user, signOut } = useSession();
 
   // Assina a tabela: `useTable` re-renderiza a cada mudança nos registros —
   // inclusive quando o `startAutoLoad()` da persistência termina de carregar.
@@ -152,6 +155,23 @@ export default function Home() {
             title="Roadmap do projeto"
             onPress={() => router.navigate("/roadmap")}
           />
+          {/* Auth (fatia A do M6): botão condicional. Só aparece se as env
+              vars do Supabase estiverem configuradas — do contrário, o botão
+              não faria nada útil. Sync ainda anônimo nesta fatia. */}
+          {AUTH_ENABLED &&
+            (user ? (
+              <>
+                <Text className="pt-1 text-center text-xs text-light-text opacity-70 dark:text-dark-text">
+                  Logado como {user.email}
+                </Text>
+                <MyButton title="Sair" onPress={() => signOut()} />
+              </>
+            ) : (
+              <MyButton
+                title="Entrar"
+                onPress={() => router.navigate("/login")}
+              />
+            ))}
           {/* Versão visível pro tester saber (e reportar) em qual bundle está —
               o OTA troca o JS sem mudar a versão do app (#131). */}
           <Text className="pt-1 text-center text-xs text-light-text opacity-50 dark:text-dark-text">

--- a/app/login.jsx
+++ b/app/login.jsx
@@ -38,7 +38,13 @@ export default function Login() {
       if (error) throw error;
       setStatus("sent");
     } catch (e) {
-      setErrorMsg(String(e?.message ?? e));
+      // Loga o erro cru pra debug no console (AuthError vem com .status, .code
+      // e .message; alguns caminhos jogam objeto opaco onde só o console ajuda).
+      console.error("[login] signInWithOtp falhou:", e);
+      const parts = [e?.message, e?.code, e?.status]
+        .filter(Boolean)
+        .map(String);
+      setErrorMsg(parts.length ? parts.join(" · ") : "erro desconhecido");
       setStatus("error");
     }
   }

--- a/app/login.jsx
+++ b/app/login.jsx
@@ -1,0 +1,132 @@
+// @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
+import { useState } from "react";
+import * as Linking from "expo-linking";
+import { ScrollView, Text } from "react-native";
+import { router } from "expo-router";
+
+import MyView from "@/components/MyView";
+import MyButton from "@/components/MyButton";
+import MyInput from "@/components/MyInput";
+import Card from "@/components/Card";
+
+import { useSession } from "@/infra/session";
+import { AUTH_ENABLED, supabase } from "@/infra/supabase";
+
+// Login por magic link (M6 auth fatia A, #207, ADR-010).
+// Sync continua anônimo por baixo — só a fatia B passa a usar o JWT.
+
+export default function Login() {
+  const { user } = useSession();
+  const [email, setEmail] = useState("");
+  const [status, setStatus] = useState("idle"); // idle | sending | sent | error
+  const [errorMsg, setErrorMsg] = useState("");
+
+  const canSend = AUTH_ENABLED && status !== "sending" && email.includes("@");
+
+  async function handleSend() {
+    if (!canSend || !supabase) return;
+    setStatus("sending");
+    setErrorMsg("");
+    try {
+      // Linking.createURL cobre native (backontrack://) e web (https://origin).
+      // Ambos precisam estar no allowlist de Redirect URLs do Supabase.
+      const emailRedirectTo = Linking.createURL("/auth/callback");
+      const { error } = await supabase.auth.signInWithOtp({
+        email: email.trim(),
+        options: { emailRedirectTo },
+      });
+      if (error) throw error;
+      setStatus("sent");
+    } catch (e) {
+      setErrorMsg(String(e?.message ?? e));
+      setStatus("error");
+    }
+  }
+
+  return (
+    <MyView
+      safe={true}
+      className="flex-1 bg-light-background dark:bg-dark-background"
+    >
+      <ScrollView
+        contentContainerStyle={{ padding: 16, gap: 16, alignItems: "center" }}
+        keyboardShouldPersistTaps="handled"
+      >
+        {!AUTH_ENABLED ? (
+          <Card className="gap-2">
+            <Text className="font-bold text-xl text-light-text dark:text-dark-text">
+              Login indisponível
+            </Text>
+            <Text className="text-base text-light-text opacity-70 dark:text-dark-text">
+              O app não foi configurado com credenciais do Supabase
+              (EXPO_PUBLIC_SUPABASE_URL / EXPO_PUBLIC_SUPABASE_ANON_KEY). Isso é
+              esperado enquanto a fatia A do M6 auth não sobe pra você.
+            </Text>
+          </Card>
+        ) : user ? (
+          <Card className="gap-3">
+            <Text className="font-bold text-xl text-light-text dark:text-dark-text">
+              Já está logado
+            </Text>
+            <Text className="text-base text-light-text opacity-70 dark:text-dark-text">
+              {user.email}
+            </Text>
+            <MyButton
+              title="Voltar ao início"
+              onPress={() => router.navigate("/")}
+            />
+          </Card>
+        ) : status === "sent" ? (
+          <Card className="gap-3">
+            <Text className="font-bold text-2xl text-light-text dark:text-dark-text">
+              Verifique seu email 📬
+            </Text>
+            <Text className="text-base text-light-text opacity-70 dark:text-dark-text">
+              Enviamos um link mágico pra {email}. Toque no link do email pra
+              entrar — o app abre logado sozinho.
+            </Text>
+            <MyButton
+              title="Não recebi, enviar de novo"
+              onPress={() => setStatus("idle")}
+            />
+          </Card>
+        ) : (
+          <Card className="gap-4">
+            <Text className="font-bold text-2xl text-light-text dark:text-dark-text">
+              Entrar
+            </Text>
+            <Text className="text-sm text-light-text opacity-70 dark:text-dark-text">
+              Sem senha: mandamos um link pro seu email; abrindo o link, você
+              entra.
+            </Text>
+
+            <MyInput
+              label="Email"
+              placeholder="seu@email.com"
+              value={email}
+              onChangeText={setEmail}
+              containerClassName="w-full"
+              className="w-full"
+              autoCapitalize="none"
+              autoComplete="email"
+              keyboardType="email-address"
+            />
+
+            {status === "error" && (
+              <Text className="text-sm text-danger">
+                Não consegui enviar ({errorMsg}). Confere o email e tenta de
+                novo.
+              </Text>
+            )}
+
+            <MyButton
+              title={status === "sending" ? "Enviando…" : "Enviar magic link"}
+              onPress={handleSend}
+              disabled={!canSend}
+            />
+          </Card>
+        )}
+      </ScrollView>
+    </MyView>
+  );
+}

--- a/infra/session.js
+++ b/infra/session.js
@@ -1,0 +1,63 @@
+// @ts-nocheck -- context/session tipos vêm do Supabase; ADR-002 style.
+import { createContext, useContext, useEffect, useState } from "react";
+import { AUTH_ENABLED, supabase } from "./supabase";
+
+// Contexto de sessão do Supabase (M6 auth fatia A, #207, ADR-010).
+//
+// SessionProvider escuta `onAuthStateChange` do Supabase e expõe {session,
+// user, ready, signOut} pro resto do app. Se AUTH_ENABLED for false (env
+// não configurada), fica em modo pass-through: ready=true, session=null.
+
+const SessionContext = createContext({
+  session: null,
+  user: null,
+  ready: false,
+  signOut: async () => {},
+});
+
+export function SessionProvider({ children }) {
+  const [session, setSession] = useState(null);
+  // ready só vira true depois da 1ª leitura da sessão persistida — evita
+  // flash de "deslogado" na abertura pra quem já estava logado.
+  const [ready, setReady] = useState(!AUTH_ENABLED);
+
+  useEffect(() => {
+    if (!AUTH_ENABLED || !supabase) return;
+
+    let mounted = true;
+
+    supabase.auth.getSession().then(({ data }) => {
+      if (!mounted) return;
+      setSession(data.session);
+      setReady(true);
+    });
+
+    const { data: sub } = supabase.auth.onAuthStateChange((_event, s) => {
+      if (!mounted) return;
+      setSession(s);
+      setReady(true);
+    });
+
+    return () => {
+      mounted = false;
+      sub.subscription.unsubscribe();
+    };
+  }, []);
+
+  const value = {
+    session,
+    user: session?.user ?? null,
+    ready,
+    signOut: async () => {
+      if (supabase) await supabase.auth.signOut();
+    },
+  };
+
+  return (
+    <SessionContext.Provider value={value}>{children}</SessionContext.Provider>
+  );
+}
+
+export function useSession() {
+  return useContext(SessionContext);
+}

--- a/infra/supabase.js
+++ b/infra/supabase.js
@@ -1,0 +1,35 @@
+/* global process */
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { createClient } from "@supabase/supabase-js";
+import { Platform } from "react-native";
+
+// Cliente Supabase pra auth (M6 auth fatia A, #207, ADR-010).
+//
+// URL/ANON KEY vêm do dashboard do Supabase — a anon key é public por design
+// (vive no bundle do app), então EXPO_PUBLIC_* é ok. JWT Secret NÃO entra
+// aqui (fica no server WS na fatia B).
+//
+// Vazio = auth desligada. Utilitário mostra estado; sync segue anônimo (o que
+// já é o comportamento da fatia 3 do sync).
+
+export const SUPABASE_URL = process.env.EXPO_PUBLIC_SUPABASE_URL ?? "";
+export const SUPABASE_ANON_KEY =
+  process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY ?? "";
+
+export const AUTH_ENABLED = Boolean(SUPABASE_URL && SUPABASE_ANON_KEY);
+
+// Se ainda não configurou, cria um stub que nunca conecta — evita crash na
+// import. Telas de login devem gate em AUTH_ENABLED antes de tentar chamar.
+export const supabase = AUTH_ENABLED
+  ? createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+      auth: {
+        // Web: `undefined` = localStorage automático. Native: AsyncStorage.
+        storage: Platform.OS === "web" ? undefined : AsyncStorage,
+        autoRefreshToken: true,
+        persistSession: true,
+        // Web: parsear tokens da URL após magic link redirect. Native: manual
+        // via deep link handler em app/auth/callback.jsx.
+        detectSessionInUrl: Platform.OS === "web",
+      },
+    })
+  : null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo/metro-runtime": "~57.0.2",
+        "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native-vector-icons/material-design-icons": "^13.1.2",
+        "@supabase/supabase-js": "^2.111.0",
         "commitizen": "^4.3.2",
         "expo": "^57.0.1",
         "expo-checkbox": "~57.0.0",
@@ -4918,6 +4920,18 @@
         }
       }
     },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
+      "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.65 <1.0"
+      }
+    },
     "node_modules/@react-native-masked-view/masked-view": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@react-native-masked-view/masked-view/-/masked-view-0.3.2.tgz",
@@ -5322,6 +5336,90 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.111.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.111.0.tgz",
+      "integrity": "sha512-hbRLgyQZEX0SDyF4LYXpv94qOIQyFATfpT5SIs2V0SisHnisVRkYgiPQWzv80l4S2mO3qof78rmoH9j5zoFsYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.111.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.111.0.tgz",
+      "integrity": "sha512-RW/OCsd6MO592zU8ifzP8/f8XzxxIdpb+Up5XaOtE26Fw+3zTp475WX7+GuuktiD1WF8pFUDe6khUPbMp77RCw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.5.tgz",
+      "integrity": "sha512-aAn9H9ovVyeApKy11OWOrrOGq8DV68yWeH4ud2lN9fzn4aO8Zb5GLL9m1pUg9nLqIcT+ZDfAcsZe0E/nqdv2lw==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.111.0",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.111.0.tgz",
+      "integrity": "sha512-pcqeDsnWP0lx9GawduYxNZJHeuTm53O7L0SC8RF8tniV3GWIPY6me6OTdnwzdwNUmNy1dzUVtSyIfE6+OflzPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.111.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.111.0.tgz",
+      "integrity": "sha512-6oRf/vZyRwg8f8GbFSJkrD2w4HAu/yTvyMViHXHS+H5hNJzdXCrUR7cP5oW7daT3YlRnzRPY9LcGSJKZAmfMSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "0.4.5",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.111.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.111.0.tgz",
+      "integrity": "sha512-UEViNmTzVOxE8dqUA81wls+n9xgmlvSFfhfwo6QxrO4kQOytCYyw3ciYFoi4XoD4Jl95NJ3jnndHN5iIudWzqw==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.111.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.111.0.tgz",
+      "integrity": "sha512-9q0/AULthQnWeiDh1vGyjoJZbSY04bu6qHcWit70pqEYn5Kv/dkCPY62Ja1123jEnJbB9Vd2pjY7Kvk/lK3peA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.111.0",
+        "@supabase/functions-js": "2.111.0",
+        "@supabase/postgrest-js": "2.111.0",
+        "@supabase/realtime-js": "2.111.0",
+        "@supabase/storage-js": "2.111.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@tailwindcss/node": {
@@ -12242,6 +12340,15 @@
       "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
@@ -16237,6 +16344,27 @@
       "resolved": "https://registry.npmjs.org/merge/-/merge-2.1.1.tgz",
       "integrity": "sha512-jz+Cfrg9GWOZbQAnDQ4hlVnQky+341Yk5ru8bZSe6sIDTCIg8n9i/u7hSQGSVOF3C7lH6mGtqjkiT9G4wFLL0w==",
       "license": "MIT"
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/merge-options/node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
   },
   "dependencies": {
     "@expo/metro-runtime": "~57.0.2",
+    "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-vector-icons/material-design-icons": "^13.1.2",
+    "@supabase/supabase-js": "^2.111.0",
     "commitizen": "^4.3.2",
     "expo": "^57.0.1",
     "expo-checkbox": "~57.0.0",


### PR DESCRIPTION
Primeira fatia do item de auth do M6 (ADR-010, #205).

## O que entra

- `@supabase/supabase-js` + `@react-native-async-storage/async-storage` instalados via `expo install`.
- `infra/supabase.js` — client Supabase gated em `AUTH_ENABLED` (ambas env vars presentes). Se vazio, `supabase` é `null` e as telas de login mostram estado "auth indisponível".
- `infra/session.js` — `SessionProvider` + `useSession()`. Escuta `onAuthStateChange`, expõe `{session, user, ready, signOut}`.
- `app/login.jsx` — email input + magic link. Estados: `idle → sending → sent | error`. Redirect URL via `Linking.createURL('/auth/callback')` (cobre native e web).
- `app/auth/callback.jsx` — recebe `?code=` do PKCE, chama `exchangeCodeForSession`, redireciona `/`. Se `?error=`, mostra e permite retry.
- `app/_layout.jsx` — envolve tudo em `SessionProvider`, registra rotas `login` e `auth/callback`.
- `app/index.jsx` — botão condicional em Utilitários: "Entrar" quando deslogado; "Logado como X" + "Sair" quando logado. Só aparece se `AUTH_ENABLED`.
- `.env.example` — documenta todas as env vars (Evolution API + Supabase + Feedback + Sync opcional).
- `.prettierignore` — inclui `.env*` (que o prettier não consegue parsear).

## Fora de escopo (fatia B / C)

- **Sync continua anônimo** — nenhuma mudança em `infra/sync.js`. Login existe mas não gate nada.
- Server WS ainda não valida JWT (fatia B).
- Migração de dados anônimos (fatia C).

## Draft porque

Depende de você:
1. Criar projeto Supabase no dashboard (~5-10 min).
2. Colar `EXPO_PUBLIC_SUPABASE_URL` + `EXPO_PUBLIC_SUPABASE_ANON_KEY` no `.env` local.
3. Configurar Redirect URLs no dashboard: `backontrack://auth/callback` + `https://backontrack.mhdn.com.br/auth/callback`.
4. Smoke: rodar app, ir em Utilitários → Entrar, mandar magic link pro seu email, confirmar que abre logado + sessão persiste em reload.

Após seu OK, tira o draft.

## Test plan

- [x] `npm test` (48/48).
- [x] `tsc --noEmit` limpo.
- [x] `eslint .` limpo.
- [x] `prettier --check` limpo (só o `.claude/settings.local.json` gitignored, sem efeito no CI).
- [ ] Smoke real de login por você (bloqueio do draft acima).

Closes #207.