### PR TITLE
fix(app): bump version 1.0.0 -> 1.1.0 to stop OTA crash loop on beta.5 APKs

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "name": "Back on Track",
     "slug": "backOnTrack",
     "scheme": "backontrack",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",


### PR DESCRIPTION
## Hotfix — parar o crash loop dos testers

O `.github/workflows/publish-update.yaml` publica OTA em `preview` toda vez que a main muda. `app.json.runtimeVersion.policy` é `\"appVersion\"`, então o runtime é o `version` — hoje `1.0.0`, o mesmo da APK **beta.5** que os testers têm.

Desde o PR #208 (M6 auth fatia A), foi adicionada dep `@react-native-async-storage/async-storage` (native module). Toda OTA a partir dali requer esse módulo em runtime. beta.5 foi buildada ANTES da fatia A e **não tem o módulo compilado dentro**. Resultado no device:

1. App abre → expo-updates baixa a OTA nova
2. Aplica → `require(\"@react-native-async-storage/async-storage\")` throw
3. Rollback pra bundle embedded
4. Próxima abertura → repete

## O fix

Bump `version` `1.0.0` → `1.1.0` em `app.json`. Como `runtimeVersion.policy: \"appVersion\"`, o runtime das próximas OTAs vira `1.1.0`. APK beta.5 (`1.0.0`) para de receber essas OTAs. Sem mais crash loop pros que ainda estão pra pegar OTAs futuras.

## Ainda falta (fora deste PR, ops CLI)

**1. Desatolar quem já baixou a OTA ruim** (comando você roda daqui):

\`\`\`bash
eas update:rollback-to-embedded --branch preview --runtime-version 1.0.0
\`\`\`

Publica uma OTA especial que instrui clientes em `1.0.0` a voltarem pro bundle embedded (do próprio APK). Sem mais crash. Ficam com o app de beta.5 (sem auth, sync anônimo — mas funcional).

**2. Nova APK em 1.1.0** (opcional, follow-up):

\`\`\`bash
eas build --profile preview --platform android
\`\`\`

Testers instalam → ganham auth completo + fatias B/C via OTA depois.

## Ordem de merge

Este PR **primeiro**. Depois #217 (fix do useSession outside provider) — que já vai pra OTA em 1.1.0, seguro.

## Test plan

- [x] Diff de 1 linha, sem lógica.
- [x] Prettier passou.
- [ ] Após merge, confirmar que publish-update workflow rodou e a próxima OTA foi tagged runtime `1.1.0` (verificar em `eas update:list --branch preview` ou dashboard EAS).