### PR TITLE
fix(login): hide raw supabase errors from user, log to console instead

### DIFF
--- a/app/login.jsx
+++ b/app/login.jsx
@@ -19,14 +19,12 @@ export default function Login() {
   const { user } = useSession();
   const [email, setEmail] = useState("");
   const [status, setStatus] = useState("idle"); // idle | sending | sent | error
-  const [errorMsg, setErrorMsg] = useState("");
 
   const canSend = AUTH_ENABLED && status !== "sending" && email.includes("@");
 
   async function handleSend() {
     if (!canSend || !supabase) return;
     setStatus("sending");
-    setErrorMsg("");
     try {
       // Linking.createURL cobre native (backontrack://) e web (https://origin).
       // Ambos precisam estar no allowlist de Redirect URLs do Supabase.
@@ -38,13 +36,10 @@ export default function Login() {
       if (error) throw error;
       setStatus("sent");
     } catch (e) {
-      // Loga o erro cru pra debug no console (AuthError vem com .status, .code
-      // e .message; alguns caminhos jogam objeto opaco onde só o console ajuda).
+      // Detalhes técnicos ficam no console — UI mostra só mensagem genérica.
+      // "Invalid API key", HTTP status, stack trace: infra interna que só
+      // atrapalha usuário final e pode vazar shape do backend.
       console.error("[login] signInWithOtp falhou:", e);
-      const parts = [e?.message, e?.code, e?.status]
-        .filter(Boolean)
-        .map(String);
-      setErrorMsg(parts.length ? parts.join(" · ") : "erro desconhecido");
       setStatus("error");
     }
   }
@@ -120,8 +115,8 @@ export default function Login() {
 
             {status === "error" && (
               <Text className="text-sm text-danger">
-                Não consegui enviar ({errorMsg}). Confere o email e tenta de
-                novo.
+                Não consegui enviar o link agora. Confere o email e tenta de
+                novo em alguns minutos.
               </Text>
             )}
 


### PR DESCRIPTION
A tela de magic link estava vazando o `AuthError` cru pro usuário:

> Não consegui enviar (Invalid API key · 401). Confere o email e tenta de novo.

Dois problemas:

1. **UX**: usuário final não sabe o que fazer com "Invalid API key · 401" — pra ele é ruído puro.
2. **Segurança/leak**: expõe status codes, códigos de erro do Supabase, e a shape do backend. Detalhes de infra interna não pertencem à UI.

## O fix

- `catch` do `signInWithOtp` só faz `console.error(e)` + `setStatus("error")`.
- UI mostra uma mensagem genérica: "Não consegui enviar o link agora. Confere o email e tenta de novo em alguns minutos."
- Estado `errorMsg` (e o seu setter) removidos — não são mais usados.

Detalhes técnicos continuam **totalmente visíveis** no console/DevTools pra debug.

## Como o bug apareceu

O rollout da fatia A do M6 auth (PR #208) subiu a tela de login com o `catch` verboso. Em produção, o `EXPO_PUBLIC_SUPABASE_ANON_KEY` no Vercel tinha sido colado 2 chars truncado — todo tester que abrisse a produção via magic link virou "Invalid API key · 401" na cara. Só descobri hoje porque o texto do erro me fez inspecionar o bundle e comparar as keys.

Key já corrigida no Vercel + rebuild disparado — este PR é o follow-up de UX pra impedir a próxima vez.

## Test plan

- [x] `npx prettier --check app/login.jsx` limpo.
- [x] `npx eslint app/login.jsx` limpo.
- [ ] Smoke manual quando o CI subir preview: forçar erro (email inválido / bloqueado) e ver a mensagem genérica.