### PR TITLE
feat(design-v2): restyle metric screen shell (M5-B slice 2)

### DIFF
--- a/components/MetricRegisterHeader.jsx
+++ b/components/MetricRegisterHeader.jsx
@@ -1,0 +1,91 @@
+// @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
+import { Pressable, Text, View } from "react-native";
+import Svg, { Path } from "react-native-svg";
+import { router } from "expo-router";
+
+import MetricIcon from "./MetricIcon";
+
+// Nav bar + header das telas de registro no visual v2 (M5-B fatia 2, mockups
+// 2a·2 e 2a·3 do Claude Design). Padrão:
+//
+//   [ < Voltar ]                       LABEL_MONO
+//
+//   [🞿] Título
+//   Subtítulo em cor secundária
+//
+// Componentes bespoke por-métrica (quick-add da água, time pickers do sono)
+// vêm em fatias 2a-2c e usam este cabeçalho por cima.
+//
+// Props:
+//   metric    — key da métrica ("water" | ...) — usada pro SVG.
+//   title     — displayName capitalizado ("Água").
+//   subtitle  — string curta. Se omitida, some.
+//   label     — mono uppercase à direita. Default: "HOJE".
+export default function MetricRegisterHeader({
+  metric,
+  title,
+  subtitle,
+  label = "HOJE",
+}) {
+  return (
+    <View className="gap-4 px-1">
+      {/* Nav bar */}
+      <View className="flex-row items-center justify-between">
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Voltar"
+          onPress={() => router.back()}
+          className="flex-row items-center gap-1 rounded-md p-1"
+        >
+          <Svg
+            width={18}
+            height={18}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="#0F1419"
+            strokeWidth={2.4}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <Path d="M15 6l-6 6 6 6" />
+          </Svg>
+          <Text
+            className="text-sm text-ink"
+            style={{ fontFamily: "Inter_500Medium" }}
+          >
+            Voltar
+          </Text>
+        </Pressable>
+        <Text
+          className="text-xs tracking-wider text-label"
+          style={{ fontFamily: "JetBrainsMono_500Medium" }}
+        >
+          {label}
+        </Text>
+      </View>
+
+      {/* Header: ícone + título + subtítulo */}
+      <View className="gap-2">
+        <View className="flex-row items-center gap-3">
+          <View className="h-9 w-9 items-center justify-center rounded-xl bg-tint-blue">
+            <MetricIcon metric={metric} size={18} color="#2E5A88" />
+          </View>
+          <Text
+            className="text-2xl text-ink"
+            style={{ fontFamily: "Inter_600SemiBold", letterSpacing: -0.24 }}
+          >
+            {title}
+          </Text>
+        </View>
+        {subtitle ? (
+          <Text
+            className="text-sm text-body-secondary"
+            style={{ fontFamily: "Inter_400Regular" }}
+          >
+            {subtitle}
+          </Text>
+        ) : null}
+      </View>
+    </View>
+  );
+}

--- a/components/categoryUtils.jsx
+++ b/components/categoryUtils.jsx
@@ -3,22 +3,27 @@ export const CATEGORY_MAP = {
   water: {
     displayName: "água",
     unit: "ml",
+    subtitle: "Adicionar quanto bebeu agora.",
   },
   sleep: {
     displayName: "sono",
     unit: "min",
+    subtitle: "Quando dormiu e acordou?",
   },
   exercise: {
     displayName: "exercício",
     unit: "min",
+    subtitle: "Registrar o exercício de hoje.",
   },
   feeding: {
     displayName: "alimentação",
     unit: "refeição",
+    subtitle: "Registrar refeição.",
   },
   study: {
     displayName: "estudo",
     unit: "min",
+    subtitle: "Registrar o tempo de estudo.",
   },
 };
 
@@ -28,5 +33,6 @@ export function getCategoryInfo(key) {
     exists: !!CATEGORY_MAP[key],
     key: CATEGORY_MAP[key]?.key ?? key,
     unit: CATEGORY_MAP[key]?.unit ?? null,
+    subtitle: CATEGORY_MAP[key]?.subtitle ?? null,
   };
 }

--- a/components/metrics/MetricScreen.jsx
+++ b/components/metrics/MetricScreen.jsx
@@ -12,9 +12,9 @@ import { Snackbar } from "react-native-paper";
 
 import ScoreRaw from "@/components/Score";
 import MyViewRaw from "@/components/MyView";
-import MyHeaderRaw from "@/components/MyHeader";
 import FieldLabelRaw from "@/components/FieldLabel";
 import CardRaw from "@/components/Card";
+import MetricRegisterHeaderRaw from "@/components/MetricRegisterHeader";
 
 import { getCategoryInfo } from "@/components/categoryUtils";
 import getDate from "@/constants/getDate";
@@ -23,16 +23,31 @@ import { getMetricConfig } from "./registry";
 
 const MyView = /** @type {any} */ (MyViewRaw);
 const Score = /** @type {any} */ (ScoreRaw);
-const MyHeader = /** @type {any} */ (MyHeaderRaw);
 const FieldLabel = /** @type {any} */ (FieldLabelRaw);
 const Card = /** @type {any} */ (CardRaw);
+const MetricRegisterHeader = /** @type {any} */ (MetricRegisterHeaderRaw);
+
+// Nav label mono. Sono ganha "NOITE PASSADA" na mockup (contexto do registro
+// é a noite anterior); outras métricas usam "HOJE · <data>".
+/** @param {string} metric @param {string} dateISO */
+function navLabelFor(metric, dateISO) {
+  if (metric === "sleep") return "NOITE PASSADA";
+  const d = new Date(dateISO);
+  const day = d.getDate();
+  const month = d
+    .toLocaleDateString("pt-BR", { month: "short" })
+    .replace(".", "");
+  return `HOJE · ${day} ${month}`.toUpperCase();
+}
 
 /**
  * @param {{ metric: string, recordId?: string }} props
  */
 export default function MetricScreen({ metric, recordId }) {
-  const { displayName, unit } = getCategoryInfo(metric);
+  const { displayName, unit, subtitle } = getCategoryInfo(metric);
   const config = getMetricConfig(metric);
+  // Título capitalizado (design v2 mostra "Água" e não "água").
+  const title = displayName.charAt(0).toUpperCase() + displayName.slice(1);
 
   const [date] = useState(getDate());
   const [score, setScore] = useState(
@@ -79,7 +94,6 @@ export default function MetricScreen({ metric, recordId }) {
       safe={true}
       className="flex-1 bg-light-background dark:bg-dark-background"
     >
-      <MyHeader />
       <Snackbar
         visible={visible}
         onDismiss={() => setVisible(false)}
@@ -90,18 +104,20 @@ export default function MetricScreen({ metric, recordId }) {
       <ScrollView
         style={{ width: "100%" }}
         contentContainerStyle={{
-          padding: 16,
-          gap: 16,
-          alignItems: "center",
+          padding: 20,
+          gap: 20,
           paddingBottom: 24,
         }}
         showsVerticalScrollIndicator={false}
       >
-        <Card className={`gap-8 ${config.cardClass ?? ""}`}>
-          <FieldLabel>
-            {date.displayDate} {displayName}
-          </FieldLabel>
+        <MetricRegisterHeader
+          metric={metric}
+          title={title}
+          subtitle={subtitle}
+          label={navLabelFor(metric, date.ISOdate)}
+        />
 
+        <Card className={`gap-8 ${config.cardClass ?? ""}`}>
           {Top && <Top extra={extra} setField={setField} />}
 
           <FieldLabel>Nota</FieldLabel>


### PR DESCRIPTION
Fatia 2 do redesign — shell visual das 5 telas de registro agora bate com as mockups do Turno 2. Elementos bespoke por métrica (quick-add da água, time pickers do sono, quality selector) vêm em sub-fatias posteriores (2a-2c).

## O que muda

- **`components/MetricRegisterHeader.jsx`** (novo) — nav bar (back arrow + label mono contextual) + header (ícone container + h2 título + subtitle). Segue mockups 2a·2 e 2a·3.

- **`components/metrics/MetricScreen.jsx`** refactor:
  - Remove `MyHeader` (faixa de chips) — navegação agora é via back arrow pra Home, no espírito do design.
  - Adiciona `MetricRegisterHeader` no topo da scroll.
  - Corpo do Card (Score, OBS, slots Top/Bottom por métrica) preservado — comportamento intacto.

- **`components/categoryUtils.jsx`** — adiciona `subtitle` por métrica usado no novo header. Valores do design onde presentes ("Adicionar quanto bebeu agora." pra água, "Quando dormiu e acordou?" pro sono) e adaptados pras outras três.

- Nav label helper `navLabelFor`: "HOJE · 12 AGO" pra maioria; "NOITE PASSADA" pro sono (a mockup do sono usa esse contexto porque o registro captura a noite anterior).

## O que fica

- Form config-driven por métrica (Score, OBS, slots via registry) — o padrão continua funcionando, só ganhou moldura v2.
- Lista de histórico no rodapé, sem mudança.
- `MyHeader` (chip strip) segue vivo em `history.jsx` — lá é aid de navegação entre métricas dentro do fluxo history-adjacent.

## Ainda vem

- **2a** (água) — quick-add chips bespoke + progress + lista "registros de hoje".
- **2b** (sono) — time pickers + duração + quality (substitui Score nessa tela).
- **2c** (exercise/feeding/study) — bespoke restante.

## Test plan

- [x] `npm test` 63/63.
- [x] `tsc --noEmit` limpo.
- [x] `eslint .` limpo.
- [x] `prettier --check` limpo.
- [ ] Preview do PR: nav bar mostra Voltar + label mono, header tem ícone tinted + título capitalizado + subtitle; toque em Voltar volta pra Home; salvar registro mantém funcional (Snackbar aparece).

Refs #232 (foundation).
