### PR TITLE
fix(design-v2): text last-letter clipping on Android (font-weight + letterSpacing)

### DIFF
--- a/app/index.jsx
+++ b/app/index.jsx
@@ -123,7 +123,7 @@ export default function Home() {
           <View className="flex-row items-center justify-between">
             <Text
               className="text-2xl text-ink"
-              style={{ fontFamily: "Inter_600SemiBold", letterSpacing: -0.24 }}
+              style={{ fontFamily: "Inter_600SemiBold" }}
             >
               {getGreeting(user)}
             </Text>

--- a/components/MetricCard.jsx
+++ b/components/MetricCard.jsx
@@ -45,7 +45,7 @@ export default function MetricCard({
       <View className="flex-1 gap-0.5">
         <View className="flex-row items-baseline justify-between">
           <Text
-            className="text-sm font-semibold text-ink"
+            className="text-sm text-ink"
             style={{ fontFamily: "Inter_600SemiBold" }}
           >
             {name}

--- a/components/MetricRegisterHeader.jsx
+++ b/components/MetricRegisterHeader.jsx
@@ -72,7 +72,7 @@ export default function MetricRegisterHeader({
           </View>
           <Text
             className="text-2xl text-ink"
-            style={{ fontFamily: "Inter_600SemiBold", letterSpacing: -0.24 }}
+            style={{ fontFamily: "Inter_600SemiBold" }}
           >
             {title}
           </Text>

--- a/components/metrics/WaterQuickAdd.jsx
+++ b/components/metrics/WaterQuickAdd.jsx
@@ -73,7 +73,6 @@ export default function WaterQuickAdd({ onAfterAdd }) {
               fontFamily: "JetBrainsMono_500Medium",
               fontSize: 72,
               lineHeight: 76,
-              letterSpacing: -2,
             }}
           >
             {totalL.toLocaleString("pt-BR", {


### PR DESCRIPTION
Fix da reincidência de última letra cortada nos textos do design v2 no Android (relatado após reinstalar o APK 1.1.1 e o OTA da fatia 2b descer). "Água" aparecia "Águ", greeting "Bom dia, X." aparecia truncado, big number 72px cortava a última letra do sufixo. Web/desktop não sofriam.

## Causas

1. **`MetricCard.jsx`** — combinava `font-semibold` (Tailwind, `fontWeight:600`) com `fontFamily: "Inter_600SemiBold"`. No Android o RN aplica bold sintético em cima da variant já pesada e o advance width termina menor que o glyph → última letra clipa.

2. **`letterSpacing` negativo** em textos com fontFamily custom (Inter/JetBrains Mono) — mesmo bug de advance width, agora do lado do RN Android. Estava em:
   - `app/index.jsx` greeting (-0.24)
   - `components/MetricRegisterHeader.jsx` h2 (-0.24)
   - `components/metrics/WaterQuickAdd.jsx` big number (-2)

## Fix

- `MetricCard`: remove `font-semibold`; peso vem do fontFamily.
- Remove todos os `letterSpacing` negativos dos componentes v2.

## Fora

- FeedingBespoke tem o mesmo `letterSpacing: -2.5` no big number — vive na branch da fatia 2c (PR #238), corrigido lá em commit separado depois deste merger.

## Test plan

- [x] `tsc --noEmit`, `eslint`, `prettier` limpos.
- [ ] Preview: verificar que "Água" na Home aparece inteiro; abrir `/(metrics)/water` e ver o header inteiro; o big number sem clip.

Pure JS. OTA cobre — testers em APK 1.1.1 recebem no launch seguinte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)