### PR TITLE
chore(release): bump app version to 1.1.1

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "name": "Back on Track",
     "slug": "backOnTrack",
     "scheme": "backontrack",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",


### PR DESCRIPTION
Patch bump pra permitir cortar APK novo com os assets nativos do M5-B (#228).

## Por quê

As mudanças de #229 (4 PNGs de identidade + `adaptiveIcon.backgroundColor`) são **assets nativos** — o `publish-update.yaml` que rodou automático no merge só publica JS bundle via OTA e deixou os assets nativos de fora. Meu device (matheus) continua rodando APK beta.5 com PNGs template.

Sem bumpar `version`, o release.yaml tentaria publicar num runtime idêntico ao APK atual — cai no mesmo incidente do PR #218 (crash silencioso ou update-em-cima-de-embed-antigo).

## O que muda

- `app.json` → `version` de `1.1.0` pra `1.1.1`

## Próximo passo (fora deste PR)

Depois de merged, disparar `release.yaml` com tag `v1.1.1` — o workflow constrói APK novo no EAS, publica release no GitHub, e empurra branch atualizando `EAS_INSTALL_URL` pro card "Obter o app". Mergear essa branch, e o design pousa em quem instalar/reinstalar.

## Test plan

- [x] Diff é 1 linha de config, sem impacto em código.
- [ ] CI (Prettier/Eslint/Types/Test) deve passar trivialmente.