### PR TITLE
fix(menu): apply safe-area top inset to menu modal panel

### DIFF
--- a/components/MenuModal.jsx
+++ b/components/MenuModal.jsx
@@ -4,6 +4,7 @@ import { useColorScheme } from "nativewind";
 import { router } from "expo-router";
 
 import MyButton from "./MyButton";
+import MyView from "./MyView";
 import SectionLabel from "./SectionLabel";
 
 import { clearAll } from "@/infra/database";
@@ -53,8 +54,10 @@ export default function MenuModal({ visible, onClose }) {
       statusBarTranslucent
     >
       <View className="flex-1 flex-row">
-        {/* Painel */}
-        <View className="w-4/5 max-w-sm bg-light-background dark:bg-dark-background">
+        {/* Painel. MyView safe=true aplica paddingTop=insets.top pro conteúdo
+            não colidir com clock/status-bar icons — o Modal usa
+            statusBarTranslucent, então sem safe-area o topo fica sob a barra. */}
+        <MyView className="w-4/5 max-w-sm bg-light-background dark:bg-dark-background">
           <ScrollView
             contentContainerStyle={{ padding: 16, gap: 12 }}
             showsVerticalScrollIndicator={false}
@@ -112,7 +115,7 @@ export default function MenuModal({ visible, onClose }) {
               {ENV.bundle ? ` · ${ENV.bundle}` : ""}
             </Text>
           </ScrollView>
-        </View>
+        </MyView>
 
         {/* Backdrop tap-to-close */}
         <Pressable className="flex-1 bg-black/40" onPress={onClose} />


### PR DESCRIPTION
Fix reportado por screenshot: o cabeçalho do menu lateral ("MENU" + toggle de tema ☀️🌙) invadia a barra de status do Android (colisão com clock/battery/wifi icons).

## Causa

O `Modal` usa `statusBarTranslucent` (que é o certo — cobre a tela toda pra o backdrop preto funcionar edge-to-edge). Mas o painel dentro dele começava a renderizar no pixel 0 sem respeitar a safe-area do topo, então "MENU" + toggle caíam sob o status bar.

## Fix

Trocar o `View` do painel por `MyView` (componente do próprio codebase que aplica `paddingTop: insets.top` + `paddingBottom: insets.bottom` via `useSafeAreaInsets`). Mesmo padrão que todas as outras telas top-level usam.

## Test plan

- [x] `npm test` (63/63).
- [x] `tsc --noEmit` limpo.
- [x] `eslint .` limpo.
- [x] `prettier --check` limpo.
- [ ] Smoke visual pós-OTA no seu device: abrir o menu, confirmar que "MENU" e o toggle começam abaixo do clock.