### PR TITLE
feat(update): download progress banner + APK-outdated warning

### DIFF
--- a/assets/latest-apk-version.json
+++ b/assets/latest-apk-version.json
@@ -1,0 +1,4 @@
+{
+  "version": "1.1.1",
+  "installUrl": "https://expo.dev/accounts/matheushnascimento/projects/backOnTrack/builds/31173d89-2af7-4a7e-8a09-f4f0b84d574b"
+}

--- a/components/UpdateBanner.jsx
+++ b/components/UpdateBanner.jsx
@@ -1,41 +1,188 @@
 // @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
 //
-// Aviso de atualização OTA pendente (#131).
+// Banners de atualização (evoluído do #131).
 //
-// O expo-updates baixa o update em background mas só o aplica na abertura
-// SEGUINTE — e faz isso em silêncio. Na prática o tester roda um bundle velho
-// sem saber: testa um bug já corrigido, bate nele e reporta "continua quebrado".
-// Este banner torna esse estado visível e deixa aplicar na hora.
+// Três estados, em ordem de prioridade (só um aparece):
 //
-// Não recarrega sozinho de propósito: seria brusco no meio de um registro.
+//   1. NATIVE_OUTDATED  — versão do APK em execução é MENOR que a última
+//      publicada. Nesses casos o OTA não cobre (`runtimeVersion.policy:
+//      "appVersion"` — publicação nova sai em runtime N+1, o device em N
+//      ignora silenciosamente). Único jeito é reinstalar o APK. Banner
+//      prioritário porque tudo mais é sintoma disso.
 //
-// Posicionado absoluto no rodapé porque cada tela já monta o próprio safe-area
-// (MyView safe) e o app é edge-to-edge: em fluxo, no topo, ele brigaria com o
-// inset das telas (gap duplo) ou ficaria sob a status bar. Absoluto flutua sobre
-// a rota atual sem mexer no layout de ninguém.
+//   2. DOWNLOADING      — expo-updates tá baixando bundle novo em background.
+//      Sem progresso real (a API pública não expõe bytes), então usamos uma
+//      ProgressBar indeterminada — sinaliza "atividade em andamento" sem
+//      mentir sobre percentual.
 //
-// Em dev/web o expo-updates é no-op: `isUpdatePending` fica false e o banner
-// nunca aparece.
-import { Pressable, Text } from "react-native";
+//   3. UPDATE_PENDING   — bundle baixado, esperando reload. Toque aplica.
+//      Comportamento original do #131.
+//
+// Em dev/web/native sem update mecanismo os hooks retornam false — banner
+// não aparece. Fetch da última APK version só tenta em native com rede;
+// falha silenciosa mantém o banner desligado.
+
+import { useEffect, useState } from "react";
+import { Linking, Platform, Pressable, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { ProgressBar } from "react-native-paper";
+import Constants from "expo-constants";
 import { useUpdates, reloadAsync } from "expo-updates";
 
+// Fonte remota da última versão do APK cortada, atualizada manualmente no repo
+// quando um build novo é distribuído. Preferi raw.githubusercontent.com em vez
+// de embed no bundle porque o cliente numa versão VELHA precisa saber de uma
+// versão MAIS NOVA que ele — o bundle dele nunca vai ter esse valor por
+// definição. Cache do GitHub CDN é ~5min, suficiente pro caso de uso.
+const LATEST_APK_URL =
+  "https://raw.githubusercontent.com/matheushnascimento/backOnTrack/main/assets/latest-apk-version.json";
+
+/**
+ * "1.1.1" vs "1.2.0" → true se `current < latest`. Assume semver simples
+ * (major.minor.patch numérico) — o que app.json.version segue.
+ */
+function isBehind(current, latest) {
+  if (!current || !latest) return false;
+  const c = current.split(".").map(Number);
+  const l = latest.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    const cv = c[i] ?? 0;
+    const lv = l[i] ?? 0;
+    if (lv > cv) return true;
+    if (lv < cv) return false;
+  }
+  return false;
+}
+
 export default function UpdateBanner() {
-  const { isUpdatePending } = useUpdates();
+  const { isUpdatePending, isDownloading } = useUpdates();
   const insets = useSafeAreaInsets();
 
-  if (!isUpdatePending) return null;
+  // Última APK conhecida — carrega em background, sem bloquear render.
+  const [latestApk, setLatestApk] = useState(
+    /** @type {{version: string, installUrl?: string} | null} */ (null),
+  );
+  useEffect(() => {
+    // Só faz sentido no native (web tem o próprio fluxo de deploy). AbortController
+    // pra não vazar setState se o componente desmontar antes do fetch resolver.
+    if (Platform.OS === "web") return;
+    const ctrl = new AbortController();
+    fetch(LATEST_APK_URL, { signal: ctrl.signal, cache: "no-store" })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => {
+        if (d?.version) setLatestApk(d);
+      })
+      .catch(() => {
+        /* falha silenciosa — banner de native update só aparece se der certo */
+      });
+    return () => ctrl.abort();
+  }, []);
 
+  const currentVersion = Constants.expoConfig?.version;
+  const nativeOutdated =
+    latestApk != null && isBehind(currentVersion, latestApk.version);
+
+  const bottomPad = insets.bottom + 12;
+
+  // Prioridade: native outdated > downloading > pending.
+  if (nativeOutdated) {
+    const url = latestApk.installUrl;
+    return (
+      <BannerBase
+        color="#2E5A88"
+        bottomPad={bottomPad}
+        onPress={url ? () => Linking.openURL(url).catch(() => {}) : undefined}
+        accessibilityLabel={`Nova versão do app disponível: ${latestApk.version}`}
+      >
+        <Text
+          className="text-center text-white"
+          style={{ fontFamily: "Inter_600SemiBold", fontSize: 14 }}
+        >
+          Nova versão do app disponível
+        </Text>
+        <Text
+          className="text-center text-white opacity-80"
+          style={{ fontFamily: "Inter_400Regular", fontSize: 12, marginTop: 2 }}
+        >
+          Toque para instalar {latestApk.version} · você está em v
+          {currentVersion}
+        </Text>
+      </BannerBase>
+    );
+  }
+
+  if (isDownloading) {
+    return (
+      <BannerBase color="#F3F4F6" bottomPad={bottomPad}>
+        <Text
+          className="text-center text-ink"
+          style={{ fontFamily: "Inter_500Medium", fontSize: 13 }}
+        >
+          Baixando atualização…
+        </Text>
+        <View style={{ marginTop: 8, borderRadius: 4, overflow: "hidden" }}>
+          <ProgressBar indeterminate color="#2E5A88" />
+        </View>
+      </BannerBase>
+    );
+  }
+
+  if (isUpdatePending) {
+    return (
+      <BannerBase
+        color="#4CAF50"
+        bottomPad={bottomPad}
+        onPress={() => reloadAsync()}
+        accessibilityLabel="Atualização pronta — toque para reiniciar"
+      >
+        <Text
+          className="text-center text-white"
+          style={{ fontFamily: "Inter_600SemiBold", fontSize: 14 }}
+        >
+          Atualização pronta — toque para reiniciar
+        </Text>
+      </BannerBase>
+    );
+  }
+
+  return null;
+}
+
+/**
+ * Wrapper visual + safe-area comum aos 3 banners. Absoluto no rodapé porque
+ * cada tela já monta o próprio safe-area (MyView safe) e o app é edge-to-edge;
+ * absoluto flutua sem mexer no layout de ninguém.
+ *
+ * @param {{
+ *   color: string,
+ *   bottomPad: number,
+ *   onPress?: () => void,
+ *   accessibilityLabel?: string,
+ *   children: any,
+ * }} props
+ */
+function BannerBase({
+  color,
+  bottomPad,
+  onPress,
+  accessibilityLabel,
+  children,
+}) {
+  const Wrap = onPress ? Pressable : View;
   return (
-    <Pressable
-      onPress={() => reloadAsync()}
-      android_ripple={{ color: "#00000022" }}
-      className="absolute right-0 bottom-0 left-0 items-center bg-secondary px-4 pt-3"
-      style={{ paddingBottom: insets.bottom + 12 }}
+    <Wrap
+      {...(onPress
+        ? {
+            onPress,
+            android_ripple: { color: "#00000022" },
+            accessibilityRole: "button",
+            accessibilityLabel,
+          }
+        : {})}
+      className="absolute right-0 bottom-0 left-0 px-4 pt-3"
+      style={{ backgroundColor: color, paddingBottom: bottomPad }}
     >
-      <Text className="text-center font-bold text-light-outerText dark:text-dark-text">
-        Atualização pronta — toque para reiniciar
-      </Text>
-    </Pressable>
+      {children}
+    </Wrap>
   );
 }


### PR DESCRIPTION
Estende o UpdateBanner com 3 estados em ordem de prioridade pra resolver 3 lacunas de percepção do tester.

## 1. NATIVE_OUTDATED (prioritário)

Quando a versão do APK em execução é **menor** que a última publicada, o OTA não cobre — `runtimeVersion.policy: "appVersion"` faz o expo-updates ignorar publish de runtime N+1 no device em N (foi exatamente isso hoje: tester em APK 1.1.0 não recebia OTAs de design v2 publicadas em 1.1.1). Sem sinal nenhum, o sintoma reportado era "meu app não atualiza".

Agora: no launch, fetch de `raw.githubusercontent.com/matheushnascimento/backOnTrack/main/assets/latest-apk-version.json` compara com `Constants.expoConfig.version`. Se atrás, banner **brand-blue** full-width com "Nova versão do app disponível" + subtitle "Toque para instalar X.Y.Z · você está em vA.B.C". Tap abre a página EAS de instalação embutida no próprio JSON (`installUrl`).

**Novo ** hospedado no repo — atualizar quando cortar APK novo. Cache do CDN é ~5min, aceitável.

## 2. DOWNLOADING

`expo-updates` baixa em background sem feedback nenhum. Em atualizações grandes (fatia 5 completa hoje) o tester ficava em bundle antigo sem saber que o novo tá chegando. Agora banner **surface-subtle** com "Baixando atualização..." + `ProgressBar indeterminate` (Paper, cor primary). Não fingimos progresso real porque a API pública do expo-updates não expõe bytes — mostrar percentual falso seria pior que a barra indeterminada.

## 3. UPDATE_PENDING

Comportamento original do #131 preservado — banner **verde** "Atualização pronta — toque para reiniciar", ação abre `reloadAsync()`.

## Estrutura

- `BannerBase` interno abstrai wrapper (posição absoluta rodapé + safe-area + backgroundColor por estado). Os 3 conteúdos ficam enxutos.
- Só um banner aparece por vez (early return por prioridade).
- Web: fetch pulado (`Platform.OS === "web"`); o web tem próprio fluxo Vercel.
- Falha do fetch (offline, GitHub down, resposta malformada): banner de native update não aparece. `AbortController` evita setState em desmontar.

## Test plan

- [x] `tsc --noEmit` limpo.
- [x] `eslint` limpo.
- [x] `prettier --check` limpo.
- [x] `npm test` 63/63.
- [ ] Preview: hoje, com todos em 1.1.1 e JSON marcando 1.1.1, nenhum banner novo aparece — comportamento OK.
- [ ] Simular native-outdated: editar temporariamente `app.json.version` pra "1.0.0" em dev + fetch mockado retornando "1.1.1" → banner aparece com o tap link.
- [ ] Simular download: forçar `fetchUpdateAsync` em preview → ver banner indeterminate durante o processo.

Refs #131 (banner original), #218 (regra do bump nativo).