### PR TITLE
feat(home): move utilities to lateral menu modal, keep only entrar on home

### DIFF
--- a/app/index.jsx
+++ b/app/index.jsx
@@ -1,8 +1,7 @@
 // @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
 //#region imports
-import { useMemo } from "react";
-import { ScrollView, Text, View } from "react-native";
-import { useColorScheme } from "nativewind";
+import { useMemo, useState } from "react";
+import { Pressable, ScrollView, Text, View } from "react-native";
 import { router } from "expo-router";
 import { useTable } from "tinybase/ui-react";
 
@@ -12,18 +11,14 @@ import MyHeader from "@/components/MyHeader";
 import InstallApp from "@/components/InstallApp";
 import Card from "@/components/Card";
 import SectionLabel from "@/components/SectionLabel";
+import MenuModal from "@/components/MenuModal";
 
-import { clearAll, getToday, store } from "@/infra/database";
+import { getToday, store } from "@/infra/database";
 import { useSession } from "@/infra/session";
 import { AUTH_ENABLED } from "@/infra/supabase";
-import { confirmAction } from "@/constants/dialogs";
-import { getEnvironmentInfo } from "@/constants/environment";
 import { CATEGORY_MAP } from "@/components/categoryUtils";
 import { minutesToHHMM } from "@/constants/duration";
 //#endregion
-
-// Versão/bundle exibidos nos Utilitários (#131).
-const ENV = getEnvironmentInfo();
 
 const METRICS = Object.keys(CATEGORY_MAP);
 const TOTAL = METRICS.length;
@@ -52,8 +47,8 @@ function MetricRow({ done, name, detail }) {
 }
 
 export default function Home() {
-  const { toggleColorScheme } = useColorScheme();
-  const { user, signOut } = useSession();
+  const { user } = useSession();
+  const [menuOpen, setMenuOpen] = useState(false);
 
   // Assina a tabela: `useTable` re-renderiza a cada mudança nos registros —
   // inclusive quando o `startAutoLoad()` da persistência termina de carregar.
@@ -66,16 +61,6 @@ export default function Home() {
   // olham os mesmos dados e sugere remover — o que reintroduziria o #108.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const today = useMemo(() => getToday(), [records]);
-
-  function handleClear() {
-    confirmAction({
-      title: "Limpar todos os dados",
-      message: "Isso apaga todos os registros. Tem certeza?",
-      confirmLabel: "Limpar",
-      // A assinatura da store cuida do re-render; não precisa reler na mão.
-      onConfirm: clearAll,
-    });
-  }
 
   const rows = METRICS.map((type) => {
     const { displayName, unit } = CATEGORY_MAP[type];
@@ -104,6 +89,22 @@ export default function Home() {
         contentContainerStyle={{ padding: 16, gap: 16, alignItems: "center" }}
         showsVerticalScrollIndicator={false}
       >
+        {/* Trigger do menu lateral: hamburger alinhado à direita, no fluxo
+            do documento pra respeitar padding/safe area do MyView (posição
+            absoluta ignoraria essas margens). */}
+        <View className="w-full flex-row justify-end">
+          <Pressable
+            accessibilityLabel="Abrir menu"
+            accessibilityRole="button"
+            onPress={() => setMenuOpen(true)}
+            className="rounded-full p-2"
+          >
+            <Text className="text-2xl text-light-text dark:text-dark-text">
+              ☰
+            </Text>
+          </Pressable>
+        </View>
+
         {/* Resumo do dia */}
         <Card className="gap-2">
           <Text className="font-bold text-2xl text-light-text dark:text-dark-text">
@@ -138,47 +139,17 @@ export default function Home() {
         {/* Obter o app (só web: QR no desktop, download no celular) */}
         <InstallApp />
 
-        {/* Utilitários */}
-        <Card className="gap-2">
-          <SectionLabel>UTILITÁRIOS</SectionLabel>
-          <MyButton title="Alternar tema" onPress={() => toggleColorScheme()} />
-          <MyButton
-            title="Histórico"
-            onPress={() => router.navigate("/history")}
-          />
-          <MyButton title="Limpar todos os dados" onPress={handleClear} />
-          <MyButton
-            title="Enviar feedback"
-            onPress={() => router.navigate("/feedback")}
-          />
-          <MyButton
-            title="Roadmap do projeto"
-            onPress={() => router.navigate("/roadmap")}
-          />
-          {/* Auth (fatia A do M6): botão condicional. Só aparece se as env
-              vars do Supabase estiverem configuradas — do contrário, o botão
-              não faria nada útil. Sync ainda anônimo nesta fatia. */}
-          {AUTH_ENABLED &&
-            (user ? (
-              <>
-                <Text className="pt-1 text-center text-xs text-light-text opacity-70 dark:text-dark-text">
-                  Logado como {user.email}
-                </Text>
-                <MyButton title="Sair" onPress={() => signOut()} />
-              </>
-            ) : (
-              <MyButton
-                title="Entrar"
-                onPress={() => router.navigate("/login")}
-              />
-            ))}
-          {/* Versão visível pro tester saber (e reportar) em qual bundle está —
-              o OTA troca o JS sem mudar a versão do app (#131). */}
-          <Text className="pt-1 text-center text-xs text-light-text opacity-50 dark:text-dark-text">
-            v{ENV.appVersion}
-            {ENV.bundle ? ` · ${ENV.bundle}` : ""}
-          </Text>
-        </Card>
+        {/* Entrar isolado só quando deslogado + auth configurada. Sair vai
+            pro MenuModal junto com "Logado como" — Home enxuta em ambos
+            estados de auth. */}
+        {AUTH_ENABLED && !user && (
+          <Card className="gap-2">
+            <MyButton
+              title="Entrar"
+              onPress={() => router.navigate("/login")}
+            />
+          </Card>
+        )}
 
         {/* Wordmark discreto — marca presente na tela principal sem competir
             com o conteúdo. Ver docs/08-design-tokens.md § Identidade visual. */}
@@ -186,6 +157,8 @@ export default function Home() {
           Back on Track · de volta aos trilhos, um registro por vez
         </Text>
       </ScrollView>
+
+      <MenuModal visible={menuOpen} onClose={() => setMenuOpen(false)} />
     </MyView>
   );
 }

--- a/app/index.jsx
+++ b/app/index.jsx
@@ -89,10 +89,10 @@ export default function Home() {
         contentContainerStyle={{ padding: 16, gap: 16, alignItems: "center" }}
         showsVerticalScrollIndicator={false}
       >
-        {/* Trigger do menu lateral: hamburger alinhado à direita, no fluxo
-            do documento pra respeitar padding/safe area do MyView (posição
-            absoluta ignoraria essas margens). */}
-        <View className="w-full flex-row justify-end">
+        {/* Trigger do menu lateral: hamburger alinhado à esquerda pra
+            casar com o painel que abre da esquerda (padrão de app mobile).
+            No fluxo do documento pra respeitar padding/safe area do MyView. */}
+        <View className="w-full flex-row justify-start">
           <Pressable
             accessibilityLabel="Abrir menu"
             accessibilityRole="button"

--- a/components/MenuModal.jsx
+++ b/components/MenuModal.jsx
@@ -1,5 +1,5 @@
 // @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
-import { Modal, Pressable, ScrollView, Text, View } from "react-native";
+import { Modal, Pressable, ScrollView, Switch, Text, View } from "react-native";
 import { useColorScheme } from "nativewind";
 import { router } from "expo-router";
 
@@ -19,8 +19,9 @@ const ENV = getEnvironmentInfo();
 // com backdrop tap-to-close. Ver decisão em conversation (drawer requeria
 // gesture-handler nativo = APK nova).
 export default function MenuModal({ visible, onClose }) {
-  const { toggleColorScheme } = useColorScheme();
+  const { colorScheme, toggleColorScheme } = useColorScheme();
   const { user, signOut } = useSession();
+  const isDark = colorScheme === "dark";
 
   // Fecha antes de navegar/agir — evita ver o modal por cima da tela nova.
   function navigateTo(path) {
@@ -71,10 +72,20 @@ export default function MenuModal({ visible, onClose }) {
               title="Roadmap do projeto"
               onPress={() => navigateTo("/roadmap")}
             />
-            <MyButton
-              title="Alternar tema"
-              onPress={() => toggleColorScheme()}
-            />
+            {/* Toggle de tema no padrão mobile — Switch nativo com label
+                à esquerda. Reflete o estado atual em vez de só "alternar"
+                (usuário sabe se está no dark antes de clicar). */}
+            <View className="flex-row items-center justify-between py-2">
+              <Text className="text-base text-light-text dark:text-dark-text">
+                Tema escuro
+              </Text>
+              <Switch
+                value={isDark}
+                onValueChange={() => toggleColorScheme()}
+                accessibilityLabel="Alternar tema escuro"
+              />
+            </View>
+
             <MyButton title="Limpar todos os dados" onPress={handleClear} />
 
             {AUTH_ENABLED && user && (

--- a/components/MenuModal.jsx
+++ b/components/MenuModal.jsx
@@ -1,0 +1,103 @@
+// @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
+import { Modal, Pressable, ScrollView, Text, View } from "react-native";
+import { useColorScheme } from "nativewind";
+import { router } from "expo-router";
+
+import MyButton from "./MyButton";
+import SectionLabel from "./SectionLabel";
+
+import { clearAll } from "@/infra/database";
+import { useSession } from "@/infra/session";
+import { AUTH_ENABLED } from "@/infra/supabase";
+import { confirmAction } from "@/constants/dialogs";
+import { getEnvironmentInfo } from "@/constants/environment";
+
+const ENV = getEnvironmentInfo();
+
+// Painel de utilitários lateral (esquerda). Aberto pelo botão hamburger da Home.
+// Modal RN nativo (sem dep nova de drawer) — animação fade, painel fixo à esquerda
+// com backdrop tap-to-close. Ver decisão em conversation (drawer requeria
+// gesture-handler nativo = APK nova).
+export default function MenuModal({ visible, onClose }) {
+  const { toggleColorScheme } = useColorScheme();
+  const { user, signOut } = useSession();
+
+  // Fecha antes de navegar/agir — evita ver o modal por cima da tela nova.
+  function navigateTo(path) {
+    onClose();
+    router.navigate(path);
+  }
+
+  function handleClear() {
+    onClose();
+    confirmAction({
+      title: "Limpar todos os dados",
+      message: "Isso apaga todos os registros. Tem certeza?",
+      confirmLabel: "Limpar",
+      onConfirm: clearAll,
+    });
+  }
+
+  function handleSignOut() {
+    onClose();
+    signOut();
+  }
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+      statusBarTranslucent
+    >
+      <View className="flex-1 flex-row">
+        {/* Painel */}
+        <View className="w-4/5 max-w-sm bg-light-background dark:bg-dark-background">
+          <ScrollView
+            contentContainerStyle={{ padding: 16, gap: 12 }}
+            showsVerticalScrollIndicator={false}
+          >
+            <SectionLabel>MENU</SectionLabel>
+            <MyButton
+              title="Histórico"
+              onPress={() => navigateTo("/history")}
+            />
+            <MyButton
+              title="Enviar feedback"
+              onPress={() => navigateTo("/feedback")}
+            />
+            <MyButton
+              title="Roadmap do projeto"
+              onPress={() => navigateTo("/roadmap")}
+            />
+            <MyButton
+              title="Alternar tema"
+              onPress={() => toggleColorScheme()}
+            />
+            <MyButton title="Limpar todos os dados" onPress={handleClear} />
+
+            {AUTH_ENABLED && user && (
+              <>
+                <Text className="pt-2 text-center text-xs text-light-text opacity-70 dark:text-dark-text">
+                  Logado como {user.email}
+                </Text>
+                <MyButton title="Sair" onPress={handleSignOut} />
+              </>
+            )}
+
+            {/* Versão pro tester (info diagnóstico). Fica no rodapé do menu
+                em vez de na Home pra não competir com o conteúdo (#131). */}
+            <Text className="pt-4 text-center text-xs text-light-text opacity-50 dark:text-dark-text">
+              v{ENV.appVersion}
+              {ENV.bundle ? ` · ${ENV.bundle}` : ""}
+            </Text>
+          </ScrollView>
+        </View>
+
+        {/* Backdrop tap-to-close */}
+        <Pressable className="flex-1 bg-black/40" onPress={onClose} />
+      </View>
+    </Modal>
+  );
+}

--- a/components/MenuModal.jsx
+++ b/components/MenuModal.jsx
@@ -59,7 +59,29 @@ export default function MenuModal({ visible, onClose }) {
             contentContainerStyle={{ padding: 16, gap: 12 }}
             showsVerticalScrollIndicator={false}
           >
-            <SectionLabel>MENU</SectionLabel>
+            {/* Cabeçalho: label MENU à esquerda, toggle de tema à direita
+                (sol ⇄ lua flanqueando o slider — padrão de app mobile). */}
+            <View className="flex-row items-center justify-between">
+              <SectionLabel>MENU</SectionLabel>
+              <View className="flex-row items-center gap-2">
+                <Text
+                  className={`text-base ${isDark ? "opacity-40" : "opacity-100"}`}
+                >
+                  ☀️
+                </Text>
+                <Switch
+                  value={isDark}
+                  onValueChange={() => toggleColorScheme()}
+                  accessibilityLabel="Alternar tema escuro"
+                />
+                <Text
+                  className={`text-base ${isDark ? "opacity-100" : "opacity-40"}`}
+                >
+                  🌙
+                </Text>
+              </View>
+            </View>
+
             <MyButton
               title="Histórico"
               onPress={() => navigateTo("/history")}
@@ -72,20 +94,6 @@ export default function MenuModal({ visible, onClose }) {
               title="Roadmap do projeto"
               onPress={() => navigateTo("/roadmap")}
             />
-            {/* Toggle de tema no padrão mobile — Switch nativo com label
-                à esquerda. Reflete o estado atual em vez de só "alternar"
-                (usuário sabe se está no dark antes de clicar). */}
-            <View className="flex-row items-center justify-between py-2">
-              <Text className="text-base text-light-text dark:text-dark-text">
-                Tema escuro
-              </Text>
-              <Switch
-                value={isDark}
-                onValueChange={() => toggleColorScheme()}
-                accessibilityLabel="Alternar tema escuro"
-              />
-            </View>
-
             <MyButton title="Limpar todos os dados" onPress={handleClear} />
 
             {AUTH_ENABLED && user && (


### PR DESCRIPTION
Card de Utilitários estava acumulando ações (5 itens + auth + versão), competindo com as métricas do dia na Home. Move tudo pra um menu lateral, deixa Home enxuta.

## O que entra

- **`components/MenuModal.jsx`** (novo) — RN Modal, animação fade, painel 80% width alinhado à esquerda, backdrop tap-to-close. Renderiza:
  - Navegação: Histórico, Enviar feedback, Roadmap do projeto
  - Ações: Alternar tema, Limpar todos os dados
  - Auth (quando logado): "Logado como <email>" + Sair
  - Rodapé: versão + bundle (info de diagnóstico dos testers, sai da Home)

- **Trigger hamburger** `☰` no topo direito da ScrollView da Home. Em fluxo do documento (não absolute), respeitando o padding/safe area do MyView.

## Home muda

- Removido o card Utilitários inteiro.
- Auth na Home agora é só o botão **Entrar**, mostrado quando `AUTH_ENABLED && !user`. Sign-out vive no menu junto com o email da conta. Home enxuta em ambos os estados.
- Versão/bundle migrou pro rodapé do menu.
- Wordmark segue como fechamento da Home.

## Sem dep nova (por que Modal em vez de Drawer)

Escolhido RN Modal em vez de `@react-navigation/drawer` — o drawer puxaria `react-native-gesture-handler` (native module), forçando cortar APK 1.2.0 + toda a dança de rollout que a gente acabou de fechar pros native modules do auth (bump `app.json.version`, cut EAS build, atualizar `EAS_INSTALL_URL`, `roll-back-to-embedded` no 1.1.0, dizer pros testers reinstalarem).

Trade-off consciente: sem gesture de swipe-from-edge. Usuário toca no hamburger, painel entra em fade.

## Test plan

- [x] `npm test` 63/63.
- [x] `tsc --noEmit` limpo.
- [x] `eslint .` limpo.
- [x] `prettier --check` limpo.
- [ ] Preview do PR: verificar hamburger visível no topo direito; abrir menu; navegar pra Histórico/Feedback/Roadmap (voltar funciona); Alternar tema; Limpar dados dispara o confirm dialog; Sair funciona (logado); Entrar funciona (deslogado, na Home mesmo).
- [ ] Pós-merge OTA: testers recebem sem reinstalar.
EOF