### PR TITLE
feat(sync): server validates supabase jwt and enforces roomId (M6 auth fatia B)

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -88,15 +88,51 @@ Arquivo JSON por sala em `/data` (volume bind-mount `./data:/data`). Um `pathId`
 
 Se apertar (concorrência alta, integridade, queries futuras), trocar por SQLite via `createSqlite3Persister` — mesmo shape, muda 1 função no `server.js`. Adiar até ter demanda concreta.
 
-## Segurança
+## Autenticação (M6 fatia B, #211, ADR-010)
 
-**Sem auth nesta fatia.** Trust-by-obscurity — quem sabe o `pathId` (userId) conecta e sincroniza. Aceitável enquanto os testers são 5-6 conhecidos e os IDs são difíceis de adivinhar. Auth real (JWT, token compartilhado, etc.) fica pra próxima fatia do M6.
+O server valida JWT do Supabase se o cliente mandar `?token=<JWT>` na URL. HS256 verificado com `crypto` nativo (zero dep). Enforça `jwt.sub === pathId` — quem sabe o path sem o token do dono não conecta (403).
+
+Duas envs controlam o comportamento:
+
+| Env                   | Default    | Efeito                                                                                                      |
+| --------------------- | ---------- | ----------------------------------------------------------------------------------------------------------- |
+| `AUTH_MODE`           | `optional` | `optional`: aceita anônimo se sem token. `required`: rejeita sem token (401).                               |
+| `SUPABASE_JWT_SECRET` | vazio      | Secret HS256 do projeto Supabase. Obrigatório se `AUTH_MODE=required` OU se algum cliente mandar `?token=`. |
+
+**Onde pegar o `SUPABASE_JWT_SECRET`:** Supabase Dashboard → Project Settings → API → **JWT Settings** → "JWT Secret". Rotate lá também se precisar. É diferente da `anon key` (que é pública, vai no bundle do app); o JWT Secret NUNCA deve ir pro cliente.
+
+Adicionar ao `.env` local do server:
+
+```bash
+cd server
+echo 'AUTH_MODE=optional' >> .env
+echo 'SUPABASE_JWT_SECRET=<colar-o-secret-aqui>' >> .env
+chmod 600 .env
+docker compose up -d --build
+```
+
+### Matriz de comportamento
+
+| Requisição                          | `AUTH_MODE=optional` | `AUTH_MODE=required` |
+| ----------------------------------- | -------------------- | -------------------- |
+| Sem `?token=`                       | ✅ aceita anônimo    | ❌ 401               |
+| `?token=` válido + `sub === pathId` | ✅ aceita            | ✅ aceita            |
+| `?token=` válido + `sub !== pathId` | ❌ 403               | ❌ 403               |
+| `?token=` assinatura inválida       | ❌ 401               | ❌ 401               |
+| `?token=` expirado                  | ❌ 401               | ❌ 401               |
+
+### Rollout
+
+1. Deploy com `AUTH_MODE=optional`. Clientes anônimos (compat) continuam sincronizando.
+2. Merge da fatia C (cliente passa a mandar JWT + migração dos dados anônimos → sala do userId). OTA chega nos testers.
+3. Aviso via WhatsApp (Evolution API) pros testers logarem — [[evolution-api-testers-stack]].
+4. Dias depois, PR separado: flip `AUTH_MODE=required` no server. Anônimo passa a ser rejeitado.
 
 Cloudflare Tunnel na frente já garante TLS válido; o server em si só fala WS plano em `127.0.0.1:8787` do host (loopback, não LAN — só o cloudflared do systemd alcança).
 
 ## O que NÃO está aqui
 
-- Integração do client do app (`createWsSynchronizer` no `infra/persistence.js`) — próxima fatia.
-- Auth real — fatia própria.
+- Cliente do app passando `?token=` — vem na fatia C junto com a migração dos dados anônimos.
+- Migração de dados anônimos → sala do userId (fatia C).
 - Validação em cenários reais (offline→online, 2 devices, reinstall) — última fatia do M6.
 - Migração de schema server-side (não temos, `MergeableStore` cuida da forma dos dados).

--- a/server/server.js
+++ b/server/server.js
@@ -1,40 +1,134 @@
 // @ts-nocheck -- código Node do server, fora do tsc do app (ADR-002).
 // TinyBase WebSocket sync server (M6, ADR-009, #198).
 //
-// Runs `createWsServer` from `tinybase/synchronizers/synchronizer-ws-server`
-// and exposes a WebSocket endpoint. Each connection's path is treated as a
-// separate "room" — the client picks the room (e.g. one per userId), the
-// server keeps one `MergeableStore` per room.
+// `createWsServer` do TinyBase expõe um endpoint WebSocket. O path da URL
+// define o pathId (a "sala"), o server mantém uma `MergeableStore` por sala
+// persistida como JSON no volume ($DATA_DIR, default ./data).
 //
-// Persistence: JSON file per room, written to $DATA_DIR (default ./data).
-// Simple and durable enough for the current scale (~10 testers); can be
-// swapped for SQLite later without touching the client.
+// Auth (M6 fatia B, #211, ADR-010): quando o cliente manda `?token=<JWT>` na
+// URL, o server valida HS256 com `SUPABASE_JWT_SECRET` e enforça que o `sub`
+// do JWT bate com o pathId — quem sabe o path sem o token do dono não conecta.
 //
-// TLS termination is done by the reverse proxy in front (Traefik in the
-// homeserver deploy — see compose.yml). This process only speaks plain WS.
+// AUTH_MODE controla o que fazer com conexões SEM token:
+//   - "optional" (default): aceita anônimo (compat com clientes atuais que
+//     usam `syncRoomId` UUID por-install).
+//   - "required": rejeita com 401 (modo final, depois que os testers migrarem
+//     via fatia C).
+//
+// TLS termina no cloudflared do host (ver compose.yml + README). Este processo
+// só fala WS plano na rede interna.
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { mkdirSync } from "node:fs";
+import { join, resolve } from "node:path";
 
 import { createMergeableStore } from "tinybase";
 import { createFilePersister } from "tinybase/persisters/persister-file";
 import { createWsServer } from "tinybase/synchronizers/synchronizer-ws-server";
 import { WebSocketServer } from "ws";
-import { mkdirSync } from "node:fs";
-import { join, resolve } from "node:path";
 
 const PORT = Number(process.env.PORT ?? 8787);
 const DATA_DIR = resolve(process.env.DATA_DIR ?? "./data");
+const AUTH_MODE = process.env.AUTH_MODE ?? "optional";
+const JWT_SECRET = process.env.SUPABASE_JWT_SECRET ?? "";
 
-// Ensure the data dir exists so `createFilePersister` can open files.
-// `recursive: true` makes this a no-op if it's already there.
+if (!["optional", "required"].includes(AUTH_MODE)) {
+  console.error(
+    `[sync] fatal: AUTH_MODE must be "optional" or "required" (got "${AUTH_MODE}")`,
+  );
+  process.exit(1);
+}
+if (AUTH_MODE === "required" && !JWT_SECRET) {
+  console.error(
+    "[sync] fatal: AUTH_MODE=required requires SUPABASE_JWT_SECRET",
+  );
+  process.exit(1);
+}
+
 mkdirSync(DATA_DIR, { recursive: true });
 
-// `pathId` is whatever comes after the host in the WS URL (e.g. `/user123`).
-// Sanitize to a filesystem-safe name so nothing sneaks out of $DATA_DIR.
+// `pathId` é o que vem depois do host na URL WS (ex.: `/user123`).
+// Sanitiza pra nome de arquivo seguro pra nada escapar do $DATA_DIR.
 function safeFilename(pathId) {
   const clean = pathId.replace(/[^A-Za-z0-9_-]/g, "-").replace(/^-+|-+$/g, "");
   return `${clean || "default"}.json`;
 }
 
-const wss = new WebSocketServer({ port: PORT });
+// base64url → Buffer. JWT usa a variante URL-safe (- e _ no lugar de + e /).
+function base64UrlDecode(str) {
+  const pad = "===".slice((str.length + 3) % 4);
+  const b64 = str.replace(/-/g, "+").replace(/_/g, "/") + pad;
+  return Buffer.from(b64, "base64");
+}
+
+// Verifica HS256 JWT contra JWT_SECRET. Retorna o payload decodificado.
+// Lança em qualquer inconsistência (formato, alg, assinatura, expiração, sub).
+function verifyJwt(token) {
+  const parts = token.split(".");
+  if (parts.length !== 3) throw new Error("malformed jwt");
+  const [headerB64, payloadB64, sigB64] = parts;
+
+  const header = JSON.parse(base64UrlDecode(headerB64).toString("utf8"));
+  if (header.alg !== "HS256") throw new Error(`unsupported alg: ${header.alg}`);
+
+  const signingInput = `${headerB64}.${payloadB64}`;
+  const expected = createHmac("sha256", JWT_SECRET)
+    .update(signingInput)
+    .digest();
+  const actual = base64UrlDecode(sigB64);
+  if (expected.length !== actual.length || !timingSafeEqual(expected, actual)) {
+    throw new Error("invalid signature");
+  }
+
+  const payload = JSON.parse(base64UrlDecode(payloadB64).toString("utf8"));
+  const now = Math.floor(Date.now() / 1000);
+  if (payload.exp && payload.exp < now) throw new Error("expired");
+  if (!payload.sub) throw new Error("no sub claim");
+
+  return payload;
+}
+
+const wss = new WebSocketServer({
+  port: PORT,
+  verifyClient: ({ req }, callback) => {
+    const url = new URL(req.url, "http://internal");
+    const pathId = url.pathname.replace(/^\/+/, "").replace(/\/+$/, "");
+    const token = url.searchParams.get("token");
+
+    if (token) {
+      if (!JWT_SECRET) {
+        // Cliente mandou token mas o server não pode validar. Recusar é mais
+        // seguro que aceitar sem checar.
+        console.error(
+          "[sync] rejecting: token sent but SUPABASE_JWT_SECRET not set",
+        );
+        return callback(false, 500, "server missing SUPABASE_JWT_SECRET");
+      }
+      try {
+        const payload = verifyJwt(token);
+        if (payload.sub !== pathId) {
+          console.warn(
+            `[sync] rejecting: jwt.sub="${payload.sub}" != pathId="${pathId}"`,
+          );
+          return callback(false, 403, "sub != pathId");
+        }
+        return callback(true);
+      } catch (e) {
+        console.warn(`[sync] rejecting: invalid token: ${e.message}`);
+        return callback(false, 401, `invalid token: ${e.message}`);
+      }
+    }
+
+    if (AUTH_MODE === "required") {
+      console.warn("[sync] rejecting: auth required, no token");
+      return callback(false, 401, "auth required");
+    }
+
+    // AUTH_MODE=optional + sem token → aceita anônimo (compat).
+    callback(true);
+  },
+});
+
 createWsServer(wss, (pathId) =>
   createFilePersister(
     createMergeableStore(),
@@ -42,4 +136,6 @@ createWsServer(wss, (pathId) =>
   ),
 );
 
-console.log(`[sync] listening on ws://0.0.0.0:${PORT} — data dir: ${DATA_DIR}`);
+console.log(
+  `[sync] listening on ws://0.0.0.0:${PORT} — data dir: ${DATA_DIR} — auth: ${AUTH_MODE}${JWT_SECRET ? " (secret loaded)" : ""}`,
+);

--- a/tests/sync-server-auth.test.js
+++ b/tests/sync-server-auth.test.js
@@ -1,0 +1,224 @@
+// @ts-nocheck -- teste; globals do jest não são tipados (ADR-002)
+// Testes de auth do server WS (M6 fatia B, #211, ADR-010).
+// Sobe o server em subprocess com AUTH_MODE / SUPABASE_JWT_SECRET distintos
+// por describe, e checa quais conexões o server aceita/rejeita durante o
+// handshake HTTP → WebSocket. Testa o CÓDIGO da auth, sem depender de rede.
+
+import { spawn } from "node:child_process";
+import { createHmac } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { WebSocket } from "ws";
+
+const SERVER_JS = resolve(__dirname, "..", "server", "server.js");
+const JWT_SECRET = "test-jwt-secret-do-not-use-in-prod-please";
+
+// --- Helpers pra construir JWT HS256 sem dep extra ------------------------
+
+function b64url(input) {
+  return Buffer.from(input)
+    .toString("base64")
+    .replace(/=/g, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+}
+
+function b64urlSig(buf) {
+  return buf
+    .toString("base64")
+    .replace(/=/g, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+}
+
+function signJwt(payload, { secret = JWT_SECRET, alg = "HS256" } = {}) {
+  const header = b64url(JSON.stringify({ alg, typ: "JWT" }));
+  const body = b64url(JSON.stringify(payload));
+  const signingInput = `${header}.${body}`;
+  const sig = b64urlSig(
+    createHmac("sha256", secret).update(signingInput).digest(),
+  );
+  return `${signingInput}.${sig}`;
+}
+
+function futureExp(seconds = 3600) {
+  return Math.floor(Date.now() / 1000) + seconds;
+}
+function pastExp(seconds = 60) {
+  return Math.floor(Date.now() / 1000) - seconds;
+}
+
+// --- Server subprocess helpers -------------------------------------------
+
+async function startServer(extraEnv = {}) {
+  const port = 41000 + Math.floor(Math.random() * 20000);
+  const dataDir = mkdtempSync(join(tmpdir(), "sync-auth-test-"));
+  const child = spawn("node", [SERVER_JS], {
+    env: {
+      ...process.env,
+      PORT: String(port),
+      DATA_DIR: dataDir,
+      ...extraEnv,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  await new Promise((resolveReady, rejectReady) => {
+    const t = setTimeout(
+      () => rejectReady(new Error("server didn't come up in 5s")),
+      5000,
+    );
+    child.stdout.on("data", (buf) => {
+      if (String(buf).includes("[sync] listening on ws://")) {
+        clearTimeout(t);
+        resolveReady();
+      }
+    });
+    child.on("exit", (code) => {
+      clearTimeout(t);
+      rejectReady(new Error(`server exited early with code ${code}`));
+    });
+  });
+
+  return { port, dataDir, child };
+}
+
+async function stopServer({ child, dataDir }) {
+  if (child && !child.killed) {
+    child.kill("SIGTERM");
+    await new Promise((r) => {
+      const t = setTimeout(() => {
+        child.kill("SIGKILL");
+        r();
+      }, 2000);
+      child.once("exit", () => {
+        clearTimeout(t);
+        r();
+      });
+    });
+  }
+  if (dataDir) rmSync(dataDir, { recursive: true, force: true });
+}
+
+/**
+ * Tenta abrir a conexão WS. Resolve com:
+ *   { open: true }               → handshake aceito
+ *   { open: false, code: <n> }   → server rejeitou (unexpected-response)
+ * Não faz TinyBase sync — só checa o handshake, que é onde a auth vive.
+ */
+function tryConnect(port, room, token, timeoutMs = 3000) {
+  return new Promise((resolveResult) => {
+    const url = `ws://localhost:${port}/${room}${token ? `?token=${encodeURIComponent(token)}` : ""}`;
+    const ws = new WebSocket(url);
+    const timer = setTimeout(() => {
+      try {
+        ws.close();
+      } catch {
+        // ignore
+      }
+      resolveResult({ open: false, code: "timeout" });
+    }, timeoutMs);
+
+    ws.once("open", () => {
+      clearTimeout(timer);
+      ws.close();
+      resolveResult({ open: true });
+    });
+    ws.once("unexpected-response", (_req, res) => {
+      clearTimeout(timer);
+      ws.close();
+      resolveResult({ open: false, code: res.statusCode });
+    });
+    ws.once("error", () => {
+      // Silenciar — o close/unexpected-response já resolve o resultado.
+    });
+    ws.once("close", (code) => {
+      clearTimeout(timer);
+      // Se resolve não foi chamado ainda (rejeição direta sem
+      // unexpected-response), reporta o close code.
+      resolveResult({ open: false, code });
+    });
+  });
+}
+
+// --- AUTH_MODE=optional --------------------------------------------------
+
+describe("AUTH_MODE=optional (default)", () => {
+  let server;
+  beforeAll(async () => {
+    server = await startServer({
+      AUTH_MODE: "optional",
+      SUPABASE_JWT_SECRET: JWT_SECRET,
+    });
+  }, 10000);
+  afterAll(async () => stopServer(server));
+
+  test("sem token: aceita anônimo (compat com clientes atuais)", async () => {
+    const res = await tryConnect(server.port, "anon-room-1", null);
+    expect(res).toEqual({ open: true });
+  });
+
+  test("JWT válido + sub === pathId: aceita", async () => {
+    const token = signJwt({ sub: "alice", exp: futureExp() });
+    const res = await tryConnect(server.port, "alice", token);
+    expect(res).toEqual({ open: true });
+  });
+
+  test("JWT válido + sub !== pathId: rejeita com 403", async () => {
+    const token = signJwt({ sub: "alice", exp: futureExp() });
+    const res = await tryConnect(server.port, "bob", token);
+    expect(res.open).toBe(false);
+    expect(res.code).toBe(403);
+  });
+
+  test("JWT com assinatura inválida: rejeita com 401", async () => {
+    const token = signJwt(
+      { sub: "alice", exp: futureExp() },
+      { secret: "wrong-secret" },
+    );
+    const res = await tryConnect(server.port, "alice", token);
+    expect(res.open).toBe(false);
+    expect(res.code).toBe(401);
+  });
+
+  test("JWT expirado: rejeita com 401", async () => {
+    const token = signJwt({ sub: "alice", exp: pastExp() });
+    const res = await tryConnect(server.port, "alice", token);
+    expect(res.open).toBe(false);
+    expect(res.code).toBe(401);
+  });
+
+  test("JWT sem sub: rejeita com 401", async () => {
+    const token = signJwt({ exp: futureExp() });
+    const res = await tryConnect(server.port, "alice", token);
+    expect(res.open).toBe(false);
+    expect(res.code).toBe(401);
+  });
+});
+
+// --- AUTH_MODE=required --------------------------------------------------
+
+describe("AUTH_MODE=required (fase final, após migração)", () => {
+  let server;
+  beforeAll(async () => {
+    server = await startServer({
+      AUTH_MODE: "required",
+      SUPABASE_JWT_SECRET: JWT_SECRET,
+    });
+  }, 10000);
+  afterAll(async () => stopServer(server));
+
+  test("sem token: rejeita com 401 (anônimo bloqueado)", async () => {
+    const res = await tryConnect(server.port, "anon-room-2", null);
+    expect(res.open).toBe(false);
+    expect(res.code).toBe(401);
+  });
+
+  test("JWT válido + sub === pathId: aceita", async () => {
+    const token = signJwt({ sub: "alice", exp: futureExp() });
+    const res = await tryConnect(server.port, "alice", token);
+    expect(res).toEqual({ open: true });
+  });
+});


### PR DESCRIPTION
Fatia B do item de auth do M6 (ADR-010, #205). Server WS passa a validar JWT do Supabase e a enforçar que `pathId === jwt.sub` — quem sabe o path sem o token do dono não conecta.

## O que entra

- **`server/server.js`**: HS256 verify via `node:crypto` (zero dep nova). Rodando no `verifyClient` do WebSocketServer, então rejeição é 401/403 no handshake HTTP — não conecta e desconecta em seguida.
- **`AUTH_MODE`** (env):
  - `optional` (default): aceita anônimo se sem token; aceita JWT válido; rejeita mismatch. Compat com clientes atuais (`syncRoomId` UUID por-install).
  - `required` (flip futuro, PR separado): rejeita sem token com 401.
- **`SUPABASE_JWT_SECRET`** (env): HS256 secret do projeto Supabase (Dashboard → Project Settings → API → **JWT Settings**). Obrigatório em `required` OU se qualquer cliente mandar `?token=`.
- **Startup validation**: `AUTH_MODE` inválido ou `required` sem secret → `process.exit(1)` com log fatal.
- **`tests/sync-server-auth.test.js`**: 8 casos, subprocess por describe (um optional, um required), sign JWT inline com `node:crypto` pra não adicionar dep de teste.
- **`server/README.md`**: seção Autenticação + matriz de comportamento + passo-a-passo pra pegar o secret + rollout planejado.

## Matriz de comportamento

|                                     | `optional`      | `required` |
| ----------------------------------- | --------------- | ---------- |
| Sem `?token=`                       | aceita anônimo  | 401        |
| `?token=` válido + `sub === pathId` | aceita          | aceita     |
| `?token=` válido + `sub !== pathId` | 403             | 403        |
| `?token=` assinatura inválida       | 401             | 401        |
| `?token=` expirado / sem sub        | 401             | 401        |

## Fora de escopo (fatia C, PR seguinte)

- Cliente montando URL com `?token=` quando logado.
- Migração dos dados anônimos → sala do `userId` no 1º sign-in.

## Rollout

1. Merge deste PR + deploy com `AUTH_MODE=optional`. Nada quebra pros testers atuais.
2. Merge da fatia C (client + migração) → OTA chega nos testers.
3. Aviso via WhatsApp (Evolution API) pros testers logarem: \"atualize o app, faça login, dados migram sozinhos\".
4. Dias depois, PR separado: flip `AUTH_MODE=required` no server.

## Test plan

- [x] `npm test` — 56/56 (48 anteriores + 8 novos de auth).
- [x] `tsc --noEmit` limpo.
- [x] `eslint .` limpo.
- [x] `prettier --check` limpo (só warn do `.claude/settings.local.json` gitignored, sem efeito no CI).
- [x] Startup manual em 3 configs (optional ok, required sem secret exit 1, AUTH_MODE=bogus exit 1).
- [ ] Deploy no homeserver + smoke remoto ainda pendente — vou depois do merge.

Closes #211.