### PR TITLE
feat(design-v2): new home layout with 5 metric cards (M5-B slice 1)

### DIFF
--- a/app/index.jsx
+++ b/app/index.jsx
@@ -5,13 +5,11 @@ import { Pressable, ScrollView, Text, View } from "react-native";
 import { router } from "expo-router";
 import { useTable } from "tinybase/ui-react";
 
-import MyButton from "@/components/MyButton";
 import MyView from "@/components/MyView";
-import MyHeader from "@/components/MyHeader";
 import InstallApp from "@/components/InstallApp";
-import Card from "@/components/Card";
-import SectionLabel from "@/components/SectionLabel";
+import MetricCard from "@/components/MetricCard";
 import MenuModal from "@/components/MenuModal";
+import Icon1c from "@/components/Icon1c";
 
 import { getToday, store } from "@/infra/database";
 import { useSession } from "@/infra/session";
@@ -21,29 +19,38 @@ import { minutesToHHMM } from "@/constants/duration";
 //#endregion
 
 const METRICS = Object.keys(CATEGORY_MAP);
-const TOTAL = METRICS.length;
 
-// Total do dia formatado por unidade: minutos -> HH:MM; refeição pluraliza;
-// o resto (ml) sai cru com a unidade.
-function formatTotal(unit, total) {
+// Formata o total do dia por unidade. Migração v2: usa vírgula pra ml (padrão pt-BR)
+// e HH:MM pra minutos. Pluraliza refeição.
+function formatValue(unit, total) {
   if (unit === "min") return minutesToHHMM(total);
   if (unit === "refeição")
     return `${total} ${total === 1 ? "refeição" : "refeições"}`;
+  if (unit === "ml") return `${total.toLocaleString("pt-BR")} ml`;
   return `${total} ${unit}`;
 }
 
-function MetricRow({ done, name, detail }) {
-  return (
-    <View className="flex-row items-center gap-2">
-      <Text className="text-base">{done ? "✅" : "⬜"}</Text>
-      <Text className="flex-1 text-base text-light-text dark:text-dark-text">
-        {name}
-      </Text>
-      <Text className="text-sm text-light-text opacity-70 dark:text-dark-text">
-        {detail}
-      </Text>
-    </View>
-  );
+// Saudação por horário. Design v2 usa "Bom dia, Ana." — nome vem do email
+// do usuário logado; deslogado usa só o cumprimento.
+function getGreeting(user) {
+  const h = new Date().getHours();
+  const g = h < 12 ? "Bom dia" : h < 18 ? "Boa tarde" : "Boa noite";
+  if (!user?.email) return `${g}.`;
+  const raw = user.email.split("@")[0];
+  const name = raw.charAt(0).toUpperCase() + raw.slice(1).toLowerCase();
+  return `${g}, ${name}.`;
+}
+
+// Data no formato "SEGUNDA · 12 AGO" (pt-BR, uppercase). Usada como label
+// discreto acima do greeting.
+function formatDateLabel() {
+  const d = new Date();
+  const weekday = d.toLocaleDateString("pt-BR", { weekday: "long" });
+  const day = d.getDate();
+  const month = d
+    .toLocaleDateString("pt-BR", { month: "short" })
+    .replace(".", "");
+  return `${weekday} · ${day} ${month}`.toUpperCase();
 }
 
 export default function Home() {
@@ -62,36 +69,35 @@ export default function Home() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const today = useMemo(() => getToday(), [records]);
 
-  const rows = METRICS.map((type) => {
+  const totalRecords = METRICS.reduce((s, m) => s + (today[m]?.length ?? 0), 0);
+
+  const cards = METRICS.map((type) => {
     const { displayName, unit } = CATEGORY_MAP[type];
     const registros = today[type] ?? [];
     const total = registros.reduce((s, r) => s + (Number(r.quantity) || 0), 0);
-    const done = registros.length > 0;
+    const active = registros.length > 0;
     return {
-      type,
-      name: displayName,
-      done,
-      detail: done ? `${formatTotal(unit, total)} · ${registros.length}×` : "—",
+      key: type,
+      metric: type,
+      name: displayName.charAt(0).toUpperCase() + displayName.slice(1),
+      active,
+      value: active ? formatValue(unit, total) : null,
+      detail:
+        active && registros.length > 1 ? `${registros.length} registros` : null,
     };
   });
-
-  const registradas = rows.filter((r) => r.done).length;
-  const pct = Math.round((registradas / TOTAL) * 100);
-  const dataHoje = new Date().toLocaleDateString("pt-BR");
 
   return (
     <MyView
       safe={true}
       className="flex-1 bg-light-background dark:bg-dark-background"
     >
-      <MyHeader />
       <ScrollView
-        contentContainerStyle={{ padding: 16, gap: 16, alignItems: "center" }}
+        contentContainerStyle={{ padding: 20, gap: 20 }}
         showsVerticalScrollIndicator={false}
       >
-        {/* Trigger do menu lateral: hamburger alinhado à esquerda pra
-            casar com o painel que abre da esquerda (padrão de app mobile).
-            No fluxo do documento pra respeitar padding/safe area do MyView. */}
+        {/* Trigger do menu lateral — hamburger alinhado à esquerda pra casar
+            com o painel que abre da esquerda. */}
         <View className="w-full flex-row justify-start">
           <Pressable
             accessibilityLabel="Abrir menu"
@@ -105,57 +111,75 @@ export default function Home() {
           </Pressable>
         </View>
 
-        {/* Resumo do dia */}
-        <Card className="gap-2">
-          <Text className="font-bold text-2xl text-light-text dark:text-dark-text">
-            Hoje
+        {/* Header: data · greeting · mini-ícone 1c · subtitle. Padrão da mockup
+            2a·1 do design v2. */}
+        <View className="gap-1 px-1">
+          <Text
+            className="text-xs tracking-wider text-label"
+            style={{ fontFamily: "JetBrainsMono_500Medium" }}
+          >
+            {formatDateLabel()}
           </Text>
-          <Text className="font-bold text-base text-light-text opacity-60 dark:text-dark-text">
-            {dataHoje} · {registradas} de {TOTAL} métricas registradas
-          </Text>
-          <View className="h-2 w-full overflow-hidden rounded-full bg-light-background dark:bg-dark-background">
+          <View className="flex-row items-center justify-between">
+            <Text
+              className="text-2xl text-ink"
+              style={{ fontFamily: "Inter_600SemiBold", letterSpacing: -0.24 }}
+            >
+              {getGreeting(user)}
+            </Text>
             <View
-              className="h-2 rounded-full bg-secondary"
-              style={{ width: `${pct}%` }}
-            />
+              className="items-center justify-center rounded-lg bg-primary"
+              style={{ width: 32, height: 32 }}
+            >
+              <Icon1c size={22} />
+            </View>
           </View>
-        </Card>
+          <Text
+            className="text-sm text-body-secondary"
+            style={{ fontFamily: "Inter_400Regular", marginTop: 2 }}
+          >
+            {totalRecords === 0
+              ? "Nenhum registro hoje ainda. Sem pressa."
+              : `${totalRecords} ${totalRecords === 1 ? "registro" : "registros"} hoje. Sem pressa.`}
+          </Text>
+        </View>
 
-        {/* Métricas do dia */}
-        <Card className="gap-3">
-          <SectionLabel>MÉTRICAS DE HOJE</SectionLabel>
-          <MyView safe={false} className="gap-2">
-            {rows.map((r) => (
-              <MetricRow
-                key={r.type}
-                done={r.done}
-                name={r.name}
-                detail={r.detail}
-              />
-            ))}
-          </MyView>
-        </Card>
+        {/* 5 metric cards — toque navega pro registro rápido. */}
+        <View className="gap-2.5">
+          {cards.map((c) => (
+            <MetricCard
+              key={c.key}
+              metric={c.metric}
+              name={c.name}
+              active={c.active}
+              value={c.value}
+              detail={c.detail}
+              onPress={() => router.navigate(`/(metrics)/${c.metric}`)}
+            />
+          ))}
+        </View>
 
         {/* Obter o app (só web: QR no desktop, download no celular) */}
         <InstallApp />
 
         {/* Entrar isolado só quando deslogado + auth configurada. Sair vai
-            pro MenuModal junto com "Logado como" — Home enxuta em ambos
-            estados de auth. */}
+            pro MenuModal junto com "Logado como". */}
         {AUTH_ENABLED && !user && (
-          <Card className="gap-2">
-            <MyButton
-              title="Entrar"
+          <View className="rounded-2xl border border-border-subtle bg-white p-4">
+            <Pressable
+              accessibilityRole="button"
               onPress={() => router.navigate("/login")}
-            />
-          </Card>
+              className="items-center rounded-xl bg-primary py-3"
+            >
+              <Text
+                className="text-sm text-white"
+                style={{ fontFamily: "Inter_500Medium" }}
+              >
+                Entrar
+              </Text>
+            </Pressable>
+          </View>
         )}
-
-        {/* Wordmark discreto — marca presente na tela principal sem competir
-            com o conteúdo. Ver docs/08-design-tokens.md § Identidade visual. */}
-        <Text className="text-center text-xs text-light-text opacity-50 dark:text-dark-text">
-          Back on Track · de volta aos trilhos, um registro por vez
-        </Text>
       </ScrollView>
 
       <MenuModal visible={menuOpen} onClose={() => setMenuOpen(false)} />

--- a/components/Icon1c.jsx
+++ b/components/Icon1c.jsx
@@ -1,0 +1,32 @@
+// @ts-nocheck -- SVG inline, sem tipos exportados
+import Svg, { Circle, Path } from "react-native-svg";
+
+// Símbolo "1c · Linha que sobe" — a marca escolhida pra identidade visual v2.
+// Curva ascendente + círculo verde no ponto de partida. Reusável pra header,
+// splash e (fatia 6) os 4 assets de app.json (icon/adaptive/splash/favicon).
+//
+// Ver docs/09-design-v2.md § "O que vem quando" pra rollout do ícone real
+// nos assets nativos.
+//
+// Props:
+//   size          — largura/altura em px (default 32)
+//   strokeColor   — cor da curva (default #F8F9FA — over blue bg)
+//   dotColor      — cor do ponto de partida (default #4CAF50)
+export default function Icon1c({
+  size = 32,
+  strokeColor = "#F8F9FA",
+  dotColor = "#4CAF50",
+}) {
+  return (
+    <Svg width={size} height={size} viewBox="0 0 1024 1024">
+      <Path
+        d="M 180 760 Q 460 760 560 520 T 860 280"
+        fill="none"
+        stroke={strokeColor}
+        strokeWidth={110}
+        strokeLinecap="round"
+      />
+      <Circle cx={180} cy={760} r={100} fill={dotColor} />
+    </Svg>
+  );
+}

--- a/components/MetricCard.jsx
+++ b/components/MetricCard.jsx
@@ -1,0 +1,77 @@
+// @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
+import { Pressable, Text, View } from "react-native";
+
+import MetricIcon from "./MetricIcon";
+
+// Card de métrica na Home v2 (M5-B fatia 1, direção 1c do design).
+// Estrutura: [ícone tinted 44×44] [nome (bold) — direita: valor ou "quando puder"] [detalhe pequeno opcional].
+// Toque no card navega pra `/(metrics)/<metric>` (registro rápido).
+//
+// Estado é derivado por quem chama:
+//   - active=true  → ícone tint-blue + brand-blue; valor destacado (mono).
+//   - active=false → ícone surface-subtle + label gray; "quando puder".
+//
+// Props:
+//   metric       — key ("water" | "sleep" | ...); usada pro SVG do ícone.
+//   name         — displayName ("Água", "Sono", ...).
+//   active       — bool: teve registro hoje?
+//   value        — string à direita: valor formatado ("1.400 ml", "7h20", "3 refeições") ou null.
+//   detail       — string abaixo (pequena): "3 registros", etc. Opcional.
+//   onPress      — handler do toque.
+export default function MetricCard({
+  metric,
+  name,
+  active,
+  value,
+  detail,
+  onPress,
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={`Métrica ${name}${active ? `, ${value}` : ", sem registros"}`}
+      className="w-full flex-row items-center gap-3 rounded-2xl border border-border-subtle bg-white p-4 active:opacity-70"
+    >
+      <View
+        className={`h-11 w-11 items-center justify-center rounded-xl ${active ? "bg-tint-blue" : "bg-surface-subtle"}`}
+      >
+        <MetricIcon
+          metric={metric}
+          size={22}
+          color={active ? "#2E5A88" : "#6B7280"}
+        />
+      </View>
+      <View className="flex-1 gap-0.5">
+        <View className="flex-row items-baseline justify-between">
+          <Text
+            className="text-sm font-semibold text-ink"
+            style={{ fontFamily: "Inter_600SemiBold" }}
+          >
+            {name}
+          </Text>
+          <Text
+            className={
+              active ? "text-xs text-body-secondary" : "text-xs text-label"
+            }
+            style={{
+              fontFamily: active
+                ? "JetBrainsMono_500Medium"
+                : "Inter_400Regular",
+            }}
+          >
+            {active ? value : "quando puder"}
+          </Text>
+        </View>
+        {detail ? (
+          <Text
+            className="text-xs text-label"
+            style={{ fontFamily: "Inter_400Regular" }}
+          >
+            {detail}
+          </Text>
+        ) : null}
+      </View>
+    </Pressable>
+  );
+}

--- a/components/MetricIcon.jsx
+++ b/components/MetricIcon.jsx
@@ -1,0 +1,42 @@
+// @ts-nocheck -- SVG inline por métrica; tipos exportados não usados
+import Svg, { Path } from "react-native-svg";
+
+// SVGs por métrica extraídos das mockups do Turno 2 (Claude Design).
+// 24x24 viewBox, stroke 2, round caps — pattern do design.
+// Cor do stroke é controlada pela cor passada (default = brand-blue).
+const PATHS = {
+  water: ["M12 2.5c-3 4-6 7-6 11a6 6 0 0 0 12 0c0-4-3-7-6-11z"],
+  sleep: ["M20 14A8 8 0 1 1 10 4a6 6 0 0 0 10 10z"],
+  exercise: [
+    "M6 4v16",
+    "M18 4v16",
+    "M4 8h4",
+    "M4 16h4",
+    "M16 8h4",
+    "M16 16h4",
+    "M8 12h8",
+  ],
+  feeding: ["M4 4c0 8 4 10 8 10s8-2 8-10", "M4 14c0 4 4 6 8 6s8-2 8-6"],
+  study: ["M3 6l9-3 9 3v10l-9 3-9-3z", "M12 3v18"],
+};
+
+export default function MetricIcon({ metric, size = 22, color = "#2E5A88" }) {
+  const paths = PATHS[metric];
+  if (!paths) return null;
+  return (
+    <Svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke={color}
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      {paths.map((d, i) => (
+        <Path key={i} d={d} />
+      ))}
+    </Svg>
+  );
+}


### PR DESCRIPTION
Fatia 1 do redesign — Home consumindo os tokens/fontes da fatia 0 (PR #233). Segue mockup 2a·1 do Claude Design.

## O que muda

- **`app/index.jsx` refeita** — header (data + saudação + mini-ícone 1c + subtitle) + 5 metric cards. Removido `MyHeader` (faixa de chips) — navegação pras telas de métrica agora é pelo toque no card. Mantido `InstallApp` (só web) e o gatilho do menu (hamburger). Mantido CTA "Entrar" quando deslogado.

- **Componentes novos:**
  - **`Icon1c`** — SVG da marca escolhida (curva ascendente + ponto verde de partida). Reutilizável no header agora e na fatia 6 pros 4 assets nativos (`icon.png` / `adaptive-icon.png` / `splash-icon.png` / `favicon.png`).
  - **`MetricIcon`** — dispatcher SVG por key de métrica (water, sleep, exercise, feeding, study). Cor do stroke muda conforme active/dormant.
  - **`MetricCard`** — card pressable com container tinted 44×44, nome, texto de estado à direita ("quando puder" quando vazio), linha de detalhe opcional. Toque navega pra `/(metrics)/<key>`.

## Header detalhado

- Data ("SEGUNDA · 12 AGO") em JetBrainsMono uppercase, cor `label`.
- Saudação adapta ao horário (Bom dia / Boa tarde / Boa noite) e ao estado de auth (adiciona o local-part do email capitalizado quando logado).
- Subtitle conta registros do dia: "3 registros hoje. Sem pressa." — tom "retomada, não conquista" do `docs/09-design-v2.md`.

## Fora de escopo

- Progress bar por métrica (precisaria de goal por métrica no domínio; não existe hoje).
- Detail lines ricas da mockup ("dormiu 23:40", "últ. registro: sáb, 40min") — precisam de lookup no histórico; ficam pras fatias 2/3.
- MetricScreen (telas de registro) reskin — fatia 2.
- Semana view — fatia 3.

## Fontes

Inter e JetBrains Mono já são pré-carregadas na fatia 0. Se ainda não carregaram no first paint, sistema mostra fallback e a UI re-renderiza quando ficarem prontas — sem splash bloqueante.

## Test plan

- [x] `npm test` 63/63.
- [x] `tsc --noEmit` limpo.
- [x] `eslint .` limpo.
- [x] `prettier --check` limpo.
- [ ] Preview do PR (Vercel): verificar Home nova, com/sem registros, com/sem login, hamburger abre menu, taps navegam pras telas de registro.

Refs #232 (foundation).
