### PR TITLE
feat(design-v2): empty state / retomada screen (M5-B slice 5)

### DIFF
--- a/app/index.jsx
+++ b/app/index.jsx
@@ -1,6 +1,6 @@
 // @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
 //#region imports
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { Pressable, ScrollView, Text, View } from "react-native";
 import { router } from "expo-router";
 import { useTable } from "tinybase/ui-react";
@@ -9,6 +9,7 @@ import MyView from "@/components/MyView";
 import InstallApp from "@/components/InstallApp";
 import MetricCard from "@/components/MetricCard";
 import Icon1c from "@/components/Icon1c";
+import RetomadaState from "@/components/RetomadaState";
 
 import { getToday, store } from "@/infra/database";
 import { useSession } from "@/infra/session";
@@ -40,6 +41,33 @@ function getGreeting(user) {
   return `${g}, ${name}.`;
 }
 
+// Dias corridos desde o último registro em qualquer métrica. Null se o store
+// nunca teve registro (usuário novo). Usado pra decidir entre Home normal e
+// estado de retomada da fatia 5.
+function computeDaysSinceLast(records) {
+  let maxCreatedAt = 0;
+  for (const row of Object.values(records)) {
+    const c = Number(row?.createdAt) || 0;
+    if (c > maxCreatedAt) maxCreatedAt = c;
+  }
+  if (maxCreatedAt === 0) return null;
+  const now = new Date();
+  const last = new Date(maxCreatedAt);
+  // Compara dias-de-calendário local, não 24h corridas — pra "faz 1 dia" só
+  // acontecer na virada do dia, não 24h depois do registro.
+  const todayMid = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate(),
+  ).getTime();
+  const lastMid = new Date(
+    last.getFullYear(),
+    last.getMonth(),
+    last.getDate(),
+  ).getTime();
+  return Math.max(0, Math.round((todayMid - lastMid) / 86_400_000));
+}
+
 // Data no formato "SEGUNDA · 12 AGO" (pt-BR, uppercase). Usada como label
 // discreto acima do greeting.
 function formatDateLabel() {
@@ -54,6 +82,10 @@ function formatDateLabel() {
 
 export default function Home() {
   const { user } = useSession();
+  // Dismissal in-memory do estado de retomada (M5-B fatia 5). Persistir viraria
+  // sub-tarefa; hoje "Depois" dura só a sessão — próximo launch com o critério
+  // ainda válido volta a mostrar, que é o objetivo (convidar até registrar).
+  const [retomadaDismissed, setRetomadaDismissed] = useState(false);
 
   // Assina a tabela: `useTable` re-renderiza a cada mudança nos registros —
   // inclusive quando o `startAutoLoad()` da persistência termina de carregar.
@@ -66,8 +98,17 @@ export default function Home() {
   // olham os mesmos dados e sugere remover — o que reintroduziria o #108.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const today = useMemo(() => getToday(), [records]);
+  const daysSinceLast = useMemo(() => computeDaysSinceLast(records), [records]);
 
   const totalRecords = METRICS.reduce((s, m) => s + (today[m]?.length ?? 0), 0);
+
+  // Retomada aparece quando: (a) nunca registrou, ou (b) 3+ dias corridos sem
+  // registro em nenhuma métrica. Dismissal in-memory desliga só nesta sessão.
+  // Registrar hoje (totalRecords>0) desliga automaticamente pelo critério (a).
+  const showRetomada =
+    !retomadaDismissed &&
+    totalRecords === 0 &&
+    (daysSinceLast === null || daysSinceLast >= 3);
 
   const cards = METRICS.map((type) => {
     const { displayName, unit } = CATEGORY_MAP[type];
@@ -84,6 +125,39 @@ export default function Home() {
         active && registros.length > 1 ? `${registros.length} registros` : null,
     };
   });
+
+  if (showRetomada) {
+    return (
+      <MyView
+        safe={true}
+        className="flex-1 bg-light-background dark:bg-dark-background"
+      >
+        <ScrollView
+          contentContainerStyle={{ flexGrow: 1 }}
+          showsVerticalScrollIndicator={false}
+        >
+          {/* Hamburger disponível também aqui pra não trancar acesso ao
+              Ajustes (ex: sair, exportar) quando o usuário está em retomada. */}
+          <View className="w-full flex-row justify-start px-3 pt-2">
+            <Pressable
+              accessibilityLabel="Abrir ajustes"
+              accessibilityRole="button"
+              onPress={() => router.navigate("/ajustes")}
+              className="rounded-full p-2"
+            >
+              <Text className="text-2xl text-light-text dark:text-dark-text">
+                ☰
+              </Text>
+            </Pressable>
+          </View>
+          <RetomadaState
+            daysSinceLast={daysSinceLast}
+            onDismiss={() => setRetomadaDismissed(true)}
+          />
+        </ScrollView>
+      </MyView>
+    );
+  }
 
   return (
     <MyView

--- a/components/RetomadaState.jsx
+++ b/components/RetomadaState.jsx
@@ -1,0 +1,144 @@
+// @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
+import { Pressable, Text, View } from "react-native";
+import { router } from "expo-router";
+
+import Icon1c from "./Icon1c";
+import MetricIcon from "./MetricIcon";
+
+// Estado "retomada" da Home (M5-B fatia 5, mockup 2a·9).
+//
+// Aparece quando a Home ia mostrar 5 cards vazios: usuário sem registro há N
+// dias (ou nunca). Substitui a Home inteira por um convite calmo — símbolo
+// grande, copy sem cobrança, 3 atalhos pra métricas mais fáceis. Tom canônico
+// do design v2: "Sem pressa", "quando puder", "que bom te ver de volta".
+//
+// Dismissal é in-memory (via prop `onDismiss`): sessão atual passa a mostrar a
+// Home normal. Próximo launch volta pra cá se o critério persistir — é o
+// desejado (o objetivo é convidar até a pessoa registrar, não esconder pra
+// sempre).
+
+/**
+ * @param {{
+ *   daysSinceLast: number | null,  // null = nunca registrou
+ *   onDismiss: () => void,
+ * }} props
+ */
+export default function RetomadaState({ daysSinceLast, onDismiss }) {
+  const isFirstTime = daysSinceLast === null;
+
+  const title = isFirstTime ? "Bem-vindo." : "Que bom te ver de volta.";
+  const subtitle = isFirstTime
+    ? "Sem pressa. O primeiro registro pode ser qualquer coisa — comece pelo mais fácil."
+    : `Faz ${daysSinceLast} ${daysSinceLast === 1 ? "dia" : "dias"} que nada foi registrado. Sem cobrança — o que importa é o próximo registro.`;
+
+  return (
+    <View className="flex-1 gap-6 p-6">
+      {/* Símbolo grande — mesmo brand-blue tinted container do resto do app */}
+      <View
+        className="items-center justify-center rounded-2xl bg-primary"
+        style={{ width: 84, height: 84 }}
+      >
+        <Icon1c size={56} />
+      </View>
+
+      {/* Copy */}
+      <View className="gap-3">
+        <Text
+          className="text-ink"
+          style={{
+            fontFamily: "Inter_600SemiBold",
+            fontSize: 26,
+            lineHeight: 32,
+          }}
+        >
+          {title}
+        </Text>
+        <Text
+          className="text-body-secondary"
+          style={{
+            fontFamily: "Inter_400Regular",
+            fontSize: 14,
+            lineHeight: 22,
+          }}
+        >
+          {subtitle}
+        </Text>
+      </View>
+
+      {/* Card com os 3 atalhos */}
+      <View className="rounded-2xl border border-border-subtle bg-white p-5">
+        <Text
+          className="mb-3 text-xs uppercase tracking-wider text-label"
+          style={{ fontFamily: "JetBrainsMono_500Medium" }}
+        >
+          Quer começar por
+        </Text>
+        <View className="gap-2.5">
+          <ShortcutButton
+            metric="water"
+            label="Um copo d'água"
+            onPress={() => router.navigate("/(metrics)/water")}
+          />
+          <ShortcutButton
+            metric="sleep"
+            label="Como foi a última noite"
+            onPress={() => router.navigate("/(metrics)/sleep")}
+          />
+          <ShortcutButton
+            label="Ver todas as métricas"
+            dim
+            onPress={onDismiss}
+          />
+        </View>
+      </View>
+
+      {/* Link "Depois" */}
+      <View className="items-center">
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Depois"
+          onPress={onDismiss}
+          className="p-4 active:opacity-70"
+        >
+          <Text
+            className="text-sm text-label underline"
+            style={{ fontFamily: "Inter_400Regular" }}
+          >
+            Depois
+          </Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+/**
+ * @param {{ metric?: string, label: string, dim?: boolean, onPress: () => void }} props
+ */
+function ShortcutButton({ metric, label, dim, onPress }) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      onPress={onPress}
+      className="flex-row items-center gap-3 rounded-xl border border-border-strong bg-light-background p-4 active:opacity-70"
+    >
+      {metric ? (
+        <MetricIcon metric={metric} size={18} color="#2E5A88" />
+      ) : (
+        <Text
+          className="text-center text-icon-dim"
+          style={{ fontFamily: "Inter_500Medium", width: 18 }}
+        >
+          …
+        </Text>
+      )}
+      <Text
+        className={`text-sm ${dim ? "text-body-secondary" : "text-ink"}`}
+        style={{ fontFamily: "Inter_400Regular" }}
+      >
+        {label}
+      </Text>
+    </Pressable>
+  );
+}


### PR DESCRIPTION
Fatia 5 do redesign — aplica a mockup 2a·9 ("Volta depois de dias fora"). A Home ganha um estado calmo que substitui os 5 cards vazios quando o usuário é novo ou está fora há dias.

## Quando aparece

`showRetomada = !dismissed && totalRecords === 0 && (daysSinceLast === null || daysSinceLast >= 3)`

Ou seja:
- **Usuário novo** (nunca registrou nada) → sempre aparece até dismiss ou primeiro registro.
- **Retorno após 3+ dias** sem registro em nenhuma métrica → aparece até dismiss ou registro hoje.
- **Uso normal** (registro nos últimos 2 dias OU hoje já teve registro) → Home padrão.

Threshold de 3 dias é conservador — o objetivo é não parecer culpa por 1-2 dias soltos, mas convidar quando o abandono começa a virar hábito.

## O que entra

- **`components/RetomadaState.jsx`** (novo):
  - Símbolo grande 84×84 `bg-primary` `rounded-2xl` com Icon1c 56px branco — cabeça visual da mockup.
  - Copy **adapta pelo isFirstTime**:
    - nunca registrou → **"Bem-vindo."** + "Sem pressa. O primeiro registro pode ser qualquer coisa — comece pelo mais fácil."
    - retomada → **"Que bom te ver de volta."** + "Faz N dias que nada foi registrado. Sem cobrança — o que importa é o próximo registro." (singular/plural correto)
  - Card **"QUER COMEÇAR POR"** com 3 atalhos:
    - `[💧 water icon]` Um copo d'água → `/(metrics)/water`
    - `[🌙 sleep icon]` Como foi a última noite → `/(metrics)/sleep`
    - `[…]` Ver todas as métricas → dispara `onDismiss` (mostra a Home padrão)
  - Link **"Depois"** discreto (label gray + underline) → dispara `onDismiss`.

- **`app/index.jsx`**:
  - `computeDaysSinceLast(records)`: itera a tabela pegando `max(createdAt)` e compara **dias-de-calendário local**, não 24h corridas (evita "faz 1 dia" aparecer 24h após o registro; só vira 1 na virada do dia). Retorna `null` se store nunca teve registro.
  - Estado `retomadaDismissed` in-memory (`useState`). **Não persiste** — dismiss dura só a sessão. Persistir viraria sub-tarefa (`store.setValue("retomadaDismissedAt", ...)`); o comportamento atual está alinhado com o objetivo (convidar até registrar, então reaparecer no próximo launch se ainda estiver sem registro é o desejado).
  - Se `showRetomada`, retorna um MyView com hamburger no topo + `<RetomadaState />`. O hamburger **fica acessível** pra não trancar Ajustes (sair, exportar, feedback) quando o usuário está no estado retomada. Sem esse "escape", quem quiser sair da conta sem antes registrar ficaria preso.

## Fora

- **Dismissal persistente**: hoje só sessão. Se virar pain point, adicionar `retomadaDismissedAt` em `store.getValues()` e comparar contra `max(createdAt)`.
- **Bottom tab bar** da mockup: continua fora — Home segue no hamburger, decisão de nav maior fica pra fatia própria (junto com Semana/Ajustes se um dia migrar tudo pra tab bar).
- **Atalhos com side effect** (ex: "Um copo d'água" adicionar 200ml direto): interpretei como navegar pra tela — é o padrão do resto do app e evita ação irreversível sem confirmação.

## Test plan

- [x] `npm test` 63/63.
- [x] `tsc --noEmit` limpo.
- [x] `eslint` limpo.
- [x] `prettier --check` limpo.
- [ ] Preview:
  - Store vazia → abrir app → ver "Bem-vindo." + 3 atalhos.
  - Registrar água → volta pra Home normal.
  - Limpar dados (via Ajustes) + esperar 3+ dias (ou modificar `createdAt` manualmente) → volta a retomada com "Que bom te ver de volta. Faz N dias..."
  - "Depois" → Home normal na sessão. Fechar/abrir app → retomada volta.
  - Hamburger no estado retomada → abre Ajustes.

Refs #241 (fatia 4), #240 (fatia 3).
