### PR TITLE
feat(sync): client sends supabase jwt on ws connection when logged in (M6 auth fatia C)

### DIFF
--- a/infra/sync-url.js
+++ b/infra/sync-url.js
@@ -1,0 +1,21 @@
+// @ts-nocheck -- helper puro; tipos vêm quando toda a infra/ for tipada (ADR-002)
+
+/**
+ * Monta a URL WS pro server de sync (M6, fatia C, #211).
+ *
+ * Isolado num arquivo próprio pra ser testável sem puxar `infra/sync.js`
+ * inteiro — que importa Supabase/AsyncStorage e não roda no jest (RN
+ * native module).
+ *
+ * Retorna `null` se algum insumo essencial faltar (baseUrl vazio, roomId
+ * ainda não carregado do disco) — o caller trata como "sync desligado" e
+ * não tenta abrir WebSocket.
+ *
+ * `token` é opcional. Quando presente, o server valida HS256 no
+ * `verifyClient` do WS (fatia B, #211) e enforça `sub === pathId`.
+ */
+export function buildSyncUrl(baseUrl, roomId, token) {
+  if (!baseUrl || !roomId) return null;
+  const base = `${baseUrl}/${encodeURIComponent(String(roomId))}`;
+  return token ? `${base}?token=${encodeURIComponent(token)}` : base;
+}

--- a/infra/sync.js
+++ b/infra/sync.js
@@ -1,10 +1,31 @@
+// @ts-nocheck -- useSession retorna contexto tipado como never no tsc (ADR-002)
 import { createWsSynchronizer } from "tinybase/synchronizers/synchronizer-ws-client";
 import { useCreateSynchronizer, useValue } from "tinybase/ui-react";
 import { SYNC_URL } from "@/constants/sync";
 import { store } from "./database";
+import { useSession } from "./session";
+import { buildSyncUrl } from "./sync-url";
+
+// Re-exporta pra manter API estável (callers antigos podem importar de sync.js).
+// A implementação vive em infra/sync-url.js pra ficar testável isolado
+// (evita puxar Supabase/AsyncStorage no jest).
+export { buildSyncUrl };
 
 /**
- * Conecta o MergeableStore ao server WS de sync (M6 fatia 3, #202).
+ * Conecta o MergeableStore ao server WS de sync.
+ *
+ * - **Deslogado** (session null): usa `syncRoomId` (UUID por-install) como
+ *   pathId, sem `?token=`. É o comportamento pré-auth (M6 fatia 3, #202) —
+ *   mantém compat enquanto o server roda em `AUTH_MODE=optional`.
+ * - **Logado** (session presente): usa `user.id` como pathId + JWT do Supabase
+ *   em `?token=`. Server valida HS256 + enforça `sub === pathId` (fatia B,
+ *   #211). Migração dos dados anônimos pra sala do userId acontece
+ *   automaticamente na 1ª conexão: MergeableStore CRDT-merge sobe os dados
+ *   locais pra sala nova (server-side JSON, [[sync-server-and-cloudflare-tunnel]]).
+ *
+ * Reconecta em toda troca de `roomId` ou `token` — cobre login, logout, e
+ * refresh silencioso do token (Supabase renova em ~1h, dispara
+ * `onAuthStateChange('TOKEN_REFRESHED')` que atualiza a session no provider).
  *
  * Depende do `useRegistrosPersistencia` já ter rodado — é ele quem carrega o
  * `syncRoomId` do disco (ou gera no 1º launch). Sem esse gate, o sync abriria
@@ -12,21 +33,23 @@ import { store } from "./database";
  *
  * Falhas de rede (offline, DNS, TLS) NÃO quebram o app: a persistência local
  * segue funcionando; o sync fica dormente até a próxima abertura. Reconexão
- * automática ficou fora de escopo desta fatia (o WS do TinyBase não reconecta
- * sozinho; se cair no meio do uso, a próxima abertura sincroniza tudo).
- *
- * Chame perto da raiz (app/_layout.jsx), depois de useRegistrosPersistencia.
+ * automática ficou fora de escopo (o WS do TinyBase não reconecta sozinho; se
+ * cair no meio do uso, a próxima abertura sincroniza tudo).
  */
 export function useRegistrosSync() {
-  const roomId = useValue("syncRoomId", store);
-  const enabled = Boolean(SYNC_URL) && Boolean(roomId);
+  const { user, session } = useSession();
+  const anonRoomId = useValue("syncRoomId", store);
+
+  // roomId: user.id se logado; senão o UUID anônimo.
+  // token: JWT se logado; senão null (server em optional-mode aceita anônimo).
+  const roomId = user?.id ?? anonRoomId;
+  const token = session?.access_token ?? null;
+  const url = buildSyncUrl(SYNC_URL, roomId, token);
 
   useCreateSynchronizer(
     store,
     async (s) => {
-      if (!enabled) return undefined;
-      // `enabled` já garante roomId truthy, mas TS não estreita cross-closure.
-      const url = `${SYNC_URL}/${encodeURIComponent(String(roomId))}`;
+      if (!url) return undefined;
       try {
         // WebSocket é global tanto no RN quanto no web — sem import.
         const ws = new WebSocket(url);
@@ -40,6 +63,8 @@ export function useRegistrosSync() {
         return undefined;
       }
     },
-    [enabled, roomId],
+    // Rerun em qualquer mudança do URL — login/logout muda roomId+token juntos;
+    // TOKEN_REFRESHED muda só o token. Ambos precisam de reconexão.
+    [url],
   );
 }

--- a/tests/sync-url.test.js
+++ b/tests/sync-url.test.js
@@ -1,0 +1,58 @@
+// @ts-nocheck -- teste; globals do jest não são tipados (ADR-002)
+// Testa o helper buildSyncUrl (M6 auth fatia C). É o único pedaço puro de
+// infra/sync.js — a lógica de montagem/encoding da URL onde bug moraria
+// (roomId com espaço, JWT com `+`/`=`, mistura de logado/deslogado).
+
+import { buildSyncUrl } from "../infra/sync-url";
+
+describe("buildSyncUrl", () => {
+  const BASE = "wss://backontrack-sync.mhdn.com.br";
+
+  test("sem baseUrl retorna null (sync desligado)", () => {
+    expect(buildSyncUrl("", "room-1", null)).toBeNull();
+    expect(buildSyncUrl(null, "room-1", null)).toBeNull();
+    expect(buildSyncUrl(undefined, "room-1", null)).toBeNull();
+  });
+
+  test("sem roomId retorna null (persistência ainda não carregou)", () => {
+    expect(buildSyncUrl(BASE, "", null)).toBeNull();
+    expect(buildSyncUrl(BASE, null, null)).toBeNull();
+    expect(buildSyncUrl(BASE, undefined, null)).toBeNull();
+  });
+
+  test("anônimo (sem token): URL só com path do roomId", () => {
+    const url = buildSyncUrl(BASE, "abc-123-uuid", null);
+    expect(url).toBe(`${BASE}/abc-123-uuid`);
+    // Sem query string.
+    expect(url).not.toContain("?");
+  });
+
+  test("logado: URL com path + ?token=", () => {
+    const jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhbGljZSJ9.sig";
+    const url = buildSyncUrl(BASE, "user-uuid", jwt);
+    expect(url).toBe(`${BASE}/user-uuid?token=${encodeURIComponent(jwt)}`);
+    expect(url).toContain("?token=");
+  });
+
+  test("encoding: caracteres URL-unsafe no roomId viram %XX", () => {
+    // roomId hipotético com espaço + slash — não deve vazar pra URL.
+    const url = buildSyncUrl(BASE, "a b/c", null);
+    // encodeURIComponent transforma " " em "%20" e "/" em "%2F".
+    expect(url).toBe(`${BASE}/a%20b%2Fc`);
+  });
+
+  test("encoding: JWT com + e = do base64 padded vira %2B / %3D", () => {
+    // Cenário real: JWT tem . como separador (safe em URL), mas se algum
+    // caractere não-safe vazar (padding = ou versão base64 padrão com +/), o
+    // encoding tem que proteger o query.
+    const token = "abc+def=xyz";
+    const url = buildSyncUrl(BASE, "room", token);
+    expect(url).toBe(`${BASE}/room?token=abc%2Bdef%3Dxyz`);
+  });
+
+  test("roomId numérico é aceito (String() coerção)", () => {
+    // useValue pode retornar tipos diferentes conforme a store — proteja o
+    // template string de virar `[object Object]` ou `undefined`.
+    expect(buildSyncUrl(BASE, 42, null)).toBe(`${BASE}/42`);
+  });
+});


### PR DESCRIPTION
Fatia C do item de auth do M6 (ADR-010, #205). Complementa a fatia B ([#212](https://github.com/matheushnascimento/backOnTrack/pull/212)) no lado cliente: sessões autenticadas conectam na sala do userId com JWT no `?token=`. Migração dos dados anônimos acontece automaticamente via CRDT do TinyBase — zero código explícito.

## O que entra

- **`infra/sync-url.js`** (novo): helper puro `buildSyncUrl(baseUrl, roomId, token)`. Isolado num arquivo próprio pra os tests não puxarem Supabase/AsyncStorage (RN native module que quebra no jest).
- **`infra/sync.js`**: usa `useSession()`. Se logado, `roomId = user.id` + JWT no `?token=`; se deslogado, fallback pro `syncRoomId` UUID (compat pré-auth). Deps do `useCreateSynchronizer = [url]` — reconecta em login, logout, e refresh silencioso do token (Supabase renova em ~1h).
- **`tests/sync-url.test.js`**: 7 casos — null base/room retorna null, sem token só path, com token adiciona query, encoding de chars URL-unsafe em roomId e token, roomId numérico.

## Migração (automática)

Quando o roomId muda no 1º sign-in, `useCreateSynchronizer` destrói o sync anônimo e cria novo pro roomId do userId. TinyBase MergeableStore CRDT-merge sobe os dados locais pra sala nova. Idempotente por design.

Dados que ficaram na sala anônima antiga permanecem órfãos no server (nenhum client reconecta lá). GC server-side é problema separado.

## Compat com o server

Server em `AUTH_MODE=optional` (fatia B, [#212](https://github.com/matheushnascimento/backOnTrack/pull/212) mergeado). Este cliente é seguro: anônimo continua funcionando pros que ainda não logaram, autenticado agora também.

## Fora de escopo

- Deploy do server com `SUPABASE_JWT_SECRET` — rollout combinado com esta fatia (opção B: um deploy só cobrindo B+C).
- Flip `AUTH_MODE=required` — PR separado, dias após aviso aos testers.

## Test plan

- [x] `npm test` — 63/63 (56 anteriores + 7 novos).
- [x] `tsc --noEmit` limpo.
- [x] `eslint .` limpo.
- [x] `prettier --check` limpo (só warn do `.claude/settings.local.json` gitignored).
- [ ] Deploy do server (fatia B + este cliente) — pós-merge, junto com envio da mensagem aos testers.
- [ ] Smoke real após deploy: login local → dados sincronizam pra sala do userId (verificar no `server/data/`).

Closes #213.