### PR TITLE
chore(dist): update EAS_INSTALL_URL to new 1.1.0 android build

### DIFF
--- a/constants/distribution.js
+++ b/constants/distribution.js
@@ -12,7 +12,7 @@
 // Internet, mas trava no Chrome). Ciclo 3, #74.
 
 export const EAS_INSTALL_URL =
-  "https://expo.dev/accounts/matheushnascimento/projects/backOnTrack/builds/a847923f-2975-4b74-9ccc-2661999e595c";
+  "https://expo.dev/accounts/matheushnascimento/projects/backOnTrack/builds/2e4d014d-d558-4c6d-9d75-0d2c2be81870";
 
 export const APK_URL =
   "https://github.com/matheushnascimento/backOnTrack/releases/latest/download/backOnTrack.apk";


### PR DESCRIPTION
Aponta o card "Obter o app" na Home pra APK nova que sai do hotfix do crash loop.

## O que muda

Uma linha em `constants/distribution.js`:
- `EAS_INSTALL_URL` de `a847923f-...` (beta.5, runtime 1.0.0, crashava com OTAs recentes) → `2e4d014d-...` (runtime 1.1.0, inclui native modules AsyncStorage + Supabase).

## Contexto (rollout do M6 auth em curso)

1. Fatia A ([#208](https://github.com/matheushnascimento/backOnTrack/pull/208)) adicionou `@react-native-async-storage/async-storage` como dep nativa.
2. beta.5 (buildada antes da fatia A) não tem esse módulo compilado. OTAs no runtime 1.0.0 crashavam nos testers ([#218](https://github.com/matheushnascimento/backOnTrack/pull/218) — bump pra 1.1.0 + `eas update:roll-back-to-embedded` pra desatolar).
3. Este PR: card da Home passa a distribuir o novo APK (id `2e4d014d`), pra testers ganharem uma versão que aceita OTAs 1.1.0 (incluindo o fix do `useSession outside provider` do [#217](https://github.com/matheushnascimento/backOnTrack/pull/217) + fatias B/C do auth).

## Por que foi manual (não via release.yaml)

O `release.yaml` faz esse `sed` automaticamente quando o build vem via `workflow_dispatch`. Como este build foi disparado local (`eas build ...`) pra fechar o hotfix rápido, não passou pelo workflow — sed na mão.

## APK_URL segue apontando pra beta.5

Fallback pra Firefox / Samsung Internet ainda vai pra `/releases/latest/` do GitHub. Pra atualizar precisa cortar nova GitHub Release (via `release.yaml` ou manual `gh release create`). Follow-up separado.

## Test plan

- [x] 1 linha, `prettier --check` limpo.
- [ ] Pós-merge, abrir `https://backontrack.mhdn.com.br` no Chrome do Android via card "Obter o app" → confirmar redirect pra página de instalação nova (`.../builds/2e4d014d-...`) e instalação completa.