### PR TITLE
fix(sync): load .env into sync container so SUPABASE_JWT_SECRET reaches node

### DIFF
--- a/server/compose.yml
+++ b/server/compose.yml
@@ -24,6 +24,10 @@ services:
     environment:
       PORT: "8787"
       DATA_DIR: "/data"
+    # Carrega .env do lado do container (auth: SUPABASE_JWT_SECRET, AUTH_MODE).
+    # `.env` é gitignored — cada deploy tem o seu.
+    env_file:
+      - .env
     volumes:
       - ./data:/data
     # Bind explícito em 127.0.0.1: acessível pelo cloudflared do host, mas não


### PR DESCRIPTION
Fix descoberto durante o deploy da fatia B ([#212](https://github.com/matheushnascimento/backOnTrack/pull/212)) no homeserver.

## O bug

`docker compose` lê `server/.env` no momento de avaliar o compose file (pra interpolação `${VAR}`), mas **não** injeta essas variáveis no `process.env` do container automaticamente. Sem `env_file: .env`, o `SUPABASE_JWT_SECRET` ficava só no host — o processo Node dentro do container subia sem enxergar o secret.

Sintoma no log: `auth: optional` (sem `(secret loaded)`). Consequência silenciosa: qualquer cliente autenticado receberia 500 do `verifyClient` hook ("token sent but SUPABASE_JWT_SECRET not set").

## O fix

Uma linha em `server/compose.yml`:

```yaml
env_file:
  - .env
```

O `.env` continua gitignored (cada deploy tem o seu). Vars explícitas em `environment:` (PORT, DATA_DIR) ainda vencem em caso de conflito.

## Validado no homeserver

- Log antes: `[sync] listening ... — auth: optional`
- Log depois: `[sync] listening ... — auth: optional (secret loaded)` ✅
- Smoke remoto anônimo (`URL=wss://backontrack-sync.mhdn.com.br npm run smoke`): round-trip OK, compat mantida ✅

## Test plan

- [x] Smoke local em 3 configs do server (rodei antes do PR da fatia B).
- [x] Deploy real no homeserver + smoke remoto anônimo passou.
- [ ] Smoke autenticado (com JWT válido) → pós-merge, quando eu logar no app.

Follow-up de #212 e #214.