### PR TITLE
feat(design-v2): weekly overview screen (M5-B slice 3)

### DIFF
--- a/app/_layout.jsx
+++ b/app/_layout.jsx
@@ -67,6 +67,7 @@ function AppTree() {
         />
         <Stack.Screen name="export" options={{ title: "Exportação" }} />
         <Stack.Screen name="history" options={{ title: "Histórico" }} />
+        <Stack.Screen name="semana" options={{ title: "Semana" }} />
         <Stack.Screen
           name="feedback"
           options={{ title: "Feedback", headerShown: true }}

--- a/app/semana.jsx
+++ b/app/semana.jsx
@@ -1,0 +1,119 @@
+// @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
+import { useMemo } from "react";
+import { Pressable, ScrollView, Text, View } from "react-native";
+import { router } from "expo-router";
+import Svg, { Path } from "react-native-svg";
+import { useTable } from "tinybase/ui-react";
+
+import MyView from "@/components/MyView";
+import WeekStrip from "@/components/WeekStrip";
+
+import { store } from "@/infra/database";
+import { METRIC_KEYS_ORDER, summarizeWeek } from "@/infra/week";
+
+// Tela Semana (M5-B fatia 3, mockup 2a·7).
+// Header mono + h1 + subtitle → strip de 7 dias com barrinhas por métrica →
+// lista "por métrica" com stat resumo. Sem tab bar por enquanto (Home segue
+// no hamburger); introduzir tab bar é decisão maior, fica pra próxima fatia.
+
+export default function Semana() {
+  const records = useTable("records", store);
+  // Recalcula quando a tabela muda (mesmo padrão da Home).
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const summary = useMemo(() => summarizeWeek(), [records]);
+
+  return (
+    <MyView
+      safe={true}
+      className="flex-1 bg-light-background dark:bg-dark-background"
+    >
+      <ScrollView
+        contentContainerStyle={{ padding: 20, gap: 20 }}
+        showsVerticalScrollIndicator={false}
+      >
+        {/* Nav bar: back → HOJE */}
+        <View className="flex-row items-center justify-between">
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Voltar"
+            onPress={() => router.back()}
+            className="flex-row items-center gap-1 rounded-full p-1 pr-2 active:opacity-70"
+          >
+            <Svg width={18} height={18} viewBox="0 0 24 24" fill="none">
+              <Path
+                d="M15 6l-6 6 6 6"
+                stroke="#2E5A88"
+                strokeWidth={2.4}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </Svg>
+            <Text
+              className="text-base text-primary"
+              style={{ fontFamily: "Inter_500Medium" }}
+            >
+              Voltar
+            </Text>
+          </Pressable>
+        </View>
+
+        {/* Header */}
+        <View className="gap-1 px-1">
+          <Text
+            className="text-xs tracking-wider text-label"
+            style={{ fontFamily: "JetBrainsMono_500Medium" }}
+          >
+            {summary.header.weekLabel}
+          </Text>
+          <Text
+            className="text-2xl text-ink"
+            style={{ fontFamily: "Inter_600SemiBold" }}
+          >
+            {summary.header.title}
+          </Text>
+          <Text
+            className="text-sm text-body-secondary"
+            style={{ fontFamily: "Inter_400Regular", marginTop: 2 }}
+          >
+            {summary.header.subtitle}
+          </Text>
+        </View>
+
+        {/* Day strip */}
+        <WeekStrip days={summary.days} />
+
+        {/* Per metric */}
+        <View className="gap-2.5">
+          <Text
+            className="text-xs uppercase tracking-wider text-label"
+            style={{ fontFamily: "JetBrainsMono_500Medium" }}
+          >
+            Por métrica
+          </Text>
+          {METRIC_KEYS_ORDER.map((key) => {
+            const m = summary.perMetric[key];
+            return (
+              <View
+                key={key}
+                className="flex-row items-center justify-between rounded-xl border border-border-subtle bg-white px-4 py-3"
+              >
+                <Text
+                  className="text-sm text-ink"
+                  style={{ fontFamily: "Inter_500Medium" }}
+                >
+                  {m.label}
+                </Text>
+                <Text
+                  className="text-sm text-body-secondary"
+                  style={{ fontFamily: "JetBrainsMono_400Regular" }}
+                >
+                  {m.stat}
+                </Text>
+              </View>
+            );
+          })}
+        </View>
+      </ScrollView>
+    </MyView>
+  );
+}

--- a/components/MenuModal.jsx
+++ b/components/MenuModal.jsx
@@ -85,6 +85,7 @@ export default function MenuModal({ visible, onClose }) {
               </View>
             </View>
 
+            <MyButton title="Semana" onPress={() => navigateTo("/semana")} />
             <MyButton
               title="Histórico"
               onPress={() => navigateTo("/history")}

--- a/components/WeekStrip.jsx
+++ b/components/WeekStrip.jsx
@@ -1,0 +1,114 @@
+// @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
+import { Text, View } from "react-native";
+
+// Faixa visual dos últimos 7 dias (M5-B fatia 3, mockup 2a·7).
+// Cada dia = coluna com stack vertical de barrinhas: 1 por métrica registrada.
+// Se todas as 5 métricas foram registradas, a barra do topo vira verde
+// (`brand-green`). Dia sem registros mostra 1 barra cinza-claro (vazio).
+// Legenda embaixo explica as cores.
+
+const MAX_METRICS = 5;
+const BAR_HEIGHT = 12;
+const BAR_GAP = 2;
+const STACK_HEIGHT = MAX_METRICS * BAR_HEIGHT + (MAX_METRICS - 1) * BAR_GAP; // 68
+
+/**
+ * @param {{ days: Array<{
+ *   date: Date,
+ *   weekdayLabel: string,
+ *   isToday: boolean,
+ *   filledMetrics: string[],
+ *   complete: boolean,
+ * }> }} props
+ */
+export default function WeekStrip({ days }) {
+  return (
+    <View className="rounded-2xl border border-border-subtle bg-white p-4">
+      <View
+        className="flex-row items-end justify-between"
+        style={{ height: STACK_HEIGHT + 24 }}
+      >
+        {days.map((day, i) => (
+          <DayColumn key={i} day={day} />
+        ))}
+      </View>
+
+      {/* Legend */}
+      <View className="mt-4 flex-row gap-3 border-t border-surface-subtle pt-3">
+        <LegendItem color="#2E5A88" label="registro" />
+        <LegendItem color="#4CAF50" label="dia completo" />
+        <LegendItem color="#E5E7EB" label="vazio" />
+      </View>
+    </View>
+  );
+}
+
+/** @param {{ day: { weekdayLabel: string, isToday: boolean, filledMetrics: string[], complete: boolean } }} props */
+function DayColumn({ day }) {
+  const filled = day.filledMetrics.length;
+  const isEmpty = filled === 0;
+
+  // Uma barrinha por métrica registrada; topo verde se completo. Se vazio,
+  // uma barra cinza placeholder.
+  const bars = isEmpty
+    ? [{ color: "#E5E7EB", key: "empty" }]
+    : Array.from({ length: filled }, (_, i) => ({
+        color: day.complete && i === filled - 1 ? "#4CAF50" : "#2E5A88",
+        key: `bar-${i}`,
+      }));
+
+  return (
+    <View className="flex-1 items-center" style={{ gap: 6 }}>
+      <View
+        className="justify-end"
+        style={{ height: STACK_HEIGHT, gap: BAR_GAP }}
+      >
+        {bars.map((b) => (
+          <View
+            key={b.key}
+            style={{
+              width: day.isToday ? 20 : 18,
+              height: day.isToday ? BAR_HEIGHT + 2 : BAR_HEIGHT,
+              backgroundColor: b.color,
+              borderRadius: 2,
+              // Ring azul lavado ao redor das barras de HOJE, sem sombra
+              // (shadow* prop no Android é caro; borderColor + borderWidth
+              // reproduz o efeito com custo zero).
+              ...(day.isToday && {
+                borderWidth: 2,
+                borderColor: "#EAF3FB",
+              }),
+            }}
+          />
+        ))}
+      </View>
+      <Text
+        style={{
+          fontFamily: "JetBrainsMono_500Medium",
+          fontSize: 10,
+          color: day.isToday ? "#2E5A88" : "#6B7280",
+          fontWeight: day.isToday ? "700" : "500",
+        }}
+      >
+        {day.isToday ? "HOJE" : day.weekdayLabel}
+      </Text>
+    </View>
+  );
+}
+
+/** @param {{ color: string, label: string }} props */
+function LegendItem({ color, label }) {
+  return (
+    <View className="flex-row items-center gap-1.5">
+      <View
+        style={{ width: 8, height: 8, backgroundColor: color, borderRadius: 2 }}
+      />
+      <Text
+        className="text-xs text-label"
+        style={{ fontFamily: "Inter_400Regular" }}
+      >
+        {label}
+      </Text>
+    </View>
+  );
+}

--- a/infra/week.js
+++ b/infra/week.js
@@ -1,0 +1,216 @@
+// @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
+// Agregador semanal para a tela Semana (M5-B fatia 3, mockup 2a·7).
+//
+// Uma passada única na tabela pra montar:
+//   - dias: [{ date, weekday, isToday, metrics: {water: N, ...}, filledCount, complete }]
+//   - porMetric: {water: {days, ...}, sleep: {avgMin}, exercise: {sessions}, ...}
+//   - resumo: { activeDays, weekLabel }
+//
+// Range: últimos 7 dias incluindo hoje (rolling), pra HOJE aparecer sempre no
+// último slot. Header exibe o número da semana ISO da data de hoje pra dar
+// contexto — não é o range ISO Mon-Sun (que seria confuso quando o rolling
+// atravessa duas semanas).
+
+import { store } from "@/infra/database";
+
+const METRICS = ["water", "sleep", "exercise", "feeding", "study"];
+const WEEKDAY_LABELS = ["DOM", "SEG", "TER", "QUA", "QUI", "SEX", "SÁB"];
+const MONTH_ABBR = [
+  "jan",
+  "fev",
+  "mar",
+  "abr",
+  "mai",
+  "jun",
+  "jul",
+  "ago",
+  "set",
+  "out",
+  "nov",
+  "dez",
+];
+
+// ISO 8601 week number. Cópia direta do algoritmo canônico — não vale trazer
+// date-fns só pra isso.
+function isoWeek(d) {
+  const t = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()));
+  const dayNum = t.getUTCDay() || 7;
+  t.setUTCDate(t.getUTCDate() + 4 - dayNum);
+  const yearStart = new Date(Date.UTC(t.getUTCFullYear(), 0, 1));
+  return Math.ceil(((t - yearStart) / 86400000 + 1) / 7);
+}
+
+function sameDay(a, b) {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
+function dateAt(daysAgo) {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  d.setDate(d.getDate() - daysAgo);
+  return d;
+}
+
+// "5–11 ago" (mesmo mês) ou "29 jul–4 ago" (cruza mês).
+function formatRange(start, end) {
+  const sM = MONTH_ABBR[start.getMonth()];
+  const eM = MONTH_ABBR[end.getMonth()];
+  if (sM === eM) return `${start.getDate()}–${end.getDate()} ${eM}`;
+  return `${start.getDate()} ${sM}–${end.getDate()} ${eM}`;
+}
+
+function copyForActiveDays(n) {
+  if (n === 0) return "Sem registros nesta semana. Sem pressa.";
+  if (n === 1) return "1 dia com registro nesta semana.";
+  if (n <= 3) return `${n} dias com registro nesta semana.`;
+  if (n <= 5) return `${n} dias com pelo menos um registro.`;
+  return `${n} dias com pelo menos um registro. Bom ritmo.`;
+}
+
+/**
+ * @returns {{
+ *   days: Array<{ date: Date, weekdayLabel: string, isToday: boolean, filledMetrics: string[], complete: boolean }>,
+ *   perMetric: Record<string, { label: string, stat: string }>,
+ *   header: { weekLabel: string, title: string, subtitle: string },
+ * }}
+ */
+export function summarizeWeek() {
+  // 7 dias, do mais antigo pro mais recente (hoje no fim).
+  const days = Array.from({ length: 7 }, (_, i) => {
+    const d = dateAt(6 - i);
+    return {
+      date: d,
+      weekdayLabel: WEEKDAY_LABELS[d.getDay()],
+      isToday: i === 6,
+      filledMetrics: /** @type {string[]} */ ([]),
+      complete: false,
+    };
+  });
+
+  // Agregações por métrica na janela.
+  const perMetricRaw = {
+    water: { totalMl: 0, daysActive: new Set() },
+    sleep: { minutes: [], daysActive: new Set() },
+    exercise: { sessions: 0, daysActive: new Set() },
+    feeding: { count: 0, daysActive: new Set() },
+    study: { minutes: 0, daysActive: new Set() },
+  };
+
+  const linhas = store.getTable("records");
+  const cutoff = days[0].date;
+  const cutoffMs = cutoff.getTime();
+
+  for (const row of Object.values(linhas)) {
+    if (!row.date || !row.type) continue;
+    const d = new Date(row.date);
+    if (d.getTime() < cutoffMs) continue;
+    // Ache o dia correspondente na janela.
+    const dayIdx = days.findIndex((day) => sameDay(day.date, d));
+    if (dayIdx < 0) continue;
+    const day = days[dayIdx];
+    if (!day.filledMetrics.includes(row.type)) day.filledMetrics.push(row.type);
+
+    const q = Number(row.quantity) || 0;
+    const key = day.date.toISOString().slice(0, 10);
+    switch (row.type) {
+      case "water":
+        perMetricRaw.water.totalMl += q;
+        perMetricRaw.water.daysActive.add(key);
+        break;
+      case "sleep":
+        perMetricRaw.sleep.minutes.push(q);
+        perMetricRaw.sleep.daysActive.add(key);
+        break;
+      case "exercise":
+        perMetricRaw.exercise.sessions += 1;
+        perMetricRaw.exercise.daysActive.add(key);
+        break;
+      case "feeding":
+        perMetricRaw.feeding.count += q;
+        perMetricRaw.feeding.daysActive.add(key);
+        break;
+      case "study":
+        perMetricRaw.study.minutes += q;
+        perMetricRaw.study.daysActive.add(key);
+        break;
+    }
+  }
+
+  // Marca completos.
+  for (const day of days) {
+    day.complete = day.filledMetrics.length >= METRICS.length;
+  }
+
+  const activeDays = days.filter((d) => d.filledMetrics.length > 0).length;
+
+  // Header.
+  const today = new Date();
+  const weekLabel =
+    `SEM ${isoWeek(today)} · ${formatRange(days[0].date, days[6].date)}`.toUpperCase();
+
+  // Per-metric stats (formatação já pronta pra render).
+  const perMetric = {
+    water: {
+      label: "Água",
+      stat: `${perMetricRaw.water.daysActive.size}/7 dias`,
+    },
+    sleep: {
+      label: "Sono",
+      stat:
+        perMetricRaw.sleep.minutes.length === 0
+          ? "sem registros"
+          : `média ${formatMinutes(avg(perMetricRaw.sleep.minutes))}`,
+    },
+    exercise: {
+      label: "Exercício",
+      stat:
+        perMetricRaw.exercise.sessions === 0
+          ? "sem sessões"
+          : `${perMetricRaw.exercise.sessions} ${perMetricRaw.exercise.sessions === 1 ? "sessão" : "sessões"}`,
+    },
+    feeding: {
+      label: "Alimentação",
+      stat:
+        perMetricRaw.feeding.count === 0
+          ? "sem refeições"
+          : `${perMetricRaw.feeding.count} ${perMetricRaw.feeding.count === 1 ? "refeição" : "refeições"}`,
+    },
+    study: {
+      label: "Estudo",
+      stat:
+        perMetricRaw.study.minutes === 0
+          ? "sem estudo"
+          : `${formatMinutes(perMetricRaw.study.minutes)} total`,
+    },
+  };
+
+  return {
+    days,
+    perMetric,
+    header: {
+      weekLabel,
+      title: "Sua semana",
+      subtitle: copyForActiveDays(activeDays),
+    },
+  };
+}
+
+function avg(arr) {
+  if (arr.length === 0) return 0;
+  return arr.reduce((s, v) => s + v, 0) / arr.length;
+}
+
+function formatMinutes(min) {
+  const total = Math.round(min);
+  const h = Math.floor(total / 60);
+  const m = total % 60;
+  if (h === 0) return `${m}min`;
+  if (m === 0) return `${h}h`;
+  return `${h}h${String(m).padStart(2, "0")}`;
+}
+
+export const METRIC_KEYS_ORDER = METRICS;


### PR DESCRIPTION
Fatia 3 do redesign — nova tela **Semana** aplicando a mockup 2a·7. Acessível via item novo no `MenuModal`.

## O que entra

- **`infra/week.js`** (novo) — `summarizeWeek()` faz **uma passada única** na tabela `records` e retorna:
  - `days[7]` (do mais antigo pro hoje) com `filledMetrics: string[]` (métricas registradas naquele dia) e `complete: boolean` (todas as 5 preenchidas).
  - `perMetric` com stat formatado por métrica: `água 6/7 dias`, `sono média 6h50`, `exercício 3 sessões`, `alimentação 14 refeições`, `estudo 2h15 total`. Copy adapta pluralização e caso "sem X".
  - `header` com `SEM XX · 5–11 ago` (ISO week + range em pt-BR abreviado, cruza mês corretamente) + subtitle sensível à quantidade de dias ativos (0 → "Sem registros nesta semana. Sem pressa."; 6+ → "N dias com pelo menos um registro. Bom ritmo.").
  - Range é **rolling últimos 7 dias** incluindo hoje — HOJE sempre no último slot. Comentário no arquivo explica a decisão vs ISO Mon-Sun.

- **`components/WeekStrip.jsx`** (novo) — visualização:
  - Coluna por dia com stack vertical: **uma barrinha 18×12 por métrica registrada** naquele dia, empilhadas de baixo pra cima. Se todas as 5 registradas, a barra do topo vira `#4CAF50` (dia completo). Se nenhuma, uma barra `#E5E7EB` placeholder (vazio).
  - Coluna do HOJE ganha ring `#EAF3FB` via `borderWidth: 2 + borderColor` (barato no Android — evita `boxShadow`/`elevation` que são caros). Barra 20×14 pra dar peso extra.
  - Label do dia em mono 10px (`SEG/TER/…/SÁB`), HOJE em brand-blue 700.
  - Legenda embaixo (registro / dia completo / vazio) separada por `border-t border-surface-subtle`.

- **`app/semana.jsx`** (nova rota) — assembla tudo:
  - Nav bar com "Voltar" (setinha brand-blue) — sem contextual right label porque a tela cobre a semana toda.
  - Header mono + h1 "Sua semana" + subtitle sensível.
  - `<WeekStrip />`.
  - Lista **POR MÉTRICA** com 5 rows, cada uma card branco border-subtle + rounded-xl, nome à esquerda + stat mono à direita.
  - Reativa via `useTable("records", store)` + `useMemo` (mesmo padrão da Home/WaterQuickAdd).

- **`components/MenuModal.jsx`** — entrada nova **"Semana"** antes de "Histórico".
- **`app/_layout.jsx`** — `<Stack.Screen name="semana" />` (headerShown false, screen tem própria nav bar).

## Fora

- **Tab bar** da mockup 2a·7 (rodapé Hoje/Semana/Ajustes): mudança maior de navegação, Home hoje tá no hamburger. Fica pra fatia futura (junto com Ajustes 2a·8) se quiser migrar pra tab bar.
- **Interação nas barrinhas** (tap num dia abrir detalhe): mockup não sugere, e o Histórico já cobre a granularidade fina.
- **Tests do `summarizeWeek`**: a função é puramente derivada de `store.getTable("records")`; ganharia bem de um teste unitário com store in-memory, mas fica pra follow-up.

## Test plan

- [x] `npm test` 63/63.
- [x] `tsc --noEmit` limpo.
- [x] `eslint` limpo.
- [x] `prettier --check` limpo.
- [ ] Preview: abrir menu → "Semana" → ver header com semana atual, strip com 7 dias (HOJE destacado), lista por métrica.
- [ ] Registrar métrica → voltar → ver contador atualizar (`useTable` re-renderiza).

Refs #238 (fatia 2c), #237 (2b), #236 (2a), #232 (foundation).
