### PR TITLE
feat(design-v2): bespoke exercise/feeding/study screens (M5-B slice 2c)

### DIFF
--- a/components/metrics/ExerciseBespoke.jsx
+++ b/components/metrics/ExerciseBespoke.jsx
@@ -1,0 +1,248 @@
+// @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
+import { useMemo, useState } from "react";
+import { Pressable, Text, TextInput, View } from "react-native";
+
+import { add } from "@/infra/database";
+import getDate from "@/constants/getDate";
+import { hhmmToMinutes } from "@/constants/duration";
+
+// UI bespoke da tela de exercício (M5-B fatia 2c, mockup 2a·4).
+// Toggle Treino/Cardio (independentes) → duração HH:MM → hora de início
+// opcional → intensidade (leve/ok/forte/puxado) mapeando pra score 2/3/4/5.
+// Nem OBS nem Nota — mockup omite; edição via ?id= volta pro genérico.
+
+const INTENSITY = [
+  { key: "leve", label: "leve", score: 2 },
+  { key: "ok", label: "ok", score: 3 },
+  { key: "forte", label: "forte", score: 4 },
+  { key: "puxado", label: "puxado", score: 5 },
+];
+
+function parseHHMM(s) {
+  if (!s) return null;
+  const m = /^(\d{1,2}):(\d{2})$/.exec(s.trim());
+  if (!m) return null;
+  const h = Number(m[1]);
+  const min = Number(m[2]);
+  if (h > 23 || min > 59) return null;
+  return { h, min };
+}
+
+/**
+ * @param {{ onAfterAdd?: () => void }} props
+ */
+export default function ExerciseBespoke({ onAfterAdd }) {
+  const [training, setTraining] = useState(false);
+  const [cardio, setCardio] = useState(false);
+  const [duration, setDuration] = useState("");
+  const [startTime, setStartTime] = useState("");
+  const [intensity, setIntensity] = useState(/** @type {number|null} */ (null));
+
+  const durationOk = useMemo(() => {
+    const p = parseHHMM(duration);
+    return p != null && p.h * 60 + p.min > 0;
+  }, [duration]);
+  const startTimeOk = useMemo(
+    () => startTime === "" || parseHHMM(startTime) != null,
+    [startTime],
+  );
+
+  const canSave =
+    (training || cardio) && durationOk && startTimeOk && intensity != null;
+
+  function handleSave() {
+    if (!canSave) return;
+    add("exercise", {
+      date: getDate().ISOdate,
+      unit: "min",
+      quantity: hhmmToMinutes(duration),
+      training,
+      cardio,
+      trainingTime: startTime,
+      score: intensity,
+    });
+    setTraining(false);
+    setCardio(false);
+    setDuration("");
+    setStartTime("");
+    setIntensity(null);
+    onAfterAdd?.();
+  }
+
+  return (
+    <View className="gap-4">
+      {/* Modalidade — toggles independentes (usuário pode marcar os dois) */}
+      <View className="flex-row gap-2.5">
+        <ModalityChip
+          label="Treino"
+          hint="peso · força"
+          selected={training}
+          onPress={() => setTraining((v) => !v)}
+        />
+        <ModalityChip
+          label="Cardio"
+          hint="corrida · bike"
+          selected={cardio}
+          onPress={() => setCardio((v) => !v)}
+        />
+      </View>
+
+      {/* Duração */}
+      <FieldRow
+        label="duração"
+        value={duration}
+        onChange={setDuration}
+        placeholder="1:00"
+        hint="obrigatório"
+      />
+
+      {/* Hora de início (opcional) */}
+      <FieldRow
+        label="começou às"
+        value={startTime}
+        onChange={setStartTime}
+        placeholder="18:30"
+        hint="opcional"
+      />
+
+      {/* Intensidade */}
+      <View className="mt-2">
+        <Text
+          className="mb-3 text-xs uppercase tracking-wider text-label"
+          style={{ fontFamily: "JetBrainsMono_500Medium" }}
+        >
+          Como foi
+        </Text>
+        <View className="flex-row gap-2">
+          {INTENSITY.map((i) => {
+            const selected = intensity === i.score;
+            return (
+              <Pressable
+                key={i.key}
+                accessibilityRole="button"
+                accessibilityLabel={`Intensidade: ${i.label}`}
+                accessibilityState={{ selected }}
+                onPress={() => setIntensity(i.score)}
+                className={`flex-1 items-center rounded-xl py-3 ${
+                  selected
+                    ? "border-2 border-primary bg-tint-blue"
+                    : "border border-border-strong bg-white"
+                }`}
+              >
+                <Text
+                  className={`text-xs ${selected ? "text-primary" : "text-body-secondary"}`}
+                  style={{
+                    fontFamily: selected
+                      ? "Inter_600SemiBold"
+                      : "Inter_400Regular",
+                  }}
+                >
+                  {i.label}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+      </View>
+
+      {/* Registrar */}
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Registrar exercício"
+        accessibilityState={{ disabled: !canSave }}
+        disabled={!canSave}
+        onPress={handleSave}
+        className={`mt-2 items-center rounded-2xl py-4 ${
+          canSave ? "bg-primary active:opacity-70" : "bg-border-strong"
+        }`}
+      >
+        <Text
+          className="text-base text-white"
+          style={{ fontFamily: "Inter_600SemiBold" }}
+        >
+          Registrar
+        </Text>
+      </Pressable>
+    </View>
+  );
+}
+
+/**
+ * @param {{ label: string, hint: string, selected: boolean, onPress: () => void }} props
+ */
+function ModalityChip({ label, hint, selected, onPress }) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      accessibilityState={{ selected }}
+      onPress={onPress}
+      className={`flex-1 rounded-2xl px-4 py-3 ${
+        selected
+          ? "border-2 border-primary bg-tint-blue"
+          : "border border-border-strong bg-white"
+      }`}
+    >
+      <Text
+        className={`text-base ${selected ? "text-primary" : "text-body-secondary"}`}
+        style={{
+          fontFamily: selected ? "Inter_600SemiBold" : "Inter_500Medium",
+        }}
+      >
+        {label}
+      </Text>
+      <Text
+        className={`text-xs ${selected ? "text-primary opacity-75" : "text-label"}`}
+        style={{ fontFamily: "Inter_400Regular", marginTop: 2 }}
+      >
+        {hint}
+      </Text>
+    </Pressable>
+  );
+}
+
+/**
+ * @param {{
+ *   label: string,
+ *   value: string,
+ *   onChange: (v: string) => void,
+ *   placeholder: string,
+ *   hint: string,
+ * }} props
+ */
+function FieldRow({ label, value, onChange, placeholder, hint }) {
+  return (
+    <View className="flex-row items-center justify-between rounded-2xl border border-border-subtle bg-white px-5 py-4">
+      <View className="gap-0.5">
+        <Text
+          className="text-xs uppercase tracking-wider text-label"
+          style={{ fontFamily: "JetBrainsMono_500Medium" }}
+        >
+          {label}
+        </Text>
+        <TextInput
+          value={value}
+          onChangeText={onChange}
+          placeholder={placeholder}
+          placeholderTextColor="#9CA3AF"
+          keyboardType="numbers-and-punctuation"
+          maxLength={5}
+          accessibilityLabel={label}
+          style={{
+            fontFamily: "JetBrainsMono_500Medium",
+            fontSize: 24,
+            color: "#0F1419",
+            padding: 0,
+            minWidth: 80,
+          }}
+        />
+      </View>
+      <Text
+        className="text-xs text-body-secondary"
+        style={{ fontFamily: "Inter_400Regular" }}
+      >
+        {hint}
+      </Text>
+    </View>
+  );
+}

--- a/components/metrics/FeedingBespoke.jsx
+++ b/components/metrics/FeedingBespoke.jsx
@@ -77,7 +77,6 @@ export default function FeedingBespoke({ onAfterAdd }) {
             fontFamily: "JetBrainsMono_500Medium",
             fontSize: 88,
             lineHeight: 92,
-            letterSpacing: -2.5,
           }}
         >
           {totalCount}

--- a/components/metrics/FeedingBespoke.jsx
+++ b/components/metrics/FeedingBespoke.jsx
@@ -1,0 +1,191 @@
+// @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
+import { useMemo } from "react";
+import { Pressable, Text, View } from "react-native";
+import { router } from "expo-router";
+import { useTable } from "tinybase/ui-react";
+
+import { add, getToday, remove, store } from "@/infra/database";
+import getDate from "@/constants/getDate";
+
+// UI bespoke da tela de alimentação (M5-B fatia 2c, mockup 2a·5).
+//
+// Diferente do modelo antigo (uma linha por dia com quantity=count), o bespoke
+// segue o padrão da água: cada [+] cria um registro com quantity=1 e [−]
+// deleta o mais recente do dia. O total exibido é o `sum(quantity)` — a agrega-
+// ção Home usa o mesmo reduce, então registros antigos (quantity=N) continuam
+// somando corretamente.
+//
+// Cada refeição ganha um rótulo automático pelo horário (café/almoço/lanche/
+// jantar). O botão "Concluir" só volta pra Home; os +/- já persistem.
+//
+// Notas + score ficam intencionalmente fora (mockup não tem). Edição via ?id=
+// cai no genérico com CounterField.
+
+function mealLabel(hourNumber) {
+  if (hourNumber < 11) return "café";
+  if (hourNumber < 15) return "almoço";
+  if (hourNumber < 18) return "lanche";
+  return "jantar";
+}
+
+function formatTime(ts) {
+  const d = new Date(ts);
+  return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+}
+
+/**
+ * @param {{ onAfterAdd?: () => void }} props
+ */
+export default function FeedingBespoke({ onAfterAdd }) {
+  const records = useTable("records", store);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const today = useMemo(() => getToday(), [records]);
+  const feedingToday = today.feeding ?? [];
+
+  const totalCount = feedingToday.reduce(
+    (s, r) => s + (Number(r.quantity) || 0),
+    0,
+  );
+
+  function handleAdd() {
+    add("feeding", {
+      date: getDate().ISOdate,
+      unit: "refeição",
+      quantity: 1,
+    });
+    onAfterAdd?.();
+  }
+
+  function handleRemove() {
+    if (feedingToday.length === 0) return;
+    // Deleta o mais recente do dia. Ordena por createdAt desc (getToday não
+    // garante ordem).
+    const sorted = [...feedingToday].sort(
+      (a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0),
+    );
+    remove(sorted[0].id);
+    onAfterAdd?.();
+  }
+
+  return (
+    <View className="gap-5">
+      {/* Big number */}
+      <View className="items-center gap-2">
+        <Text
+          className="text-primary"
+          style={{
+            fontFamily: "JetBrainsMono_500Medium",
+            fontSize: 88,
+            lineHeight: 92,
+            letterSpacing: -2.5,
+          }}
+        >
+          {totalCount}
+        </Text>
+        <Text
+          className="text-xs text-label"
+          style={{ fontFamily: "Inter_400Regular" }}
+        >
+          {totalCount === 1 ? "refeição hoje" : "refeições hoje"}
+        </Text>
+      </View>
+
+      {/* +/- controls */}
+      <View className="flex-row gap-2.5">
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Remover última refeição"
+          accessibilityState={{ disabled: totalCount === 0 }}
+          disabled={totalCount === 0}
+          onPress={handleRemove}
+          className={`flex-1 items-center rounded-2xl border py-4 ${
+            totalCount === 0
+              ? "border-border-subtle bg-surface-subtle"
+              : "border-border-strong bg-white active:opacity-70"
+          }`}
+        >
+          <Text
+            className={totalCount === 0 ? "text-icon-dim" : "text-ink"}
+            style={{ fontFamily: "JetBrainsMono_500Medium", fontSize: 22 }}
+          >
+            −
+          </Text>
+        </Pressable>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Adicionar refeição"
+          onPress={handleAdd}
+          className="flex-1 items-center rounded-2xl border border-border-strong bg-white py-4 active:opacity-70"
+        >
+          <Text
+            className="text-ink"
+            style={{ fontFamily: "JetBrainsMono_500Medium", fontSize: 22 }}
+          >
+            +
+          </Text>
+        </Pressable>
+      </View>
+
+      {/* Registros de hoje */}
+      {feedingToday.length > 0 && (
+        <View>
+          <Text
+            className="mb-2.5 text-xs uppercase tracking-wider text-label"
+            style={{ fontFamily: "JetBrainsMono_500Medium" }}
+          >
+            Registros de hoje
+          </Text>
+          <View className="gap-2">
+            {[...feedingToday]
+              .sort((a, b) => (a.createdAt ?? 0) - (b.createdAt ?? 0))
+              .map((r) => {
+                const time = formatTime(r.createdAt);
+                const hour = new Date(r.createdAt ?? 0).getHours();
+                return (
+                  <View key={r.id} className="flex-row justify-between">
+                    <Text
+                      className="text-xs text-body-secondary"
+                      style={{ fontFamily: "Inter_400Regular" }}
+                    >
+                      {time}
+                    </Text>
+                    <Text
+                      className="text-xs text-ink"
+                      style={{ fontFamily: "JetBrainsMono_400Regular" }}
+                    >
+                      {mealLabel(hour)}
+                    </Text>
+                  </View>
+                );
+              })}
+          </View>
+        </View>
+      )}
+
+      {/* Info card sereno */}
+      <View className="rounded-2xl bg-tint-blue px-4 py-3">
+        <Text
+          className="text-sm text-primary"
+          style={{ fontFamily: "Inter_400Regular" }}
+        >
+          3–4 no dia costuma ser um bom ritmo. Sem pressa.
+        </Text>
+      </View>
+
+      {/* Concluir — só volta pra Home. Cada +/- já persistiu. */}
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Concluir e voltar"
+        onPress={() => router.back()}
+        className="mt-1 items-center rounded-2xl bg-primary py-4 active:opacity-70"
+      >
+        <Text
+          className="text-base text-white"
+          style={{ fontFamily: "Inter_600SemiBold" }}
+        >
+          Concluir
+        </Text>
+      </Pressable>
+    </View>
+  );
+}

--- a/components/metrics/StudyBespoke.jsx
+++ b/components/metrics/StudyBespoke.jsx
@@ -1,0 +1,199 @@
+// @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
+import { useMemo, useState } from "react";
+import { Pressable, Text, TextInput, View } from "react-native";
+import Svg, { Path } from "react-native-svg";
+
+import { add } from "@/infra/database";
+import getDate from "@/constants/getDate";
+import { hhmmToMinutes } from "@/constants/duration";
+
+// UI bespoke da tela de estudo (M5-B fatia 2c, mockup 2a·6).
+// Toggle "Feito" full-width com check → duração HH:MM (default "00:00") →
+// pill de foco single-select (leitura/curso/prática/revisão/outro, opcional) →
+// info card sereno → Registrar.
+//
+// `focus` é campo novo no modelo (opcional, string) — não quebra registros
+// antigos porque loadExtra do genérico ignora e a leitura direta é só no
+// bespoke. Sem score/OBS (mockup omite).
+
+const FOCUS = ["leitura", "curso", "prática", "revisão", "outro"];
+
+function parseHHMM(s) {
+  if (!s) return null;
+  const m = /^(\d{1,2}):(\d{2})$/.exec(s.trim());
+  if (!m) return null;
+  const h = Number(m[1]);
+  const min = Number(m[2]);
+  if (h > 23 || min > 59) return null;
+  return h * 60 + min;
+}
+
+/**
+ * @param {{ onAfterAdd?: () => void }} props
+ */
+export default function StudyBespoke({ onAfterAdd }) {
+  const [studied, setStudied] = useState(true);
+  const [duration, setDuration] = useState("");
+  const [focus, setFocus] = useState(/** @type {string|null} */ (null));
+
+  const durationMin = useMemo(() => parseHHMM(duration), [duration]);
+  const canSave = studied && durationMin != null && durationMin > 0;
+
+  function handleSave() {
+    if (!canSave) return;
+    add("study", {
+      date: getDate().ISOdate,
+      unit: "min",
+      quantity: hhmmToMinutes(duration),
+      studied,
+      focus: focus ?? "",
+    });
+    setStudied(true);
+    setDuration("");
+    setFocus(null);
+    onAfterAdd?.();
+  }
+
+  return (
+    <View className="gap-4">
+      {/* Feito toggle full-width */}
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Marcar como feito"
+        accessibilityState={{ selected: studied }}
+        onPress={() => setStudied((v) => !v)}
+        className={`flex-row items-center justify-center gap-2.5 rounded-2xl py-4 ${
+          studied
+            ? "border-2 border-primary bg-tint-blue"
+            : "border border-border-strong bg-white"
+        }`}
+      >
+        {studied && (
+          <Svg width={18} height={18} viewBox="0 0 24 24" fill="none">
+            <Path
+              d="M20 6L9 17l-5-5"
+              stroke="#2E5A88"
+              strokeWidth={2.4}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </Svg>
+        )}
+        <Text
+          className={studied ? "text-primary" : "text-body-secondary"}
+          style={{
+            fontFamily: studied ? "Inter_600SemiBold" : "Inter_500Medium",
+            fontSize: 15,
+          }}
+        >
+          Feito
+        </Text>
+      </Pressable>
+
+      {/* Duração */}
+      <View>
+        <View className="flex-row items-center justify-between rounded-2xl border border-border-subtle bg-white px-5 py-4">
+          <View className="gap-0.5">
+            <Text
+              className="text-xs uppercase tracking-wider text-label"
+              style={{ fontFamily: "JetBrainsMono_500Medium" }}
+            >
+              duração
+            </Text>
+            <TextInput
+              value={duration}
+              onChangeText={setDuration}
+              placeholder="00:45"
+              placeholderTextColor="#9CA3AF"
+              keyboardType="numbers-and-punctuation"
+              maxLength={5}
+              accessibilityLabel="Duração"
+              style={{
+                fontFamily: "JetBrainsMono_500Medium",
+                fontSize: 24,
+                color: "#0F1419",
+                padding: 0,
+                minWidth: 80,
+              }}
+            />
+          </View>
+        </View>
+        <Text
+          className="ml-1 mt-2 text-xs text-label"
+          style={{ fontFamily: "JetBrainsMono_400Regular" }}
+        >
+          quanto puder é suficiente
+        </Text>
+      </View>
+
+      {/* Foco (opcional) */}
+      <View className="mt-2">
+        <Text
+          className="mb-3 text-xs uppercase tracking-wider text-label"
+          style={{ fontFamily: "JetBrainsMono_500Medium" }}
+        >
+          No que estudou
+        </Text>
+        <View className="flex-row flex-wrap gap-1.5">
+          {FOCUS.map((f) => {
+            const selected = focus === f;
+            return (
+              <Pressable
+                key={f}
+                accessibilityRole="button"
+                accessibilityLabel={`Foco: ${f}`}
+                accessibilityState={{ selected }}
+                onPress={() => setFocus(selected ? null : f)}
+                className={`rounded-full px-3.5 py-2 ${
+                  selected
+                    ? "border-2 border-primary bg-tint-blue"
+                    : "border border-border-strong bg-white"
+                }`}
+              >
+                <Text
+                  className={`text-xs ${selected ? "text-primary" : "text-body-secondary"}`}
+                  style={{
+                    fontFamily: selected
+                      ? "Inter_600SemiBold"
+                      : "Inter_400Regular",
+                  }}
+                >
+                  {f}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+      </View>
+
+      {/* Info card */}
+      <View className="rounded-2xl bg-surface-subtle px-4 py-3">
+        <Text
+          className="text-sm text-body-secondary"
+          style={{ fontFamily: "Inter_400Regular" }}
+        >
+          15 minutos já contam. Quando puder.
+        </Text>
+      </View>
+
+      {/* Registrar */}
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Registrar estudo"
+        accessibilityState={{ disabled: !canSave }}
+        disabled={!canSave}
+        onPress={handleSave}
+        className={`mt-2 items-center rounded-2xl py-4 ${
+          canSave ? "bg-primary active:opacity-70" : "bg-border-strong"
+        }`}
+      >
+        <Text
+          className="text-base text-white"
+          style={{ fontFamily: "Inter_600SemiBold" }}
+        >
+          Registrar
+        </Text>
+      </Pressable>
+    </View>
+  );
+}

--- a/components/metrics/registry.jsx
+++ b/components/metrics/registry.jsx
@@ -14,6 +14,9 @@ import FieldLabelRaw from "@/components/FieldLabel";
 import MyHistory, { MyExerciseHistory } from "@/components/MyHistory";
 import WaterQuickAdd from "./WaterQuickAdd";
 import SleepBespoke from "./SleepBespoke";
+import ExerciseBespoke from "./ExerciseBespoke";
+import FeedingBespoke from "./FeedingBespoke";
+import StudyBespoke from "./StudyBespoke";
 
 import { hhmmToMinutes, minutesToHHMM } from "@/constants/duration";
 import {
@@ -176,6 +179,11 @@ const REGISTRY = {
       />
     ),
     Bottom: ({ onSubmit }) => <MyButton title="Salvar" onPress={onSubmit} />,
+    // Fatia 2c do M5-B: novos registros usam UI bespoke (big number counter,
+    // +/- imediatos, cada + cria row quantity=1). Ver FeedingBespoke.jsx.
+    renderCustom: ({ onAfterAdd }) => (
+      <FeedingBespoke onAfterAdd={onAfterAdd} />
+    ),
   },
 
   exercise: {
@@ -257,6 +265,11 @@ const REGISTRY = {
         <MyButton title="Salvar" onPress={onSubmit} />
       </MyView>
     ),
+    // Fatia 2c do M5-B: novos registros usam UI bespoke (modalidade toggle +
+    // duração + hora de início opcional + intensidade). Ver ExerciseBespoke.jsx.
+    renderCustom: ({ onAfterAdd }) => (
+      <ExerciseBespoke onAfterAdd={onAfterAdd} />
+    ),
   },
 
   study: {
@@ -292,6 +305,9 @@ const REGISTRY = {
         <MyButton title="Salvar" onPress={onSubmit} />
       </MyView>
     ),
+    // Fatia 2c do M5-B: novos registros usam UI bespoke (Feito toggle +
+    // duração + foco opcional em pills). Ver StudyBespoke.jsx.
+    renderCustom: ({ onAfterAdd }) => <StudyBespoke onAfterAdd={onAfterAdd} />,
   },
 };
 


### PR DESCRIPTION
Fecha as 5 telas de registro do design v2 com as 3 restantes (exercício, alimentação, estudo). Aplica os mockups 2a·4, 2a·5 e 2a·6 vindos do Claude Design (turno adicional pedido ao designer pra cobrir métricas que o bundle original não tinha). Junto com água (fatia 2a, #236) e sono (fatia 2b, #237), completa o padrão bespoke em todas as métricas.

## O que entra

- **`components/metrics/ExerciseBespoke.jsx`** (2a·4)
  - Chips **Treino** / **Cardio** como toggles independentes (`training`/`cardio` continuam sendo dois bools no modelo — usuário pode marcar os dois).
  - Card **duração** HH:MM (obrigatório) e card **começou às** HH:MM (opcional). Ambos com input mono 24px, label uppercase mono 11px.
  - Row **Como foi** com 4 chips (leve / ok / forte / puxado) mapeando pra `score` 2/3/4/5, reusando a infra do histórico.
  - Registrar desabilita até: (training OU cardio) + duração válida > 0 + intensidade escolhida.

- **`components/metrics/FeedingBespoke.jsx`** (2a·5)
  - Big number 88px mono `#2E5A88` com o total do dia (`sum(quantity)` de todas as rows de feeding de hoje).
  - Chips [**−**] e [**+**] grid 2 col, instant-write. **Cada `+` cria uma row com `quantity: 1`**; `−` deleta a mais recente (por `createdAt` desc). Mudança de padrão vs. o modelo antigo (uma row/dia com `quantity=N`), mas a agregação da Home continua correta em ambos os regimes porque usa reduce. Sem migração necessária: rows antigas com `quantity=3` contam por 3, novas por 1.
  - Lista **Registros de hoje** com rótulo automático **café/almoço/lanche/jantar** derivado do horário do `createdAt` (<11 café, <15 almoço, <18 lanche, senão jantar). Rótulo não é persistido — só derivado.
  - Info card tint-blue: "3–4 no dia costuma ser um bom ritmo. Sem pressa."
  - Botão **Concluir** só volta pra Home (`router.back()`) — os +/- já persistiram. Mantém a assinatura visual do padrão (botão primary no rodapé) sem duplicar ação.

- **`components/metrics/StudyBespoke.jsx`** (2a·6)
  - Toggle **Feito** full-width com ícone check quando selecionado (default `true` porque o próprio ato de abrir a tela indica intenção — usuário pode desmarcar se registrar tentativa sem sucesso).
  - Card **duração** HH:MM obrigatório + hint `quanto puder é suficiente` abaixo.
  - Row **No que estudou** com pills rounded-full single-select opcional (leitura/curso/prática/revisão/outro). Armazenado em campo **novo** `focus: string` no record — não quebra rows antigas (loadExtra do genérico ignora, buildData nunca setou).
  - Info card `bg-surface-subtle`: "15 minutos já contam. Quando puder."
  - Registrar exige: `studied` + duração > 0.

## Wiring

- **`components/metrics/registry.jsx`** — 3 novos `renderCustom` slots (exercise, feeding, study). Cada um com comentário apontando pro arquivo bespoke. Configs antigas (initialExtra/loadExtra/buildData/Top/Bottom) permanecem intactas pra edição via `?id=`.

## Extrapolações a documentar

- **Exercise `training` + `cardio` como toggles independentes**: mockup mostra só um selecionado, mas o data model tem 2 bools. Mantive independente pra não perder capacidade (usuário faz treino + cardio no mesmo dia).
- **Feeding sem persistência de rótulo (café/almoço)**: os labels são derivados do horário, não escolhidos pelo usuário. Se quiser controle explícito, precisa campo `mealType` no modelo — trabalho futuro.
- **Study `focus` novo no schema**: campo opcional, não obriga migração; mockup do histórico ainda não usa. Se a Semana (fatia 3) mostrar foco, tem tudo aqui.

## Fora

- Edição via `?id=` de qualquer uma das 5 métricas segue no genérico — intencional (min/max/ideal, campos parciais). Migrar edição pro bespoke é sub-fatia futura se surgir necessidade.
- Fatia 3: Semana view.

## Test plan

- [x] `npm test` 63/63.
- [x] `tsc --noEmit` limpo.
- [x] `eslint .` limpo.
- [x] `prettier --check` limpo.
- [ ] Preview: entrar em `/(metrics)/exercise` → Treino selecionado + duração 1:00 + intensidade "ok" → Registrar salva → Snackbar. `/(metrics)/feeding` → toque em `+` incrementa big number ao vivo (sem submit); `−` decrementa; concluir volta. `/(metrics)/study` → Feito default marcado, duração 0:30, pill "leitura" → Registrar salva.

Refs #237 (fatia 2b), #236 (fatia 2a), #232 (foundation).
