### PR TITLE
fix(auth): force pkce flow so native callback receives ?code= not #hash

### DIFF
--- a/app/auth/callback.jsx
+++ b/app/auth/callback.jsx
@@ -15,9 +15,13 @@ import { supabase } from "@/infra/supabase";
 // sessão via PKCE, redireciona pra /.
 
 export default function AuthCallback() {
-  const { code, error, error_description } = useLocalSearchParams();
+  const params = useLocalSearchParams();
+  const { code, error, error_description } = params;
   const [status, setStatus] = useState("exchanging");
   const [errorMsg, setErrorMsg] = useState("");
+  // TEMP debug: mostra os params do deep link — se PKCE está funcionando,
+  // `code` deve estar presente. Se hash-flow, params tem outros campos.
+  const debugParams = JSON.stringify(params, null, 2);
 
   useEffect(() => {
     // Supabase pode redirecionar com `?error=...` em vez de `?code=...`
@@ -88,6 +92,13 @@ export default function AuthCallback() {
               Não deu certo
             </Text>
             <Text className="text-sm text-danger">{errorMsg}</Text>
+            {/* TEMP debug: mostra params do deep link pra diagnóstico. */}
+            <Text
+              selectable
+              className="text-xs text-light-text opacity-70 dark:text-dark-text"
+            >
+              DEBUG params: {debugParams}
+            </Text>
             <MyButton
               title="Tentar de novo"
               onPress={() => router.replace("/login")}

--- a/infra/supabase.js
+++ b/infra/supabase.js
@@ -57,6 +57,11 @@ function safeCreateClient() {
         // Web: parsear tokens da URL após magic link redirect. Native: manual
         // via deep link handler em app/auth/callback.jsx.
         detectSessionInUrl: Platform.OS === "web",
+        // Força PKCE em todas as plataformas. Sem isso, o supabase-js pode
+        // gerar magic link em hash-flow (#access_token=...) que só funciona
+        // com detectSessionInUrl=true — quebra no native, onde o callback
+        // precisa do ?code= pra chamar exchangeCodeForSession.
+        flowType: "pkce",
       },
     });
   } catch (e) {


### PR DESCRIPTION
Native magic link callback cai na tela "Link inválido ou sem código de autenticação" — user fica deslogado. Debug do PR #222 confirmou que supabase agora está OK (createClient sucedeu, sem init error) — o crash de módulo sumiu; **isso é bug separado no deep link handling**.

## Causa raiz

Nossa config do supabase-js tem `detectSessionInUrl` **só pra web**. No native o client não parseia `#access_token` do fragment da URL. E magic link do Supabase usa **hash-flow** por default, a menos que o client esteja explicitamente configurado com **PKCE**.

No native o que acontece:

1. Magic link abre `backontrack://auth/callback#access_token=...` (hash)
2. Expo Router roteia pra `/auth/callback` sem query params
3. `code` param em `callback.jsx` fica undefined
4. Cai no fallback `onAuthStateChange` com timeout de 3s
5. Nada dispara (client native não auto-parseia hash)
6. Timeout → tela "Link inválido"

## Fix

`flowType: "pkce"` na config do auth. Supabase agora gera magic link com `?code=` em todas as plataformas. Callback usa o caminho PKCE (`exchangeCodeForSession`) que já funciona.

Web: sem mudança de comportamento (supabase-js recente já usa pkce por default; explícito é mais seguro).

## Debug bonus

`callback.jsx` também mostra `JSON.stringify(useLocalSearchParams())` na tela de erro. Se o fix não resolver 100%, a gente vê exatamente o que chega no deep link.

## Rollout

Ambas as mudanças vão via OTA no merge — não precisa rebuild da APK.

## Test plan

- [x] `npm test` 63/63.
- [x] `tsc --noEmit` limpo.
- [x] `eslint .` limpo.
- [x] `prettier --check` limpo.
- [ ] Após merge + OTA: reabrir app 2x pro OTA aplicar; magic link novo; callback deve autenticar em vez de mostrar erro.
- [ ] Se `code` chegar: PKCE path funciona → logado.
- [ ] Se ainda der erro: linha DEBUG mostra o que chegou → próxima hipótese.
