### PR TITLE
fix(sync): move useRegistrosSync inside SessionProvider so useSession sees user

### DIFF
--- a/app/_layout.jsx
+++ b/app/_layout.jsx
@@ -11,52 +11,61 @@ import UpdateBanner from "@/components/UpdateBanner";
 
 export default function RootLayout() {
   useRegistrosPersistencia();
-  // Depois de persistência: o hook de sync depende do syncRoomId já estar
-  // carregado do disco (ver infra/sync.js).
-  useRegistrosSync();
 
   return (
     <SafeAreaProvider>
       {/* SessionProvider envolve tudo (M6 auth fatia A, #207) — expõe a
-          sessão do Supabase pros filhos via useSession. Sync ainda anônimo
-          nesta fatia; JWT só vira gate na fatia B. */}
+          sessão do Supabase pros filhos via useSession. useRegistrosSync
+          precisa vir por DENTRO do provider senão useSession retorna o
+          default do contexto (user: null) e o sync nunca sai da sala
+          anônima após login. */}
       <SessionProvider>
-        {/* View de raiz só pra ancorar o UpdateBanner sobre a rota atual. */}
-        <View className="flex-1">
-          <Stack screenOptions={{ headerShown: false }}>
-            <Stack.Screen name="index" options={{ title: "Hoje" }} />
-            {/* Roadmap/Feedback/Admin não têm relação com registro de métrica,
-                então não usam o MyHeader (faixa de chips). Ativam o header
-                nativo do Expo Router pra ganhar título + back arrow (#178). */}
-            <Stack.Screen
-              name="roadmap"
-              options={{ title: "Roadmap", headerShown: true }}
-            />
-            <Stack.Screen name="export" options={{ title: "Exportação" }} />
-            <Stack.Screen name="history" options={{ title: "Histórico" }} />
-            <Stack.Screen
-              name="feedback"
-              options={{ title: "Feedback", headerShown: true }}
-            />
-            {/* Rota de admin (testers) — acesso só por deep link backontrack://admin */}
-            <Stack.Screen
-              name="admin"
-              options={{ title: "Admin", headerShown: true }}
-            />
-            <Stack.Screen
-              name="login"
-              options={{ title: "Entrar", headerShown: true }}
-            />
-            {/* Callback do magic link — headless, autopropulsão pra /. */}
-            <Stack.Screen
-              name="auth/callback"
-              options={{ title: "Autenticando", headerShown: false }}
-            />
-            <Stack.Screen name="(metrics)" />
-          </Stack>
-          <UpdateBanner />
-        </View>
+        <AppTree />
       </SessionProvider>
     </SafeAreaProvider>
+  );
+}
+
+// Filho do SessionProvider — usa `useSession` via useRegistrosSync.
+function AppTree() {
+  // Sync depende do syncRoomId (carregado por useRegistrosPersistencia no
+  // root) E da session — deve rodar DENTRO do SessionProvider.
+  useRegistrosSync();
+
+  return (
+    <View className="flex-1">
+      <Stack screenOptions={{ headerShown: false }}>
+        <Stack.Screen name="index" options={{ title: "Hoje" }} />
+        {/* Roadmap/Feedback/Admin não têm relação com registro de métrica,
+            então não usam o MyHeader (faixa de chips). Ativam o header
+            nativo do Expo Router pra ganhar título + back arrow (#178). */}
+        <Stack.Screen
+          name="roadmap"
+          options={{ title: "Roadmap", headerShown: true }}
+        />
+        <Stack.Screen name="export" options={{ title: "Exportação" }} />
+        <Stack.Screen name="history" options={{ title: "Histórico" }} />
+        <Stack.Screen
+          name="feedback"
+          options={{ title: "Feedback", headerShown: true }}
+        />
+        {/* Rota de admin (testers) — acesso só por deep link backontrack://admin */}
+        <Stack.Screen
+          name="admin"
+          options={{ title: "Admin", headerShown: true }}
+        />
+        <Stack.Screen
+          name="login"
+          options={{ title: "Entrar", headerShown: true }}
+        />
+        {/* Callback do magic link — headless, autopropulsão pra /. */}
+        <Stack.Screen
+          name="auth/callback"
+          options={{ title: "Autenticando", headerShown: false }}
+        />
+        <Stack.Screen name="(metrics)" />
+      </Stack>
+      <UpdateBanner />
+    </View>
   );
 }


### PR DESCRIPTION
Bug de escopo do React context na fatia C (#214) — `useSession()` retornava sempre o valor default do contexto no `useRegistrosSync`, então o sync ficava sempre anônimo mesmo pós-login.

## O bug

Em `app/_layout.jsx`:

```jsx
export default function RootLayout() {
  useRegistrosPersistencia();
  useRegistrosSync();   // ← chamado AQUI, fora do <SessionProvider>

  return (
    <SafeAreaProvider>
      <SessionProvider>  // ← Provider está no return
        ...
```

`useRegistrosSync` chama `useSession()` internamente. Mas `useSession` está **fora** do `<SessionProvider>` no tree — retorna `{user: null, session: null}` (default do context), independente de logado ou não.

## Sintoma real (produção)

Confirmado agora ao vivo:
- App mostra "Logado como matheus.mhddn@gmail.com" em Utilitários (que usa `useSession` de dentro da tree, funciona).
- WebSocket abre em `wss://backontrack-sync.mhdn.com.br/w75uhdnz7r24fxzck9nq4` — sala anônima, sem `?token=`.
- Nenhum arquivo `<user-uuid>.json` (formato UUID Supabase com hifens) aparece em `server/data/` — só os UUIDs anônimos por-install de sempre.

## Fix

Introduz um componente `AppTree` que vive DENTRO do `<SessionProvider>` e chama `useRegistrosSync` lá. `useRegistrosPersistencia` fica na raiz (não depende de session).

## Por que os testes não pegaram

`tests/sync-url.test.js` só exercita o helper puro `buildSyncUrl`. Este é um bug de **fiação da árvore React** — requer teste de integração com `SessionProvider + RootLayout` renderizados juntos. Follow-up válido pra M4 mas fora de escopo desta correção.

## Test plan

- [x] Prettier/Eslint/Types limpos.
- [x] `npm test` 63/63.
- [ ] Preview do PR: logar → WebSocket deve abrir com `/<user-uuid>?token=...` (verificar em DevTools Network → WS).
- [ ] Server data: após 1º sync autenticado, deve aparecer `<user-uuid>.json` em `server/data/` (verificado depois do merge + OTA nos testers).

Follow-up de #213 (fatia C) / PR #214.