### PR TITLE
chore(design-v2): foundation — tokens, fonts, docs (M5-B slice 0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,8 @@ convite.txt
 # Bind-mount do docker compose vira `server/data/` no host de dev.
 server/data/
 
+# Fonte visual do design v2 (Claude Design bundle, M5-B). ~600KB, referência
+# local — os tokens extraídos vivem em docs/09-design-v2.md.
+Back on Track - Icon Directions.html
+
+

--- a/app/_layout.jsx
+++ b/app/_layout.jsx
@@ -4,6 +4,17 @@ import "@/global.css";
 import { Stack } from "expo-router";
 import { View } from "react-native";
 import { SafeAreaProvider } from "react-native-safe-area-context";
+import { useFonts } from "expo-font";
+import {
+  Inter_400Regular,
+  Inter_500Medium,
+  Inter_600SemiBold,
+} from "@expo-google-fonts/inter";
+import {
+  JetBrainsMono_400Regular,
+  JetBrainsMono_500Medium,
+} from "@expo-google-fonts/jetbrains-mono";
+
 import { useRegistrosPersistencia } from "@/infra/persistence";
 import { SessionProvider } from "@/infra/session";
 import { useRegistrosSync } from "@/infra/sync";
@@ -11,6 +22,17 @@ import UpdateBanner from "@/components/UpdateBanner";
 
 export default function RootLayout() {
   useRegistrosPersistencia();
+  // Fontes do design v2 (M5-B fatia 0). Carrega em background; se ainda não
+  // tiver terminado, sistema serve o fallback e a UI re-renderiza quando
+  // ficarem prontas. Não bloqueia boot pra não introduzir splash extra —
+  // fatia 1+ é que começa a usar essas famílias. Ver docs/09-design-v2.md.
+  useFonts({
+    Inter_400Regular,
+    Inter_500Medium,
+    Inter_600SemiBold,
+    JetBrainsMono_400Regular,
+    JetBrainsMono_500Medium,
+  });
 
   return (
     <SafeAreaProvider>

--- a/docs/08-design-tokens.md
+++ b/docs/08-design-tokens.md
@@ -1,5 +1,7 @@
 # Design Tokens — Back on Track
 
+> **Nota (M5-B, agosto 2026):** o redesign completo baseado no Turno 2 do Claude Design vive em [09-design-v2.md](09-design-v2.md). Este doc segue como baseline pra telas ainda não migradas — os dois convergem quando todas as fatias 1-6 do v2 estiverem em produção.
+
 Referência viva do design system do M5. Cada seção fecha uma decisão sobre um **eixo** (raio, tipografia, espaçamento, cor…) e mostra onde ela vale. O objetivo é matar as escolhas ad-hoc que a auditoria pegou em [docs/07-auditoria-ui.md](07-auditoria-ui.md) — de forma que "qual valor uso aqui?" tenha uma resposta óbvia em cada eixo.
 
 O doc cresce em fatias: começa com raio (fatia 1); tipografia, espaçamento, sombra e cor entram conforme a milestone avança. Cada fatia deve ter um PR próprio e um item ✅ no roadmap.

--- a/docs/09-design-v2.md
+++ b/docs/09-design-v2.md
@@ -1,0 +1,111 @@
+# Design v2 — Back on Track
+
+Este documento é a fonte única dos tokens visuais do redesign completo (M5-B) baseado no Turno 2 do Claude Design. **Estende** e progressivamente substitui a base do [08-design-tokens.md](./08-design-tokens.md) — os tokens M5 continuam válidos até que cada tela seja migrada.
+
+## Tom
+
+**Retomada, não conquista.** Sem streaks, sem badges, sem exclamação. O usuário vem, registra, sai. Copy calma: "3 registros hoje. Sem pressa." em vez de "🎉 Parabéns! Você bateu sua meta!".
+
+## Paleta
+
+### Marca (canônica, sem cor nova)
+
+| Token         | Hex       | Uso                                           |
+| ------------- | --------- | --------------------------------------------- |
+| `brand-blue`  | `#2E5A88` | Ícone, ações primárias, identidade            |
+| `brand-green` | `#4CAF50` | Ponto de partida do símbolo, sucesso discreto |
+| `bg-canvas`   | `#F8F9FA` | Fundo geral (light), splash background        |
+| `ink`         | `#0F1419` | Texto principal, alto contraste               |
+
+### Grays semânticos (novos)
+
+Vindos do design, mapeando aos usos concretos das mockups.
+
+| Token            | Hex       | Uso                                                                             |
+| ---------------- | --------- | ------------------------------------------------------------------------------- |
+| `label`          | `#6B7280` | Section labels (MENU, MÉTRICAS DE HOJE), metadados (data, contadores discretos) |
+| `body-secondary` | `#4B5563` | Texto secundário — descrições curtas embaixo de headings                        |
+| `border-subtle`  | `#E5E7EB` | Borda de card, divisor fino                                                     |
+| `border-strong`  | `#D1D5DB` | Borda mais forte quando precisa contraste                                       |
+| `surface-subtle` | `#F3F4F6` | Fundo interno de área secundária (row hover, section bg)                        |
+| `icon-dim`       | `#9CA3AF` | Ícone desativado ou de peso menor                                               |
+
+### Tint
+
+| Token       | Hex       | Uso                                                       |
+| ----------- | --------- | --------------------------------------------------------- |
+| `tint-blue` | `#EAF3FB` | Fundo do container de ícone da métrica água (azul lavado) |
+
+Métricas usam o mesmo padrão de tint. Cada métrica ganha o seu no roadmap — não hardcode aqui além do exemplo água.
+
+## Tipografia
+
+Duas famílias, ambas via `expo-font` + `@expo-google-fonts/*` (OTA-safe, sem native change):
+
+- **Inter** (400/500/600) — corpo e headings
+- **JetBrains Mono** (400/500) — labels em uppercase (section headers, chips)
+
+### Escala (px direto — sem rem, sem `62.5%`)
+
+| Papel         | Size / Weight / Family            | Nota                                       |
+| ------------- | --------------------------------- | ------------------------------------------ |
+| Section label | 11px · 500 · JetBrains Mono UPPER | tracking `0.1em`                           |
+| Tag/chip      | 11px · 500 · JetBrains Mono UPPER | tracking `0.12em`                          |
+| Small         | 12-13px · 400 · Inter             | metadados, descrições curtas               |
+| Body          | 14-15px · 400 · Inter             | texto padrão                               |
+| Body strong   | 14px · 500 · Inter                | destaques inline                           |
+| Subhead       | 18-20px · 500 · Inter             | títulos de card                            |
+| H1 tela       | 24px · 600 · Inter                | "Bom dia, Ana."                            |
+| H1 documento  | 32px · 600 · Inter                | headers de página fora do app (docs, mock) |
+
+Corpo em 14-15px é **menor** que o M5 baseline de 17px (iOS-aligned). Migração é gradual — telas velhas seguem no 17, telas novas nascem no 14. Convergem quando todas migrarem.
+
+## Radius
+
+| Token            | Value | Uso                                           |
+| ---------------- | ----- | --------------------------------------------- |
+| `radius-tag`     | 2px   | Chips/tags pequenas                           |
+| `radius-icon`    | 12px  | Container de ícone de métrica (44×44)         |
+| `radius-card`    | 16px  | Card padrão                                   |
+| `radius-full`    | 999px | Pills, avatars, alguns botões                 |
+| (frame do phone) | 42px  | Só nas mockups do design, não é radius do app |
+
+M5 já tem `rounded-full` / `rounded-lg` / `rounded-md`. Reaproveita: `rounded-full` (=999px), `rounded-2xl` (=16px, mesmo do `radius-card`), etc. Ver 08.
+
+## Componentes-chave (do design)
+
+### Metric card (Home)
+
+```
++--------------------------------------------+
+| [icon-container 44×44 tint bg]  Água       |
+|                                  350ml     |
++--------------------------------------------+
+```
+
+- Card: `bg-white`, `rounded-2xl` (16px), `border-subtle` (`#E5E7EB`), padding 16px
+- Ícone container: 44×44px, `radius-icon` (12px), fundo tint por-métrica (`tint-blue` pra água)
+- Nome: 14px/500 Inter, cor `ink`
+- Estado: 12-13px/400 Inter, cor `label` ou valor (ml/refeição) em 14px
+
+### Section label
+
+Uppercase, JetBrains Mono 11px, cor `label`, tracking 0.1em. Reusar via `<SectionLabel>` que já existe (só troca a família da fonte).
+
+### Icon container tinted
+
+44×44, `rounded-xl` (12px), fundo tint por-métrica, ícone SVG 22×22 dentro na cor da marca ou cor semântica.
+
+## O que vem quando
+
+Fatia 0 (esta): docs, tokens em `tailwind.config.js`, fontes carregadas no boot. **Nada visual muda.**
+
+Fatias 1-5: Home → registro → semana → ajustes → empty state. Cada tela consome os tokens acima.
+
+Fatia 6: substituir os 4 assets do ícone (`icon.png`, `adaptive-icon.png`, `splash-icon.png`, `favicon.png`) pela **direção 1c (Linha que sobe)**. Mudança nativa → bump `version` → APK 1.2.0.
+
+## Ver também
+
+- [08-design-tokens.md](./08-design-tokens.md) — baseline M5 (ainda válido pras telas não migradas)
+- [04-roadmap-milestones.md](./04-roadmap-milestones.md) — item M5-B na milestone Design System
+- Arquivo `Back on Track - Icon Directions.html` no repo local (gitignored) — fonte visual do Claude Design

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "backOnTrack",
       "version": "1.0.0",
       "dependencies": {
+        "@expo-google-fonts/inter": "^0.4.2",
+        "@expo-google-fonts/jetbrains-mono": "^0.4.1",
         "@expo/metro-runtime": "~57.0.2",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native-vector-icons/material-design-icons": "^13.1.2",
@@ -2046,6 +2048,18 @@
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
+    },
+    "node_modules/@expo-google-fonts/inter": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/inter/-/inter-0.4.2.tgz",
+      "integrity": "sha512-syfiImMaDmq7cFi0of+waE2M4uSCyd16zgyWxdPOY7fN2VBmSLKEzkfbZgeOjJq61kSqPBNNtXjggiQiSD6gMQ==",
+      "license": "MIT AND OFL-1.1"
+    },
+    "node_modules/@expo-google-fonts/jetbrains-mono": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/jetbrains-mono/-/jetbrains-mono-0.4.1.tgz",
+      "integrity": "sha512-CslACrtMOcRwoWXCO7OMEI+9w3fukWSoBtvNz46OqPoogEuuoY0tkDY1O8sFumk8t0pC6Cx0Xr95O0TOQhpkug==",
+      "license": "MIT AND OFL-1.1"
     },
     "node_modules/@expo-google-fonts/material-symbols": {
       "version": "0.4.38",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "test": "jest"
   },
   "dependencies": {
+    "@expo-google-fonts/inter": "^0.4.2",
+    "@expo-google-fonts/jetbrains-mono": "^0.4.1",
     "@expo/metro-runtime": "~57.0.2",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-vector-icons/material-design-icons": "^13.1.2",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,6 +13,17 @@ module.exports = {
         danger: Colors.danger,
         light: Colors.light,
         dark: Colors.dark,
+        // Tokens semânticos do design v2 (M5-B). Ver docs/09-design-v2.md.
+        // Adicionados sem remover nada do M5 — telas antigas seguem com o
+        // baseline; telas novas nascem consumindo estes.
+        ink: "#0F1419",
+        label: "#6B7280",
+        "body-secondary": "#4B5563",
+        "border-subtle": "#E5E7EB",
+        "border-strong": "#D1D5DB",
+        "surface-subtle": "#F3F4F6",
+        "icon-dim": "#9CA3AF",
+        "tint-blue": "#EAF3FB",
       },
       // Escala de tipografia canônica do M5 — px direto (não rem) pra não
       // depender de font-size base do html, que no bundle web tinha um truque


### PR DESCRIPTION
Fatia 0 do redesign completo (Turno 2 do Claude Design canvas). Prepara chão sem mexer em tela — as fatias 1-6 vão consumir tokens/fontes/docs daqui.

## O que entra

- **`docs/09-design-v2.md`** (novo) — fonte única dos tokens v2:
  - Paleta de marca (canônica, sem cor nova): `#2E5A88`, `#4CAF50`, `#F8F9FA`, `#0F1419`
  - Grays semânticos novos: `label` (#6B7280), `body-secondary` (#4B5563), `border-subtle` (#E5E7EB), `border-strong` (#D1D5DB), `surface-subtle` (#F3F4F6), `icon-dim` (#9CA3AF)
  - Tint: `tint-blue` (#EAF3FB) pro fundo do ícone de métrica água
  - Tipografia: Inter (400/500/600) + JetBrains Mono (400/500), escala em px
  - Radius: 16px card, 12px icon container, 999px pill, 2px tag
  - Tom: "retomada, não conquista"
- **`tailwind.config.js`** — adiciona os semânticos como utility classes. Nada removido; baseline M5 (`danger`, `secondary`, escala tipográfica) intacto.
- **`app/_layout.jsx`** — preload de Inter e JetBrains Mono via `expo-font` + `@expo-google-fonts/*`. Não bloqueia boot (system font como fallback até carregar).
- **`docs/08-design-tokens.md`** — nota no topo apontando pra 09. Os dois coexistem até todas as telas migrarem.
- **`.gitignore`** — ignora o `Back on Track - Icon Directions.html` local (~580KB, fonte visual do Claude Design).

## Sem mudança nativa

`@expo-google-fonts/inter` e `@expo-google-fonts/jetbrains-mono` são pure-JS + assets de fonte. `expo-font` já está presente transitivamente (expo-router usa; app já carrega MaterialSymbols pelo mesmo caminho). Ship via OTA.

## Fora de escopo

- Home, telas de registro, semana, ajustes, empty state (fatias 1-5)
- Substituir os 4 assets do ícone pela direção 1c (fatia 6, mudança nativa → APK 1.2.0)

## Test plan

- [x] `npm test` 63/63.
- [x] `tsc --noEmit` limpo.
- [x] `eslint .` limpo.
- [x] `prettier --check` limpo.
- [ ] Preview do PR (Vercel): verificar que nenhuma tela visualmente mudou — só tokens e fonte carregando em background.

Closes #232.
