### PR TITLE
fix(supabase): make createClient non-fatal + log runtime env values (debug)

### DIFF
--- a/infra/supabase.js
+++ b/infra/supabase.js
@@ -16,12 +16,35 @@ export const SUPABASE_URL = process.env.EXPO_PUBLIC_SUPABASE_URL ?? "";
 export const SUPABASE_ANON_KEY =
   process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY ?? "";
 
+// TEMP debug (crash investigation): logs the URL/key that Metro actually
+// baked at build time. Visible via `adb logcat *:S ReactNativeJS:V`.
+// Remove after fixing.
+console.log(
+  "[supabase-debug] URL type:",
+  typeof SUPABASE_URL,
+  "length:",
+  SUPABASE_URL?.length,
+  "value:",
+  JSON.stringify(SUPABASE_URL),
+);
+console.log(
+  "[supabase-debug] KEY type:",
+  typeof SUPABASE_ANON_KEY,
+  "length:",
+  SUPABASE_ANON_KEY?.length,
+  "first 4:",
+  JSON.stringify(SUPABASE_ANON_KEY?.slice(0, 4)),
+);
+
 export const AUTH_ENABLED = Boolean(SUPABASE_URL && SUPABASE_ANON_KEY);
 
-// Se ainda não configurou, cria um stub que nunca conecta — evita crash na
-// import. Telas de login devem gate em AUTH_ENABLED antes de tentar chamar.
-export const supabase = AUTH_ENABLED
-  ? createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+// Envelope createClient em try/catch pra crash de validação (ex.: URL
+// inválido) NÃO derrubar o app inteiro. Retorna null e loga — app abre
+// com auth desligada em vez de crash na abertura.
+function safeCreateClient() {
+  if (!AUTH_ENABLED) return null;
+  try {
+    return createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
       auth: {
         // Web: `undefined` = localStorage automático. Native: AsyncStorage.
         storage: Platform.OS === "web" ? undefined : AsyncStorage,
@@ -31,5 +54,12 @@ export const supabase = AUTH_ENABLED
         // via deep link handler em app/auth/callback.jsx.
         detectSessionInUrl: Platform.OS === "web",
       },
-    })
-  : null;
+    });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    console.error("[supabase-debug] createClient falhou:", msg);
+    return null;
+  }
+}
+
+export const supabase = safeCreateClient();


### PR DESCRIPTION
Investigação do crash `Invalid supabaseUrl: Must be a valid HTTP or HTTPS URL.` na APK 1.1.0.

## Contexto

- 2 APKs cortadas do mesmo source (main c1faebc): `2e4d014d` e `342a5b7b`. Ambas crasham.
- Bundle da APK (Hermes bytecode) contém as strings literais corretas — verificado extraindo com python:
  - `https://rrakpqaxjjpglmdexvkb.supabase.co` presente
  - `sb_publishable_fsZS7EUMJKZ_oWc5SnqRvA_g9AB9hoy` presente
- Metro substituiu `process.env.EXPO_PUBLIC_SUPABASE_*` (0 ocorrências no bundle).
- EAS env vars são `type: string`, valores corretos, workflow log confirma que foram carregados no build.
- `roll-back-to-embedded` publicado pra runtime 1.1.0. Uninstall + reinstall + clear data feitos. Continua crashando.
- Conclusão: strings estão bakeadas, mas o valor que chega em `createClient` em runtime não passa na validação.

## O que muda

1. **`safeCreateClient()`** — wrap em try/catch. Se validação lançar, loga e retorna `null` em vez de derrubar o app. Estado de auth fica "indisponível" mas app abre.
2. **Debug logs em `console.log`** no init do módulo:
   - `typeof SUPABASE_URL`, `.length`, `JSON.stringify` do valor (mostra chars invisíveis como `\uXXXX`)
   - Mesma coisa pra `SUPABASE_ANON_KEY` (primeiros 4 chars só, por segurança)
   - Se `createClient` falhar: erro completo

Visível via `adb logcat *:S ReactNativeJS:V` no device.

## Próximo passo após o merge

- Cortar 3ª APK com esses logs.
- Instalar no device, abrir, capturar adb logcat.
- Descobrir o que está corrompendo o valor entre bundle e runtime.
- Remover os logs de debug + fixar a causa real.

## Test plan

- [x] `npm test` 63/63.
- [x] `tsc --noEmit` limpo.
- [x] `eslint .` limpo.
- [x] `prettier --check` limpo.
- [ ] APK 3: abrir → app não crasha (auth indisponível esperado) → adb logcat mostra os debug logs.

Temporário — deve ser revertido junto com o fix da causa raiz.