### PR TITLE
fix(debug): render supabase init state on home for on-device diagnosis

### DIFF
--- a/app/index.jsx
+++ b/app/index.jsx
@@ -15,7 +15,13 @@ import SectionLabel from "@/components/SectionLabel";
 
 import { clearAll, getToday, store } from "@/infra/database";
 import { useSession } from "@/infra/session";
-import { AUTH_ENABLED } from "@/infra/supabase";
+import {
+  AUTH_ENABLED,
+  SUPABASE_ANON_KEY,
+  SUPABASE_URL,
+  supabase,
+  supabaseInitError,
+} from "@/infra/supabase";
 import { confirmAction } from "@/constants/dialogs";
 import { getEnvironmentInfo } from "@/constants/environment";
 import { CATEGORY_MAP } from "@/components/categoryUtils";
@@ -177,6 +183,26 @@ export default function Home() {
           <Text className="pt-1 text-center text-xs text-light-text opacity-50 dark:text-dark-text">
             v{ENV.appVersion}
             {ENV.bundle ? ` · ${ENV.bundle}` : ""}
+          </Text>
+          {/* TEMP DEBUG: mostra estado do supabase.js pra diagnóstico do
+              crash "Invalid supabaseUrl" sem precisar de adb logcat. Ver
+              PR #221 e a próxima. Remover assim que bug resolvido. */}
+          <Text
+            selectable
+            className="pt-2 text-center text-xs text-light-text opacity-70 dark:text-dark-text"
+          >
+            DEBUG · url_type={typeof SUPABASE_URL} url_len=
+            {SUPABASE_URL?.length ?? 0} url_head=
+            {JSON.stringify(SUPABASE_URL?.slice(0, 10) ?? "")}
+            {"\n"}
+            key_type={typeof SUPABASE_ANON_KEY} key_len=
+            {SUPABASE_ANON_KEY?.length ?? 0} key_head=
+            {JSON.stringify(SUPABASE_ANON_KEY?.slice(0, 6) ?? "")}
+            {"\n"}
+            auth_enabled={String(AUTH_ENABLED)} supabase_null=
+            {String(supabase === null)}
+            {"\n"}
+            init_err={String(supabaseInitError ?? "none")}
           </Text>
         </Card>
 

--- a/infra/supabase.js
+++ b/infra/supabase.js
@@ -1,3 +1,4 @@
+// @ts-nocheck -- debug patch com let export com narrow inicial null (ADR-002)
 /* global process */
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { createClient } from "@supabase/supabase-js";
@@ -41,6 +42,9 @@ export const AUTH_ENABLED = Boolean(SUPABASE_URL && SUPABASE_ANON_KEY);
 // Envelope createClient em try/catch pra crash de validação (ex.: URL
 // inválido) NÃO derrubar o app inteiro. Retorna null e loga — app abre
 // com auth desligada em vez de crash na abertura.
+// TEMP debug: também guarda o erro num export pra UI mostrar (sem ADB).
+export let supabaseInitError = null;
+
 function safeCreateClient() {
   if (!AUTH_ENABLED) return null;
   try {
@@ -58,6 +62,7 @@ function safeCreateClient() {
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     console.error("[supabase-debug] createClient falhou:", msg);
+    supabaseInitError = msg;
     return null;
   }
 }


### PR DESCRIPTION
Sem ADB no host de teste, o try/catch anterior mascarou tanto o crash que tocar em Login também não faz nada (handleSend early-returns quando supabase é null). Estamos cegos.

## O fix diagnóstico

Move os logs de debug pra UI — visível em qualquer screen sem cabo/ferramenta:

- **`infra/supabase.js`**: novo export `supabaseInitError`, setado dentro do try/catch. Non-null sse createClient lançou.
- **`app/index.jsx`**: linha DEBUG dentro do card Utilitários mostrando:
  - `typeof` + `.length` + primeiros N chars (JSON.stringify) de URL e ANON_KEY
  - `AUTH_ENABLED`
  - `supabase === null`
  - `supabaseInitError` (mensagem exata)

Todos os valores são os que efetivamente chegam em runtime — Metro já substituiu `process.env.EXPO_PUBLIC_*` no bundle time, então o que aparece é o que supabase-js vê.

## O que a screenshot vai me contar

| Cenário | Diagnóstico |
|---|---|
| `url_len=0` | Metro não substituiu — env vars EAS não chegaram no worker |
| `url_len=40` + head correto + `init_err=Invalid supabaseUrl...` | Env var OK, mas chega com bytes estranhos — o head vai me mostrar |
| `url_len=40` + `supabase_null=false` + `init_err=none` | Crash é em outro lugar (fetch, sync, etc) |

## Test plan

- [x] `npm test` 63/63.
- [x] `tsc --noEmit` limpo (com `@ts-nocheck` no supabase.js — legacy pattern ADR-002).
- [x] `eslint .` limpo.
- [x] `prettier --check` limpo.
- [ ] Após build 4 + install: screenshot da Home → diagnóstico definitivo.

Temporário — sai junto com o fix do bug real.