### PR TITLE
chore(debug): remove supabase init debug UI now that auth works end to end

### DIFF
--- a/app/auth/callback.jsx
+++ b/app/auth/callback.jsx
@@ -15,13 +15,9 @@ import { supabase } from "@/infra/supabase";
 // sessão via PKCE, redireciona pra /.
 
 export default function AuthCallback() {
-  const params = useLocalSearchParams();
-  const { code, error, error_description } = params;
+  const { code, error, error_description } = useLocalSearchParams();
   const [status, setStatus] = useState("exchanging");
   const [errorMsg, setErrorMsg] = useState("");
-  // TEMP debug: mostra os params do deep link — se PKCE está funcionando,
-  // `code` deve estar presente. Se hash-flow, params tem outros campos.
-  const debugParams = JSON.stringify(params, null, 2);
 
   useEffect(() => {
     // Supabase pode redirecionar com `?error=...` em vez de `?code=...`
@@ -92,13 +88,6 @@ export default function AuthCallback() {
               Não deu certo
             </Text>
             <Text className="text-sm text-danger">{errorMsg}</Text>
-            {/* TEMP debug: mostra params do deep link pra diagnóstico. */}
-            <Text
-              selectable
-              className="text-xs text-light-text opacity-70 dark:text-dark-text"
-            >
-              DEBUG params: {debugParams}
-            </Text>
             <MyButton
               title="Tentar de novo"
               onPress={() => router.replace("/login")}

--- a/app/index.jsx
+++ b/app/index.jsx
@@ -15,13 +15,7 @@ import SectionLabel from "@/components/SectionLabel";
 
 import { clearAll, getToday, store } from "@/infra/database";
 import { useSession } from "@/infra/session";
-import {
-  AUTH_ENABLED,
-  SUPABASE_ANON_KEY,
-  SUPABASE_URL,
-  supabase,
-  supabaseInitError,
-} from "@/infra/supabase";
+import { AUTH_ENABLED } from "@/infra/supabase";
 import { confirmAction } from "@/constants/dialogs";
 import { getEnvironmentInfo } from "@/constants/environment";
 import { CATEGORY_MAP } from "@/components/categoryUtils";
@@ -183,26 +177,6 @@ export default function Home() {
           <Text className="pt-1 text-center text-xs text-light-text opacity-50 dark:text-dark-text">
             v{ENV.appVersion}
             {ENV.bundle ? ` · ${ENV.bundle}` : ""}
-          </Text>
-          {/* TEMP DEBUG: mostra estado do supabase.js pra diagnóstico do
-              crash "Invalid supabaseUrl" sem precisar de adb logcat. Ver
-              PR #221 e a próxima. Remover assim que bug resolvido. */}
-          <Text
-            selectable
-            className="pt-2 text-center text-xs text-light-text opacity-70 dark:text-dark-text"
-          >
-            DEBUG · url_type={typeof SUPABASE_URL} url_len=
-            {SUPABASE_URL?.length ?? 0} url_head=
-            {JSON.stringify(SUPABASE_URL?.slice(0, 10) ?? "")}
-            {"\n"}
-            key_type={typeof SUPABASE_ANON_KEY} key_len=
-            {SUPABASE_ANON_KEY?.length ?? 0} key_head=
-            {JSON.stringify(SUPABASE_ANON_KEY?.slice(0, 6) ?? "")}
-            {"\n"}
-            auth_enabled={String(AUTH_ENABLED)} supabase_null=
-            {String(supabase === null)}
-            {"\n"}
-            init_err={String(supabaseInitError ?? "none")}
           </Text>
         </Card>
 

--- a/infra/supabase.js
+++ b/infra/supabase.js
@@ -1,4 +1,4 @@
-// @ts-nocheck -- debug patch com let export com narrow inicial null (ADR-002)
+// @ts-nocheck -- `export let supabaseInitError = null` narrow bate no tsc (ADR-002)
 /* global process */
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { createClient } from "@supabase/supabase-js";
@@ -17,34 +17,16 @@ export const SUPABASE_URL = process.env.EXPO_PUBLIC_SUPABASE_URL ?? "";
 export const SUPABASE_ANON_KEY =
   process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY ?? "";
 
-// TEMP debug (crash investigation): logs the URL/key that Metro actually
-// baked at build time. Visible via `adb logcat *:S ReactNativeJS:V`.
-// Remove after fixing.
-console.log(
-  "[supabase-debug] URL type:",
-  typeof SUPABASE_URL,
-  "length:",
-  SUPABASE_URL?.length,
-  "value:",
-  JSON.stringify(SUPABASE_URL),
-);
-console.log(
-  "[supabase-debug] KEY type:",
-  typeof SUPABASE_ANON_KEY,
-  "length:",
-  SUPABASE_ANON_KEY?.length,
-  "first 4:",
-  JSON.stringify(SUPABASE_ANON_KEY?.slice(0, 4)),
-);
-
 export const AUTH_ENABLED = Boolean(SUPABASE_URL && SUPABASE_ANON_KEY);
+
+// Guarda o erro de init pra caso o cliente precise mostrar diagnóstico.
+// Non-null sse `createClient` lançou (ex.: URL inválida — aconteceu no
+// rollout do M6 quando as env vars EAS vieram com control char SYN).
+export let supabaseInitError = null;
 
 // Envelope createClient em try/catch pra crash de validação (ex.: URL
 // inválido) NÃO derrubar o app inteiro. Retorna null e loga — app abre
 // com auth desligada em vez de crash na abertura.
-// TEMP debug: também guarda o erro num export pra UI mostrar (sem ADB).
-export let supabaseInitError = null;
-
 function safeCreateClient() {
   if (!AUTH_ENABLED) return null;
   try {
@@ -66,7 +48,7 @@ function safeCreateClient() {
     });
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
-    console.error("[supabase-debug] createClient falhou:", msg);
+    console.error("[supabase] createClient failed:", msg);
     supabaseInitError = msg;
     return null;
   }


### PR DESCRIPTION
Auth ponta a ponta validada em web e native (magic link, callback, sessão, sync pra sala do userId). Os debug patches que ajudaram a caçar o SYN prefix e o hash-flow do PKCE podem sair.

## O que sai

- **`app/index.jsx`**: remove a linha DEBUG do card Utilitários e os imports que ela precisava (`SUPABASE_URL`, `SUPABASE_ANON_KEY`, `supabase`, `supabaseInitError`). Só `AUTH_ENABLED` fica pra gate do botão Entrar/Sair.
- **`app/auth/callback.jsx`**: remove o dump JSON de `useLocalSearchParams` do card de erro. Destructuring de `code`/`error`/`error_description` continua igual.
- **`infra/supabase.js`**: remove os dois `[supabase-debug]` console.log que printavam URL e key no init do módulo.

## O que fica (permanente, defensivo)

- **`safeCreateClient()` try/catch** — se um misconfig futuro tornar a URL inválida de novo, o app abre com auth desligada em vez de crash loop no init. Foi o único caminho de env ruim → crash loop e vale manter não-fatal.
- **`supabaseInitError` export** — populado quando o catch dispara; UI futura pode usar (ex: banner "Auth indisponível").
- **`flowType: "pkce"`** na config do auth — necessário pro callback native receber `?code=`.

## Test plan

- [x] `npm test` 63/63.
- [x] `tsc --noEmit` limpo.
- [x] `eslint .` limpo.
- [x] `prettier --check` limpo.
- [ ] Pós-merge + OTA: Home fica sem a linha DEBUG. Callback error state (se algum dia disparar) sem JSON dump.
