### PR TITLE
feat(design-v2): bespoke water quick-add screen (M5-B slice 2a)

### DIFF
--- a/components/metrics/MetricScreen.jsx
+++ b/components/metrics/MetricScreen.jsx
@@ -87,7 +87,16 @@ export default function MetricScreen({ metric, recordId }) {
     setReloadKey((prev) => prev + 1);
   }
 
-  const { Top, Bottom, History } = config;
+  const { Top, Bottom, History, renderCustom } = config;
+  // renderCustom substitui o corpo Score/OBS/Top/Bottom em NOVOS registros
+  // (recordId ausente). Edição via `?id=` cai no fluxo genérico pra continuar
+  // funcionando com os campos do modelo (min/max/ideal, duração, etc). Ver
+  // typedef MetricConfig e docs/09-design-v2.md fatia 2a.
+  const useCustom = !!renderCustom && !recordId;
+  function afterAdd() {
+    setVisible(true);
+    setReloadKey((prev) => prev + 1);
+  }
 
   return (
     <MyView
@@ -117,32 +126,38 @@ export default function MetricScreen({ metric, recordId }) {
           label={navLabelFor(metric, date.ISOdate)}
         />
 
-        <Card className={`gap-8 ${config.cardClass ?? ""}`}>
-          {Top && <Top extra={extra} setField={setField} />}
+        {useCustom ? (
+          <Card className={config.cardClass ?? ""}>
+            {renderCustom({ onAfterAdd: afterAdd })}
+          </Card>
+        ) : (
+          <Card className={`gap-8 ${config.cardClass ?? ""}`}>
+            {Top && <Top extra={extra} setField={setField} />}
 
-          <FieldLabel>Nota</FieldLabel>
-          <Score value={score} onPress={setScore} />
+            <FieldLabel>Nota</FieldLabel>
+            <Score value={score} onPress={setScore} />
 
-          <MyView safe={false} className="gap-1">
-            <FieldLabel>OBS:</FieldLabel>
-            <TextInput
-              value={observation}
-              onChangeText={setObservation}
-              className="h-16 rounded-lg bg-light-backgroundCard p-2 text-base font-normal text-light-text dark:bg-dark-backgroundCard dark:text-dark-text"
-              placeholder={config.obsPlaceholder}
-            />
-          </MyView>
+            <MyView safe={false} className="gap-1">
+              <FieldLabel>OBS:</FieldLabel>
+              <TextInput
+                value={observation}
+                onChangeText={setObservation}
+                className="h-16 rounded-lg bg-light-backgroundCard p-2 text-base font-normal text-light-text dark:bg-dark-backgroundCard dark:text-dark-text"
+                placeholder={config.obsPlaceholder}
+              />
+            </MyView>
 
-          {Bottom && (
-            <Bottom
-              extra={extra}
-              setField={setField}
-              onSubmit={handleSubmit}
-              displayName={displayName}
-              unit={unit}
-            />
-          )}
-        </Card>
+            {Bottom && (
+              <Bottom
+                extra={extra}
+                setField={setField}
+                onSubmit={handleSubmit}
+                displayName={displayName}
+                unit={unit}
+              />
+            )}
+          </Card>
+        )}
         <History tableName={metric} reload={reloadKey} />
       </ScrollView>
     </MyView>

--- a/components/metrics/WaterQuickAdd.jsx
+++ b/components/metrics/WaterQuickAdd.jsx
@@ -1,0 +1,171 @@
+// @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
+import { useMemo } from "react";
+import { Pressable, Text, View } from "react-native";
+import { useTable } from "tinybase/ui-react";
+
+import { add, getToday, store } from "@/infra/database";
+import getDate from "@/constants/getDate";
+
+// UI bespoke da tela de água (M5-B fatia 2a, mockup 2a·2 do Claude Design).
+// Substitui o card Score/OBS/Top/Bottom da MetricScreen quando o registry
+// aponta pra `renderCustom`. Padrão "quick log":
+//
+//   [big number: 1,4 L]
+//   [de 2 L hoje]  [==== progress bar]
+//
+//   ADICIONAR
+//   [+ 200 ml / copo]   [+ 500 ml / garrafa]
+//   [+ 1 L / squeeze]
+//
+//   REGISTROS DE HOJE
+//   08:15         200 ml
+//   ...
+//
+// Cada chip cria um registro imediatamente (sem staging). Snackbar do
+// MetricScreen (via onAfterAdd) confirma. "outro…" custom amount fica pra
+// sub-fatia futura.
+
+const GOAL_ML = 2000;
+
+const QUICK_ADD = [
+  { amount: 200, label: "200 ml", hint: "copo" },
+  { amount: 500, label: "500 ml", hint: "garrafa" },
+  { amount: 1000, label: "1 L", hint: "squeeze" },
+];
+
+function formatTime(ts) {
+  const d = new Date(ts);
+  return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+}
+
+/**
+ * @param {{ onAfterAdd?: () => void }} props
+ */
+export default function WaterQuickAdd({ onAfterAdd }) {
+  // Assina a tabela pra re-renderizar quando um novo registro chega (inclusive
+  // pós-startAutoLoad da persistência). Mesmo padrão da Home.
+  const records = useTable("records", store);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const today = useMemo(() => getToday(), [records]);
+  const waterToday = today.water ?? [];
+
+  const totalMl = waterToday.reduce((s, r) => s + (Number(r.quantity) || 0), 0);
+  const totalL = totalMl / 1000;
+  const pct = Math.min(100, Math.round((totalMl / GOAL_ML) * 100));
+
+  function handleAdd(amount) {
+    add("water", {
+      date: getDate().ISOdate,
+      unit: "ml",
+      quantity: amount,
+    });
+    onAfterAdd?.();
+  }
+
+  return (
+    <View className="gap-6">
+      {/* Big number */}
+      <View className="items-center gap-3">
+        <View className="flex-row items-baseline gap-1.5">
+          <Text
+            className="text-primary"
+            style={{
+              fontFamily: "JetBrainsMono_500Medium",
+              fontSize: 72,
+              lineHeight: 76,
+              letterSpacing: -2,
+            }}
+          >
+            {totalL.toLocaleString("pt-BR", {
+              minimumFractionDigits: 1,
+              maximumFractionDigits: 1,
+            })}
+          </Text>
+          <Text
+            className="text-label"
+            style={{ fontFamily: "JetBrainsMono_500Medium", fontSize: 20 }}
+          >
+            L
+          </Text>
+        </View>
+        <Text
+          className="text-xs text-label"
+          style={{ fontFamily: "Inter_400Regular" }}
+        >
+          de {GOAL_ML / 1000} L hoje
+        </Text>
+        <View className="h-1.5 w-full overflow-hidden rounded-full bg-border-subtle">
+          <View
+            className="h-full rounded-full bg-primary"
+            style={{ width: `${pct}%` }}
+          />
+        </View>
+      </View>
+
+      {/* Quick add chips */}
+      <View>
+        <Text
+          className="mb-3 text-xs uppercase tracking-wider text-label"
+          style={{ fontFamily: "JetBrainsMono_500Medium" }}
+        >
+          Adicionar
+        </Text>
+        <View className="flex-row flex-wrap -m-1">
+          {QUICK_ADD.map((qa) => (
+            <View key={qa.amount} className="w-1/2 p-1">
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={`Adicionar ${qa.label}`}
+                onPress={() => handleAdd(qa.amount)}
+                className="gap-0.5 rounded-2xl border border-border-strong bg-white p-4 active:opacity-70"
+              >
+                <Text
+                  className="text-base text-ink"
+                  style={{ fontFamily: "Inter_500Medium" }}
+                >
+                  + {qa.label}
+                </Text>
+                <Text
+                  className="text-xs text-label"
+                  style={{ fontFamily: "Inter_400Regular" }}
+                >
+                  {qa.hint}
+                </Text>
+              </Pressable>
+            </View>
+          ))}
+        </View>
+      </View>
+
+      {/* Today's entries */}
+      {waterToday.length > 0 && (
+        <View>
+          <Text
+            className="mb-2.5 text-xs uppercase tracking-wider text-label"
+            style={{ fontFamily: "JetBrainsMono_500Medium" }}
+          >
+            Registros de hoje
+          </Text>
+          <View className="gap-2">
+            {waterToday.map((r) => (
+              <View key={r.id} className="flex-row justify-between">
+                <Text
+                  className="text-xs text-body-secondary"
+                  style={{ fontFamily: "Inter_400Regular" }}
+                >
+                  {formatTime(r.createdAt)}
+                </Text>
+                <Text
+                  className="text-xs text-ink"
+                  style={{ fontFamily: "JetBrainsMono_400Regular" }}
+                >
+                  {r.quantity} ml
+                </Text>
+              </View>
+            ))}
+          </View>
+        </View>
+      )}
+    </View>
+  );
+}

--- a/components/metrics/registry.jsx
+++ b/components/metrics/registry.jsx
@@ -12,6 +12,7 @@ import MyButtonRaw from "@/components/MyButton";
 import MyCheckboxRaw from "@/components/MyCheckbox";
 import FieldLabelRaw from "@/components/FieldLabel";
 import MyHistory, { MyExerciseHistory } from "@/components/MyHistory";
+import WaterQuickAdd from "./WaterQuickAdd";
 
 import { hhmmToMinutes, minutesToHHMM } from "@/constants/duration";
 import {
@@ -48,6 +49,10 @@ const INPUT_LG =
  * @property {(props: SlotProps) => any} [Top]
  * @property {(props: SlotProps) => any} [Bottom]
  * @property {string} [cardClass]
+ * @property {(props: { onAfterAdd: () => void }) => any} [renderCustom]  Se
+ *   presente, substitui o corpo Score/OBS/Top/Bottom do card na criação de
+ *   novos registros (recordId ausente). Edição via `?id=` cai no fluxo
+ *   genérico. Usado por métricas com padrão bespoke (fatia 2a+ do M5-B).
  */
 
 /** Slot MIN/MAX/IDEAL compartilhado por água e sono. @param {SlotProps} p */
@@ -69,6 +74,9 @@ const REGISTRY = {
   water: {
     obsPlaceholder: "Observações sobre água...",
     History: MyHistory,
+    // Estado inicial + loadExtra + buildData continuam usados no fluxo de
+    // EDIÇÃO (recordId presente cai no shell genérico com o Top/Bottom).
+    // Novos registros usam o `renderCustom` (WaterQuickAdd) abaixo.
     initialExtra: { quantity: "", min: "", max: "", ideal: "" },
     loadExtra: (r) => ({
       quantity: String(r.quantity ?? ""),
@@ -94,6 +102,9 @@ const REGISTRY = {
         <MyButton title="Salvar" onPress={onSubmit} />
       </MyView>
     ),
+    // Fatia 2a do M5-B: novos registros usam o UI bespoke (big number +
+    // quick-add chips + lista de hoje). Ver components/metrics/WaterQuickAdd.jsx.
+    renderCustom: ({ onAfterAdd }) => <WaterQuickAdd onAfterAdd={onAfterAdd} />,
   },
 
   sleep: {


### PR DESCRIPTION
Sub-slice 2a of the redesign — water register screen gets the bespoke "quick log" layout from mockup 2a·2, replacing the generic Score/OBS/ Top/Bottom body only when creating new records. Editing an existing record (?id=X) still falls back to the generic form so historical fields (min/max/ideal) keep working.

## New

- components/metrics/WaterQuickAdd.jsx — the bespoke content:
  - Big number (72px JetBrains Mono, brand blue) showing today's total in litres, unit "L" in label color.
  - "de 2 L hoje" line + 6px progress bar (goal hardcoded at 2000ml for now — per-user goal is a separate concern).
  - "ADICIONAR" section (mono uppercase label) with three quick-add chips in a 2-column grid: +200ml (copo), +500ml (garrafa), +1L (squeeze). Each chip taps → immediate record, no staging.
  - "REGISTROS DE HOJE" section listing each entry as [time · amount].

## Wiring

- components/metrics/registry.jsx — water config gets a new `renderCustom({ onAfterAdd })` slot. Documented in the MetricConfig typedef.

- components/metrics/MetricScreen.jsx — reads `renderCustom` from config. When present AND no recordId, renders it instead of the standard Score/OBS/Top/Bottom body. Score, OBS, min/max/ideal are intentionally absent from the bespoke UI (the mockup doesn't have them; they'd fight the "quick log" pattern). `onAfterAdd` triggers the same Snackbar + reloadKey bump as the generic path.

## What's out

- "outro…" custom-amount chip from the mockup — deferred (needs a modal input; skipping in this slice for scope).
- Per-user water goal — hardcoded 2000ml; a settings screen for goals is future work.
- Other metrics — sleep is slice 2b, exercise/feeding/study slice 2c.

Refs #232 (foundation).