### PR TITLE
chore(install): aponta a instalação pro build v1.1.1

### DIFF
--- a/constants/distribution.js
+++ b/constants/distribution.js
@@ -12,7 +12,7 @@
 // Internet, mas trava no Chrome). Ciclo 3, #74.
 
 export const EAS_INSTALL_URL =
-  "https://expo.dev/accounts/matheushnascimento/projects/backOnTrack/builds/2e4d014d-d558-4c6d-9d75-0d2c2be81870";
+  "https://expo.dev/accounts/matheushnascimento/projects/backOnTrack/builds/31173d89-2af7-4a7e-8a09-f4f0b84d574b";
 
 export const APK_URL =
   "https://github.com/matheushnascimento/backOnTrack/releases/latest/download/backOnTrack.apk";


### PR DESCRIPTION
Aponta o card "Obter o app" pra o novo build EAS do v1.1.1 (release automático via `release.yaml`, run [30778781207](https://github.com/matheushnascimento/backOnTrack/actions/runs/30778781207)).

## O que muda

- `constants/distribution.js` — `EAS_INSTALL_URL` passa de `.../builds/2e4d014d-...` (beta.5 / v1.1.0) pra `.../builds/31173d89-...` (v1.1.1).

## Contexto

Novo build v1.1.1 carrega os assets nativos do M5-B (ícones + `adaptiveIcon.backgroundColor`) que não chegavam via OTA. Sem esse PR, o card de instalação continua apontando pra APK antigo — usuário novo baixaria o v1.1.0.

## Test plan

- [x] Diff é 1 linha (URL do build), automatizado por `release.yaml`.
- [ ] Pós-merge: OTA reempurra o card com o link novo pros installs existentes.