### PR TITLE
feat(design-v2): dark mode tokens applied to all v2 screens (Turno 3)

### DIFF
--- a/app/ajustes.jsx
+++ b/app/ajustes.jsx
@@ -11,6 +11,7 @@ import { useSession } from "@/infra/session";
 import { AUTH_ENABLED } from "@/infra/supabase";
 import { confirmAction } from "@/constants/dialogs";
 import { getEnvironmentInfo } from "@/constants/environment";
+import { useThemeTokens } from "@/constants/themeTokens";
 
 const ENV = getEnvironmentInfo();
 
@@ -44,6 +45,7 @@ export default function Ajustes() {
   const { colorScheme, toggleColorScheme } = useColorScheme();
   const { user, signOut } = useSession();
   const isDark = colorScheme === "dark";
+  const t = useThemeTokens();
 
   function handleClear() {
     confirmAction({
@@ -55,10 +57,7 @@ export default function Ajustes() {
   }
 
   return (
-    <MyView
-      safe={true}
-      className="flex-1 bg-light-background dark:bg-dark-background"
-    >
+    <MyView safe={true} className="flex-1 bg-light-background dark:bg-app-dark">
       <ScrollView
         contentContainerStyle={{ padding: 20, gap: 20 }}
         showsVerticalScrollIndicator={false}
@@ -74,14 +73,14 @@ export default function Ajustes() {
             <Svg width={18} height={18} viewBox="0 0 24 24" fill="none">
               <Path
                 d="M15 6l-6 6 6 6"
-                stroke="#2E5A88"
+                stroke={t.primary}
                 strokeWidth={2.4}
                 strokeLinecap="round"
                 strokeLinejoin="round"
               />
             </Svg>
             <Text
-              className="text-base text-primary"
+              className="text-base text-primary dark:text-primary-dark"
               style={{ fontFamily: "Inter_500Medium" }}
             >
               Voltar
@@ -92,13 +91,13 @@ export default function Ajustes() {
         {/* Header */}
         <View className="gap-1 px-1">
           <Text
-            className="text-2xl text-ink"
+            className="text-2xl text-ink dark:text-ink-dark"
             style={{ fontFamily: "Inter_600SemiBold" }}
           >
             Ajustes
           </Text>
           <Text
-            className="text-sm text-body-secondary"
+            className="text-sm text-body-secondary dark:text-body-secondary-dark"
             style={{ fontFamily: "Inter_400Regular", marginTop: 2 }}
           >
             Metas gentis. Pode mudar a qualquer hora.
@@ -137,7 +136,7 @@ export default function Ajustes() {
           {/* Tema com switch inline (mesmo controle do MenuModal antigo) */}
           <View className="flex-row items-center justify-between border-t border-surface-subtle px-4 py-3">
             <Text
-              className="text-sm text-ink"
+              className="text-sm text-ink dark:text-ink-dark"
               style={{ fontFamily: "Inter_400Regular" }}
             >
               Tema escuro
@@ -185,7 +184,7 @@ export default function Ajustes() {
 
         {/* Tagline */}
         <Text
-          className="mt-2 text-center text-xs text-icon-dim"
+          className="mt-2 text-center text-xs text-icon-dim dark:text-icon-dim-dark"
           style={{ fontFamily: "Inter_400Regular", fontStyle: "italic" }}
         >
           Back on Track · de volta aos trilhos, um registro por vez.
@@ -194,7 +193,7 @@ export default function Ajustes() {
         {/* Bundle info discreto (mantém diagnóstico do tester) */}
         {ENV.bundle ? (
           <Text
-            className="text-center text-xs text-icon-dim"
+            className="text-center text-xs text-icon-dim dark:text-icon-dim-dark"
             style={{ fontFamily: "JetBrainsMono_400Regular" }}
           >
             {ENV.bundle}
@@ -208,9 +207,9 @@ export default function Ajustes() {
 /** @param {{ title: string, children: any }} props */
 function Section({ title, children }) {
   return (
-    <View className="overflow-hidden rounded-2xl border border-border-subtle bg-white">
+    <View className="overflow-hidden rounded-2xl border border-border-subtle dark:border-border-subtle-dark bg-white dark:bg-card-dark">
       <Text
-        className="px-4 pt-3.5 pb-1.5 text-xs uppercase tracking-wider text-label"
+        className="px-4 pt-3.5 pb-1.5 text-xs uppercase tracking-wider text-label dark:text-label-dark"
         style={{ fontFamily: "JetBrainsMono_500Medium" }}
       >
         {title}
@@ -256,7 +255,7 @@ function Row({
       }`}
     >
       <Text
-        className={`text-sm ${destructive ? "text-danger" : "text-ink"}`}
+        className={`text-sm ${destructive ? "text-danger dark:text-danger" : "text-ink dark:text-ink-dark"}`}
         style={{ fontFamily: "Inter_400Regular" }}
       >
         {label}
@@ -264,7 +263,7 @@ function Row({
       <View className="flex-row items-center gap-1">
         {value ? (
           <Text
-            className="text-sm text-body-secondary"
+            className="text-sm text-body-secondary dark:text-body-secondary-dark"
             style={{
               fontFamily: valueMono
                 ? "JetBrainsMono_400Regular"
@@ -277,7 +276,7 @@ function Row({
         ) : null}
         {valueChevron || (onPress && !disabled && !destructive) ? (
           <Text
-            className="text-sm text-label"
+            className="text-sm text-label dark:text-label-dark"
             style={{ fontFamily: "Inter_400Regular" }}
           >
             ›

--- a/app/index.jsx
+++ b/app/index.jsx
@@ -13,6 +13,7 @@ import RetomadaState from "@/components/RetomadaState";
 
 import { getToday, store } from "@/infra/database";
 import { useSession } from "@/infra/session";
+import { useThemeTokens } from "@/constants/themeTokens";
 import { AUTH_ENABLED } from "@/infra/supabase";
 import { CATEGORY_MAP } from "@/components/categoryUtils";
 import { minutesToHHMM } from "@/constants/duration";
@@ -82,6 +83,7 @@ function formatDateLabel() {
 
 export default function Home() {
   const { user } = useSession();
+  const t = useThemeTokens();
   // Dismissal in-memory do estado de retomada (M5-B fatia 5). Persistir viraria
   // sub-tarefa; hoje "Depois" dura só a sessão — próximo launch com o critério
   // ainda válido volta a mostrar, que é o objetivo (convidar até registrar).
@@ -130,7 +132,7 @@ export default function Home() {
     return (
       <MyView
         safe={true}
-        className="flex-1 bg-light-background dark:bg-dark-background"
+        className="flex-1 bg-light-background dark:bg-app-dark"
       >
         <ScrollView
           contentContainerStyle={{ flexGrow: 1 }}
@@ -160,10 +162,7 @@ export default function Home() {
   }
 
   return (
-    <MyView
-      safe={true}
-      className="flex-1 bg-light-background dark:bg-dark-background"
-    >
+    <MyView safe={true} className="flex-1 bg-light-background dark:bg-app-dark">
       <ScrollView
         contentContainerStyle={{ padding: 20, gap: 20 }}
         showsVerticalScrollIndicator={false}
@@ -187,27 +186,31 @@ export default function Home() {
             2a·1 do design v2. */}
         <View className="gap-1 px-1">
           <Text
-            className="text-xs tracking-wider text-label"
+            className="text-xs tracking-wider text-label dark:text-label-dark"
             style={{ fontFamily: "JetBrainsMono_500Medium" }}
           >
             {formatDateLabel()}
           </Text>
           <View className="flex-row items-center justify-between">
             <Text
-              className="text-2xl text-ink"
+              className="text-2xl text-ink dark:text-ink-dark"
               style={{ fontFamily: "Inter_600SemiBold" }}
             >
               {getGreeting(user)}
             </Text>
             <View
-              className="items-center justify-center rounded-lg bg-primary"
+              className="items-center justify-center rounded-lg bg-primary dark:bg-primary-dark"
               style={{ width: 32, height: 32 }}
             >
-              <Icon1c size={22} />
+              <Icon1c
+                size={22}
+                strokeColor={t.onPrimary}
+                dotColor={t.accentToday}
+              />
             </View>
           </View>
           <Text
-            className="text-sm text-body-secondary"
+            className="text-sm text-body-secondary dark:text-body-secondary-dark"
             style={{ fontFamily: "Inter_400Regular", marginTop: 2 }}
           >
             {totalRecords === 0
@@ -237,14 +240,14 @@ export default function Home() {
         {/* Entrar isolado só quando deslogado + auth configurada. Sair vai
             pra tela de Ajustes junto com "Logado como". */}
         {AUTH_ENABLED && !user && (
-          <View className="rounded-2xl border border-border-subtle bg-white p-4">
+          <View className="rounded-2xl border border-border-subtle dark:border-border-subtle-dark bg-white dark:bg-card-dark p-4">
             <Pressable
               accessibilityRole="button"
               onPress={() => router.navigate("/login")}
-              className="items-center rounded-xl bg-primary py-3"
+              className="items-center rounded-xl bg-primary dark:bg-primary-dark py-3"
             >
               <Text
-                className="text-sm text-white"
+                className="text-sm text-white dark:text-on-primary-dark"
                 style={{ fontFamily: "Inter_500Medium" }}
               >
                 Entrar

--- a/app/semana.jsx
+++ b/app/semana.jsx
@@ -10,6 +10,7 @@ import WeekStrip from "@/components/WeekStrip";
 
 import { store } from "@/infra/database";
 import { METRIC_KEYS_ORDER, summarizeWeek } from "@/infra/week";
+import { useThemeTokens } from "@/constants/themeTokens";
 
 // Tela Semana (M5-B fatia 3, mockup 2a·7).
 // Header mono + h1 + subtitle → strip de 7 dias com barrinhas por métrica →
@@ -17,16 +18,14 @@ import { METRIC_KEYS_ORDER, summarizeWeek } from "@/infra/week";
 // no hamburger); introduzir tab bar é decisão maior, fica pra próxima fatia.
 
 export default function Semana() {
+  const t = useThemeTokens();
   const records = useTable("records", store);
   // Recalcula quando a tabela muda (mesmo padrão da Home).
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const summary = useMemo(() => summarizeWeek(), [records]);
 
   return (
-    <MyView
-      safe={true}
-      className="flex-1 bg-light-background dark:bg-dark-background"
-    >
+    <MyView safe={true} className="flex-1 bg-light-background dark:bg-app-dark">
       <ScrollView
         contentContainerStyle={{ padding: 20, gap: 20 }}
         showsVerticalScrollIndicator={false}
@@ -42,14 +41,14 @@ export default function Semana() {
             <Svg width={18} height={18} viewBox="0 0 24 24" fill="none">
               <Path
                 d="M15 6l-6 6 6 6"
-                stroke="#2E5A88"
+                stroke={t.primary}
                 strokeWidth={2.4}
                 strokeLinecap="round"
                 strokeLinejoin="round"
               />
             </Svg>
             <Text
-              className="text-base text-primary"
+              className="text-base text-primary dark:text-primary-dark"
               style={{ fontFamily: "Inter_500Medium" }}
             >
               Voltar
@@ -60,19 +59,19 @@ export default function Semana() {
         {/* Header */}
         <View className="gap-1 px-1">
           <Text
-            className="text-xs tracking-wider text-label"
+            className="text-xs tracking-wider text-label dark:text-label-dark"
             style={{ fontFamily: "JetBrainsMono_500Medium" }}
           >
             {summary.header.weekLabel}
           </Text>
           <Text
-            className="text-2xl text-ink"
+            className="text-2xl text-ink dark:text-ink-dark"
             style={{ fontFamily: "Inter_600SemiBold" }}
           >
             {summary.header.title}
           </Text>
           <Text
-            className="text-sm text-body-secondary"
+            className="text-sm text-body-secondary dark:text-body-secondary-dark"
             style={{ fontFamily: "Inter_400Regular", marginTop: 2 }}
           >
             {summary.header.subtitle}
@@ -85,7 +84,7 @@ export default function Semana() {
         {/* Per metric */}
         <View className="gap-2.5">
           <Text
-            className="text-xs uppercase tracking-wider text-label"
+            className="text-xs uppercase tracking-wider text-label dark:text-label-dark"
             style={{ fontFamily: "JetBrainsMono_500Medium" }}
           >
             Por métrica
@@ -95,16 +94,16 @@ export default function Semana() {
             return (
               <View
                 key={key}
-                className="flex-row items-center justify-between rounded-xl border border-border-subtle bg-white px-4 py-3"
+                className="flex-row items-center justify-between rounded-xl border border-border-subtle dark:border-border-subtle-dark bg-white dark:bg-card-dark px-4 py-3"
               >
                 <Text
-                  className="text-sm text-ink"
+                  className="text-sm text-ink dark:text-ink-dark"
                   style={{ fontFamily: "Inter_500Medium" }}
                 >
                   {m.label}
                 </Text>
                 <Text
-                  className="text-sm text-body-secondary"
+                  className="text-sm text-body-secondary dark:text-body-secondary-dark"
                   style={{ fontFamily: "JetBrainsMono_400Regular" }}
                 >
                   {m.stat}

--- a/components/MetricCard.jsx
+++ b/components/MetricCard.jsx
@@ -2,6 +2,7 @@
 import { Pressable, Text, View } from "react-native";
 
 import MetricIcon from "./MetricIcon";
+import { useThemeTokens } from "@/constants/themeTokens";
 
 // Card de métrica na Home v2 (M5-B fatia 1, direção 1c do design).
 // Estrutura: [ícone tinted 44×44] [nome (bold) — direita: valor ou "quando puder"] [detalhe pequeno opcional].
@@ -26,33 +27,36 @@ export default function MetricCard({
   detail,
   onPress,
 }) {
+  const t = useThemeTokens();
   return (
     <Pressable
       onPress={onPress}
       accessibilityRole="button"
       accessibilityLabel={`Métrica ${name}${active ? `, ${value}` : ", sem registros"}`}
-      className="w-full flex-row items-center gap-3 rounded-2xl border border-border-subtle bg-white p-4 active:opacity-70"
+      className="w-full flex-row items-center gap-3 rounded-2xl border border-border-subtle dark:border-border-subtle-dark bg-white dark:bg-card-dark p-4 active:opacity-70"
     >
       <View
-        className={`h-11 w-11 items-center justify-center rounded-xl ${active ? "bg-tint-blue" : "bg-surface-subtle"}`}
+        className={`h-11 w-11 items-center justify-center rounded-xl ${active ? "bg-tint-blue dark:bg-tint-blue-dark" : "bg-surface-subtle dark:bg-surface-subtle-dark"}`}
       >
         <MetricIcon
           metric={metric}
           size={22}
-          color={active ? "#2E5A88" : "#6B7280"}
+          color={active ? t.primary : t.label}
         />
       </View>
       <View className="flex-1 gap-0.5">
         <View className="flex-row items-baseline justify-between">
           <Text
-            className="text-sm text-ink"
+            className="text-sm text-ink dark:text-ink-dark"
             style={{ fontFamily: "Inter_600SemiBold" }}
           >
             {name}
           </Text>
           <Text
             className={
-              active ? "text-xs text-body-secondary" : "text-xs text-label"
+              active
+                ? "text-xs text-body-secondary dark:text-body-secondary-dark"
+                : "text-xs text-label dark:text-label-dark"
             }
             style={{
               fontFamily: active
@@ -65,7 +69,7 @@ export default function MetricCard({
         </View>
         {detail ? (
           <Text
-            className="text-xs text-label"
+            className="text-xs text-label dark:text-label-dark"
             style={{ fontFamily: "Inter_400Regular" }}
           >
             {detail}

--- a/components/MetricRegisterHeader.jsx
+++ b/components/MetricRegisterHeader.jsx
@@ -4,6 +4,7 @@ import Svg, { Path } from "react-native-svg";
 import { router } from "expo-router";
 
 import MetricIcon from "./MetricIcon";
+import { useThemeTokens } from "@/constants/themeTokens";
 
 // Nav bar + header das telas de registro no visual v2 (M5-B fatia 2, mockups
 // 2a·2 e 2a·3 do Claude Design). Padrão:
@@ -27,6 +28,7 @@ export default function MetricRegisterHeader({
   subtitle,
   label = "HOJE",
 }) {
+  const t = useThemeTokens();
   return (
     <View className="gap-4 px-1">
       {/* Nav bar */}
@@ -42,7 +44,7 @@ export default function MetricRegisterHeader({
             height={18}
             viewBox="0 0 24 24"
             fill="none"
-            stroke="#0F1419"
+            stroke={t.ink}
             strokeWidth={2.4}
             strokeLinecap="round"
             strokeLinejoin="round"
@@ -50,14 +52,14 @@ export default function MetricRegisterHeader({
             <Path d="M15 6l-6 6 6 6" />
           </Svg>
           <Text
-            className="text-sm text-ink"
+            className="text-sm text-ink dark:text-ink-dark"
             style={{ fontFamily: "Inter_500Medium" }}
           >
             Voltar
           </Text>
         </Pressable>
         <Text
-          className="text-xs tracking-wider text-label"
+          className="text-xs tracking-wider text-label dark:text-label-dark"
           style={{ fontFamily: "JetBrainsMono_500Medium" }}
         >
           {label}
@@ -67,11 +69,11 @@ export default function MetricRegisterHeader({
       {/* Header: ícone + título + subtítulo */}
       <View className="gap-2">
         <View className="flex-row items-center gap-3">
-          <View className="h-9 w-9 items-center justify-center rounded-xl bg-tint-blue">
-            <MetricIcon metric={metric} size={18} color="#2E5A88" />
+          <View className="h-9 w-9 items-center justify-center rounded-xl bg-tint-blue dark:bg-tint-blue-dark">
+            <MetricIcon metric={metric} size={18} color={t.primary} />
           </View>
           <Text
-            className="text-2xl text-ink"
+            className="text-2xl text-ink dark:text-ink-dark"
             style={{ fontFamily: "Inter_600SemiBold" }}
           >
             {title}
@@ -79,7 +81,7 @@ export default function MetricRegisterHeader({
         </View>
         {subtitle ? (
           <Text
-            className="text-sm text-body-secondary"
+            className="text-sm text-body-secondary dark:text-body-secondary-dark"
             style={{ fontFamily: "Inter_400Regular" }}
           >
             {subtitle}

--- a/components/RetomadaState.jsx
+++ b/components/RetomadaState.jsx
@@ -4,6 +4,7 @@ import { router } from "expo-router";
 
 import Icon1c from "./Icon1c";
 import MetricIcon from "./MetricIcon";
+import { useThemeTokens } from "@/constants/themeTokens";
 
 // Estado "retomada" da Home (M5-B fatia 5, mockup 2a·9).
 //
@@ -24,6 +25,7 @@ import MetricIcon from "./MetricIcon";
  * }} props
  */
 export default function RetomadaState({ daysSinceLast, onDismiss }) {
+  const t = useThemeTokens();
   const isFirstTime = daysSinceLast === null;
 
   const title = isFirstTime ? "Bem-vindo." : "Que bom te ver de volta.";
@@ -35,16 +37,16 @@ export default function RetomadaState({ daysSinceLast, onDismiss }) {
     <View className="flex-1 gap-6 p-6">
       {/* Símbolo grande — mesmo brand-blue tinted container do resto do app */}
       <View
-        className="items-center justify-center rounded-2xl bg-primary"
+        className="items-center justify-center rounded-2xl bg-primary dark:bg-primary-dark"
         style={{ width: 84, height: 84 }}
       >
-        <Icon1c size={56} />
+        <Icon1c size={56} strokeColor={t.onPrimary} dotColor={t.accentToday} />
       </View>
 
       {/* Copy */}
       <View className="gap-3">
         <Text
-          className="text-ink"
+          className="text-ink dark:text-ink-dark"
           style={{
             fontFamily: "Inter_600SemiBold",
             fontSize: 26,
@@ -54,7 +56,7 @@ export default function RetomadaState({ daysSinceLast, onDismiss }) {
           {title}
         </Text>
         <Text
-          className="text-body-secondary"
+          className="text-body-secondary dark:text-body-secondary-dark"
           style={{
             fontFamily: "Inter_400Regular",
             fontSize: 14,
@@ -66,9 +68,9 @@ export default function RetomadaState({ daysSinceLast, onDismiss }) {
       </View>
 
       {/* Card com os 3 atalhos */}
-      <View className="rounded-2xl border border-border-subtle bg-white p-5">
+      <View className="rounded-2xl border border-border-subtle dark:border-border-subtle-dark bg-white dark:bg-card-dark p-5">
         <Text
-          className="mb-3 text-xs uppercase tracking-wider text-label"
+          className="mb-3 text-xs uppercase tracking-wider text-label dark:text-label-dark"
           style={{ fontFamily: "JetBrainsMono_500Medium" }}
         >
           Quer começar por
@@ -101,7 +103,7 @@ export default function RetomadaState({ daysSinceLast, onDismiss }) {
           className="p-4 active:opacity-70"
         >
           <Text
-            className="text-sm text-label underline"
+            className="text-sm text-label dark:text-label-dark underline"
             style={{ fontFamily: "Inter_400Regular" }}
           >
             Depois
@@ -116,25 +118,26 @@ export default function RetomadaState({ daysSinceLast, onDismiss }) {
  * @param {{ metric?: string, label: string, dim?: boolean, onPress: () => void }} props
  */
 function ShortcutButton({ metric, label, dim, onPress }) {
+  const t = useThemeTokens();
   return (
     <Pressable
       accessibilityRole="button"
       accessibilityLabel={label}
       onPress={onPress}
-      className="flex-row items-center gap-3 rounded-xl border border-border-strong bg-light-background p-4 active:opacity-70"
+      className="flex-row items-center gap-3 rounded-xl border border-border-strong dark:border-border-strong-dark bg-light-background dark:bg-app-dark p-4 active:opacity-70"
     >
       {metric ? (
-        <MetricIcon metric={metric} size={18} color="#2E5A88" />
+        <MetricIcon metric={metric} size={18} color={t.primary} />
       ) : (
         <Text
-          className="text-center text-icon-dim"
+          className="text-center text-icon-dim dark:text-icon-dim-dark"
           style={{ fontFamily: "Inter_500Medium", width: 18 }}
         >
           …
         </Text>
       )}
       <Text
-        className={`text-sm ${dim ? "text-body-secondary" : "text-ink"}`}
+        className={`text-sm ${dim ? "text-body-secondary dark:text-body-secondary-dark" : "text-ink dark:text-ink-dark"}`}
         style={{ fontFamily: "Inter_400Regular" }}
       >
         {label}

--- a/components/UpdateBanner.jsx
+++ b/components/UpdateBanner.jsx
@@ -29,6 +29,8 @@ import { ProgressBar } from "react-native-paper";
 import Constants from "expo-constants";
 import { useUpdates, reloadAsync } from "expo-updates";
 
+import { useThemeTokens } from "@/constants/themeTokens";
+
 // Fonte remota da última versão do APK cortada, atualizada manualmente no repo
 // quando um build novo é distribuído. Preferi raw.githubusercontent.com em vez
 // de embed no bundle porque o cliente numa versão VELHA precisa saber de uma
@@ -57,6 +59,7 @@ function isBehind(current, latest) {
 export default function UpdateBanner() {
   const { isUpdatePending, isDownloading } = useUpdates();
   const insets = useSafeAreaInsets();
+  const t = useThemeTokens();
 
   // Última APK conhecida — carrega em background, sem bloquear render.
   const [latestApk, setLatestApk] = useState(
@@ -89,19 +92,19 @@ export default function UpdateBanner() {
     const url = latestApk.installUrl;
     return (
       <BannerBase
-        color="#2E5A88"
+        color={t.primary}
         bottomPad={bottomPad}
         onPress={url ? () => Linking.openURL(url).catch(() => {}) : undefined}
         accessibilityLabel={`Nova versão do app disponível: ${latestApk.version}`}
       >
         <Text
-          className="text-center text-white"
+          className="text-center text-white dark:text-on-primary-dark"
           style={{ fontFamily: "Inter_600SemiBold", fontSize: 14 }}
         >
           Nova versão do app disponível
         </Text>
         <Text
-          className="text-center text-white opacity-80"
+          className="text-center text-white dark:text-on-primary-dark opacity-80"
           style={{ fontFamily: "Inter_400Regular", fontSize: 12, marginTop: 2 }}
         >
           Toque para instalar {latestApk.version} · você está em v
@@ -113,15 +116,15 @@ export default function UpdateBanner() {
 
   if (isDownloading) {
     return (
-      <BannerBase color="#F3F4F6" bottomPad={bottomPad}>
+      <BannerBase color={t.surfaceSubtle} bottomPad={bottomPad}>
         <Text
-          className="text-center text-ink"
+          className="text-center text-ink dark:text-ink-dark"
           style={{ fontFamily: "Inter_500Medium", fontSize: 13 }}
         >
           Baixando atualização…
         </Text>
         <View style={{ marginTop: 8, borderRadius: 4, overflow: "hidden" }}>
-          <ProgressBar indeterminate color="#2E5A88" />
+          <ProgressBar indeterminate color={t.primary} />
         </View>
       </BannerBase>
     );
@@ -130,7 +133,7 @@ export default function UpdateBanner() {
   if (isUpdatePending) {
     return (
       <BannerBase
-        color="#4CAF50"
+        color={t.accentToday}
         bottomPad={bottomPad}
         onPress={() => reloadAsync()}
         accessibilityLabel="Atualização pronta — toque para reiniciar"

--- a/components/WeekStrip.jsx
+++ b/components/WeekStrip.jsx
@@ -1,6 +1,8 @@
 // @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
 import { Text, View } from "react-native";
 
+import { useThemeTokens } from "@/constants/themeTokens";
+
 // Faixa visual dos últimos 7 dias (M5-B fatia 3, mockup 2a·7).
 // Cada dia = coluna com stack vertical de barrinhas: 1 por métrica registrada.
 // Se todas as 5 métricas foram registradas, a barra do topo vira verde
@@ -22,8 +24,9 @@ const STACK_HEIGHT = MAX_METRICS * BAR_HEIGHT + (MAX_METRICS - 1) * BAR_GAP; // 
  * }> }} props
  */
 export default function WeekStrip({ days }) {
+  const t = useThemeTokens();
   return (
-    <View className="rounded-2xl border border-border-subtle bg-white p-4">
+    <View className="rounded-2xl border border-border-subtle dark:border-border-subtle-dark bg-white dark:bg-card-dark p-4">
       <View
         className="flex-row items-end justify-between"
         style={{ height: STACK_HEIGHT + 24 }}
@@ -34,10 +37,10 @@ export default function WeekStrip({ days }) {
       </View>
 
       {/* Legend */}
-      <View className="mt-4 flex-row gap-3 border-t border-surface-subtle pt-3">
-        <LegendItem color="#2E5A88" label="registro" />
-        <LegendItem color="#4CAF50" label="dia completo" />
-        <LegendItem color="#E5E7EB" label="vazio" />
+      <View className="mt-4 flex-row gap-3 border-t border-surface-subtle dark:border-surface-subtle-dark pt-3">
+        <LegendItem color={t.primary} label="registro" />
+        <LegendItem color={t.accentToday} label="dia completo" />
+        <LegendItem color={t.borderSubtle} label="vazio" />
       </View>
     </View>
   );
@@ -45,15 +48,16 @@ export default function WeekStrip({ days }) {
 
 /** @param {{ day: { weekdayLabel: string, isToday: boolean, filledMetrics: string[], complete: boolean } }} props */
 function DayColumn({ day }) {
+  const t = useThemeTokens();
   const filled = day.filledMetrics.length;
   const isEmpty = filled === 0;
 
   // Uma barrinha por métrica registrada; topo verde se completo. Se vazio,
   // uma barra cinza placeholder.
   const bars = isEmpty
-    ? [{ color: "#E5E7EB", key: "empty" }]
+    ? [{ color: t.borderSubtle, key: "empty" }]
     : Array.from({ length: filled }, (_, i) => ({
-        color: day.complete && i === filled - 1 ? "#4CAF50" : "#2E5A88",
+        color: day.complete && i === filled - 1 ? t.accentToday : t.primary,
         key: `bar-${i}`,
       }));
 
@@ -76,7 +80,7 @@ function DayColumn({ day }) {
               // reproduz o efeito com custo zero).
               ...(day.isToday && {
                 borderWidth: 2,
-                borderColor: "#EAF3FB",
+                borderColor: t.tintBlue,
               }),
             }}
           />
@@ -86,7 +90,7 @@ function DayColumn({ day }) {
         style={{
           fontFamily: "JetBrainsMono_500Medium",
           fontSize: 10,
-          color: day.isToday ? "#2E5A88" : "#6B7280",
+          color: day.isToday ? t.primary : t.label,
           fontWeight: day.isToday ? "700" : "500",
         }}
       >
@@ -104,7 +108,7 @@ function LegendItem({ color, label }) {
         style={{ width: 8, height: 8, backgroundColor: color, borderRadius: 2 }}
       />
       <Text
-        className="text-xs text-label"
+        className="text-xs text-label dark:text-label-dark"
         style={{ fontFamily: "Inter_400Regular" }}
       >
         {label}

--- a/components/metrics/ExerciseBespoke.jsx
+++ b/components/metrics/ExerciseBespoke.jsx
@@ -5,6 +5,7 @@ import { Pressable, Text, TextInput, View } from "react-native";
 import { add } from "@/infra/database";
 import getDate from "@/constants/getDate";
 import { hhmmToMinutes } from "@/constants/duration";
+import { useThemeTokens } from "@/constants/themeTokens";
 
 // UI bespoke da tela de exercício (M5-B fatia 2c, mockup 2a·4).
 // Toggle Treino/Cardio (independentes) → duração HH:MM → hora de início
@@ -108,7 +109,7 @@ export default function ExerciseBespoke({ onAfterAdd }) {
       {/* Intensidade */}
       <View className="mt-2">
         <Text
-          className="mb-3 text-xs uppercase tracking-wider text-label"
+          className="mb-3 text-xs uppercase tracking-wider text-label dark:text-label-dark"
           style={{ fontFamily: "JetBrainsMono_500Medium" }}
         >
           Como foi
@@ -125,12 +126,12 @@ export default function ExerciseBespoke({ onAfterAdd }) {
                 onPress={() => setIntensity(i.score)}
                 className={`flex-1 items-center rounded-xl py-3 ${
                   selected
-                    ? "border-2 border-primary bg-tint-blue"
-                    : "border border-border-strong bg-white"
+                    ? "border-2 border-primary dark:border-primary-dark bg-tint-blue dark:bg-tint-blue-dark"
+                    : "border border-border-strong dark:border-border-strong-dark bg-white dark:bg-card-dark"
                 }`}
               >
                 <Text
-                  className={`text-xs ${selected ? "text-primary" : "text-body-secondary"}`}
+                  className={`text-xs ${selected ? "text-primary dark:text-primary-dark" : "text-body-secondary dark:text-body-secondary-dark"}`}
                   style={{
                     fontFamily: selected
                       ? "Inter_600SemiBold"
@@ -153,11 +154,13 @@ export default function ExerciseBespoke({ onAfterAdd }) {
         disabled={!canSave}
         onPress={handleSave}
         className={`mt-2 items-center rounded-2xl py-4 ${
-          canSave ? "bg-primary active:opacity-70" : "bg-border-strong"
+          canSave
+            ? "bg-primary dark:bg-primary-dark active:opacity-70"
+            : "bg-border-strong dark:bg-border-strong-dark"
         }`}
       >
         <Text
-          className="text-base text-white"
+          className="text-base text-white dark:text-on-primary-dark"
           style={{ fontFamily: "Inter_600SemiBold" }}
         >
           Registrar
@@ -179,12 +182,12 @@ function ModalityChip({ label, hint, selected, onPress }) {
       onPress={onPress}
       className={`flex-1 rounded-2xl px-4 py-3 ${
         selected
-          ? "border-2 border-primary bg-tint-blue"
-          : "border border-border-strong bg-white"
+          ? "border-2 border-primary dark:border-primary-dark bg-tint-blue dark:bg-tint-blue-dark"
+          : "border border-border-strong dark:border-border-strong-dark bg-white dark:bg-card-dark"
       }`}
     >
       <Text
-        className={`text-base ${selected ? "text-primary" : "text-body-secondary"}`}
+        className={`text-base ${selected ? "text-primary dark:text-primary-dark" : "text-body-secondary dark:text-body-secondary-dark"}`}
         style={{
           fontFamily: selected ? "Inter_600SemiBold" : "Inter_500Medium",
         }}
@@ -192,7 +195,7 @@ function ModalityChip({ label, hint, selected, onPress }) {
         {label}
       </Text>
       <Text
-        className={`text-xs ${selected ? "text-primary opacity-75" : "text-label"}`}
+        className={`text-xs ${selected ? "text-primary dark:text-primary-dark opacity-75" : "text-label dark:text-label-dark"}`}
         style={{ fontFamily: "Inter_400Regular", marginTop: 2 }}
       >
         {hint}
@@ -211,11 +214,12 @@ function ModalityChip({ label, hint, selected, onPress }) {
  * }} props
  */
 function FieldRow({ label, value, onChange, placeholder, hint }) {
+  const t = useThemeTokens();
   return (
-    <View className="flex-row items-center justify-between rounded-2xl border border-border-subtle bg-white px-5 py-4">
+    <View className="flex-row items-center justify-between rounded-2xl border border-border-subtle dark:border-border-subtle-dark bg-white dark:bg-card-dark px-5 py-4">
       <View className="gap-0.5">
         <Text
-          className="text-xs uppercase tracking-wider text-label"
+          className="text-xs uppercase tracking-wider text-label dark:text-label-dark"
           style={{ fontFamily: "JetBrainsMono_500Medium" }}
         >
           {label}
@@ -224,21 +228,21 @@ function FieldRow({ label, value, onChange, placeholder, hint }) {
           value={value}
           onChangeText={onChange}
           placeholder={placeholder}
-          placeholderTextColor="#9CA3AF"
+          placeholderTextColor={t.iconDim}
           keyboardType="numbers-and-punctuation"
           maxLength={5}
           accessibilityLabel={label}
           style={{
             fontFamily: "JetBrainsMono_500Medium",
             fontSize: 24,
-            color: "#0F1419",
+            color: t.ink,
             padding: 0,
             minWidth: 80,
           }}
         />
       </View>
       <Text
-        className="text-xs text-body-secondary"
+        className="text-xs text-body-secondary dark:text-body-secondary-dark"
         style={{ fontFamily: "Inter_400Regular" }}
       >
         {hint}

--- a/components/metrics/FeedingBespoke.jsx
+++ b/components/metrics/FeedingBespoke.jsx
@@ -72,7 +72,7 @@ export default function FeedingBespoke({ onAfterAdd }) {
       {/* Big number */}
       <View className="items-center gap-2">
         <Text
-          className="text-primary"
+          className="text-primary dark:text-primary-dark"
           style={{
             fontFamily: "JetBrainsMono_500Medium",
             fontSize: 88,
@@ -82,7 +82,7 @@ export default function FeedingBespoke({ onAfterAdd }) {
           {totalCount}
         </Text>
         <Text
-          className="text-xs text-label"
+          className="text-xs text-label dark:text-label-dark"
           style={{ fontFamily: "Inter_400Regular" }}
         >
           {totalCount === 1 ? "refeição hoje" : "refeições hoje"}
@@ -99,12 +99,16 @@ export default function FeedingBespoke({ onAfterAdd }) {
           onPress={handleRemove}
           className={`flex-1 items-center rounded-2xl border py-4 ${
             totalCount === 0
-              ? "border-border-subtle bg-surface-subtle"
-              : "border-border-strong bg-white active:opacity-70"
+              ? "border-border-subtle dark:border-border-subtle-dark bg-surface-subtle dark:bg-surface-subtle-dark"
+              : "border-border-strong dark:border-border-strong-dark bg-white dark:bg-card-dark active:opacity-70"
           }`}
         >
           <Text
-            className={totalCount === 0 ? "text-icon-dim" : "text-ink"}
+            className={
+              totalCount === 0
+                ? "text-icon-dim dark:text-icon-dim-dark"
+                : "text-ink dark:text-ink-dark"
+            }
             style={{ fontFamily: "JetBrainsMono_500Medium", fontSize: 22 }}
           >
             −
@@ -114,10 +118,10 @@ export default function FeedingBespoke({ onAfterAdd }) {
           accessibilityRole="button"
           accessibilityLabel="Adicionar refeição"
           onPress={handleAdd}
-          className="flex-1 items-center rounded-2xl border border-border-strong bg-white py-4 active:opacity-70"
+          className="flex-1 items-center rounded-2xl border border-border-strong dark:border-border-strong-dark bg-white dark:bg-card-dark py-4 active:opacity-70"
         >
           <Text
-            className="text-ink"
+            className="text-ink dark:text-ink-dark"
             style={{ fontFamily: "JetBrainsMono_500Medium", fontSize: 22 }}
           >
             +
@@ -129,7 +133,7 @@ export default function FeedingBespoke({ onAfterAdd }) {
       {feedingToday.length > 0 && (
         <View>
           <Text
-            className="mb-2.5 text-xs uppercase tracking-wider text-label"
+            className="mb-2.5 text-xs uppercase tracking-wider text-label dark:text-label-dark"
             style={{ fontFamily: "JetBrainsMono_500Medium" }}
           >
             Registros de hoje
@@ -143,13 +147,13 @@ export default function FeedingBespoke({ onAfterAdd }) {
                 return (
                   <View key={r.id} className="flex-row justify-between">
                     <Text
-                      className="text-xs text-body-secondary"
+                      className="text-xs text-body-secondary dark:text-body-secondary-dark"
                       style={{ fontFamily: "Inter_400Regular" }}
                     >
                       {time}
                     </Text>
                     <Text
-                      className="text-xs text-ink"
+                      className="text-xs text-ink dark:text-ink-dark"
                       style={{ fontFamily: "JetBrainsMono_400Regular" }}
                     >
                       {mealLabel(hour)}
@@ -162,9 +166,9 @@ export default function FeedingBespoke({ onAfterAdd }) {
       )}
 
       {/* Info card sereno */}
-      <View className="rounded-2xl bg-tint-blue px-4 py-3">
+      <View className="rounded-2xl bg-tint-blue dark:bg-tint-blue-dark px-4 py-3">
         <Text
-          className="text-sm text-primary"
+          className="text-sm text-primary dark:text-primary-dark"
           style={{ fontFamily: "Inter_400Regular" }}
         >
           3–4 no dia costuma ser um bom ritmo. Sem pressa.
@@ -176,10 +180,10 @@ export default function FeedingBespoke({ onAfterAdd }) {
         accessibilityRole="button"
         accessibilityLabel="Concluir e voltar"
         onPress={() => router.back()}
-        className="mt-1 items-center rounded-2xl bg-primary py-4 active:opacity-70"
+        className="mt-1 items-center rounded-2xl bg-primary dark:bg-primary-dark py-4 active:opacity-70"
       >
         <Text
-          className="text-base text-white"
+          className="text-base text-white dark:text-on-primary-dark"
           style={{ fontFamily: "Inter_600SemiBold" }}
         >
           Concluir

--- a/components/metrics/SleepBespoke.jsx
+++ b/components/metrics/SleepBespoke.jsx
@@ -4,6 +4,7 @@ import { Pressable, Text, TextInput, View } from "react-native";
 
 import { add } from "@/infra/database";
 import getDate from "@/constants/getDate";
+import { useThemeTokens } from "@/constants/themeTokens";
 
 // UI bespoke da tela de sono (M5-B fatia 2b, mockup 2a·3 do Claude Design).
 // Substitui o card Score/OBS/Top/Bottom da MetricScreen quando o registry
@@ -111,15 +112,15 @@ export default function SleepBespoke({ onAfterAdd }) {
       />
 
       {/* duração calculada */}
-      <View className="flex-row items-center justify-between rounded-2xl bg-tint-blue px-5 py-4">
+      <View className="flex-row items-center justify-between rounded-2xl bg-tint-blue dark:bg-tint-blue-dark px-5 py-4">
         <Text
-          className="text-sm text-primary"
+          className="text-sm text-primary dark:text-primary-dark"
           style={{ fontFamily: "Inter_500Medium" }}
         >
           Duração
         </Text>
         <Text
-          className="text-primary"
+          className="text-primary dark:text-primary-dark"
           style={{
             fontFamily: "JetBrainsMono_500Medium",
             fontSize: 22,
@@ -132,7 +133,7 @@ export default function SleepBespoke({ onAfterAdd }) {
       {/* qualidade */}
       <View className="mt-2">
         <Text
-          className="mb-3 text-xs uppercase tracking-wider text-label"
+          className="mb-3 text-xs uppercase tracking-wider text-label dark:text-label-dark"
           style={{ fontFamily: "JetBrainsMono_500Medium" }}
         >
           Como se sente hoje
@@ -149,13 +150,15 @@ export default function SleepBespoke({ onAfterAdd }) {
                 onPress={() => setQuality(q.score)}
                 className={`flex-1 items-center rounded-xl py-3 ${
                   selected
-                    ? "border-2 border-primary bg-tint-blue"
-                    : "border border-border-strong bg-white"
+                    ? "border-2 border-primary dark:border-primary-dark bg-tint-blue dark:bg-tint-blue-dark"
+                    : "border border-border-strong dark:border-border-strong-dark bg-white dark:bg-card-dark"
                 }`}
               >
                 <Text
                   className={`text-xs ${
-                    selected ? "text-primary" : "text-body-secondary"
+                    selected
+                      ? "text-primary dark:text-primary-dark"
+                      : "text-body-secondary dark:text-body-secondary-dark"
                   }`}
                   style={{
                     fontFamily: selected
@@ -179,11 +182,13 @@ export default function SleepBespoke({ onAfterAdd }) {
         disabled={!canSave}
         onPress={handleSave}
         className={`mt-2 items-center rounded-2xl py-4 ${
-          canSave ? "bg-primary active:opacity-70" : "bg-border-strong"
+          canSave
+            ? "bg-primary dark:bg-primary-dark active:opacity-70"
+            : "bg-border-strong dark:bg-border-strong-dark"
         }`}
       >
         <Text
-          className="text-base text-white"
+          className="text-base text-white dark:text-on-primary-dark"
           style={{ fontFamily: "Inter_600SemiBold" }}
         >
           Registrar
@@ -203,11 +208,12 @@ export default function SleepBespoke({ onAfterAdd }) {
  * }} props
  */
 function TimeRow({ label, value, onChange, dayLabel, placeholder }) {
+  const t = useThemeTokens();
   return (
-    <View className="flex-row items-center justify-between rounded-2xl border border-border-subtle bg-white px-5 py-4">
+    <View className="flex-row items-center justify-between rounded-2xl border border-border-subtle dark:border-border-subtle-dark bg-white dark:bg-card-dark px-5 py-4">
       <View className="gap-0.5">
         <Text
-          className="text-xs uppercase tracking-wider text-label"
+          className="text-xs uppercase tracking-wider text-label dark:text-label-dark"
           style={{ fontFamily: "JetBrainsMono_500Medium" }}
         >
           {label}
@@ -216,21 +222,21 @@ function TimeRow({ label, value, onChange, dayLabel, placeholder }) {
           value={value}
           onChangeText={onChange}
           placeholder={placeholder}
-          placeholderTextColor="#9CA3AF"
+          placeholderTextColor={t.iconDim}
           keyboardType="numbers-and-punctuation"
           maxLength={5}
           accessibilityLabel={`Horário — ${label}`}
           style={{
             fontFamily: "JetBrainsMono_500Medium",
             fontSize: 24,
-            color: "#0F1419",
+            color: t.ink,
             padding: 0,
             minWidth: 80,
           }}
         />
       </View>
       <Text
-        className="text-xs text-body-secondary"
+        className="text-xs text-body-secondary dark:text-body-secondary-dark"
         style={{ fontFamily: "Inter_400Regular" }}
       >
         {dayLabel}

--- a/components/metrics/StudyBespoke.jsx
+++ b/components/metrics/StudyBespoke.jsx
@@ -6,6 +6,7 @@ import Svg, { Path } from "react-native-svg";
 import { add } from "@/infra/database";
 import getDate from "@/constants/getDate";
 import { hhmmToMinutes } from "@/constants/duration";
+import { useThemeTokens } from "@/constants/themeTokens";
 
 // UI bespoke da tela de estudo (M5-B fatia 2c, mockup 2a·6).
 // Toggle "Feito" full-width com check → duração HH:MM (default "00:00") →
@@ -32,6 +33,7 @@ function parseHHMM(s) {
  * @param {{ onAfterAdd?: () => void }} props
  */
 export default function StudyBespoke({ onAfterAdd }) {
+  const t = useThemeTokens();
   const [studied, setStudied] = useState(true);
   const [duration, setDuration] = useState("");
   const [focus, setFocus] = useState(/** @type {string|null} */ (null));
@@ -64,15 +66,15 @@ export default function StudyBespoke({ onAfterAdd }) {
         onPress={() => setStudied((v) => !v)}
         className={`flex-row items-center justify-center gap-2.5 rounded-2xl py-4 ${
           studied
-            ? "border-2 border-primary bg-tint-blue"
-            : "border border-border-strong bg-white"
+            ? "border-2 border-primary dark:border-primary-dark bg-tint-blue dark:bg-tint-blue-dark"
+            : "border border-border-strong dark:border-border-strong-dark bg-white dark:bg-card-dark"
         }`}
       >
         {studied && (
           <Svg width={18} height={18} viewBox="0 0 24 24" fill="none">
             <Path
               d="M20 6L9 17l-5-5"
-              stroke="#2E5A88"
+              stroke={t.primary}
               strokeWidth={2.4}
               strokeLinecap="round"
               strokeLinejoin="round"
@@ -80,7 +82,11 @@ export default function StudyBespoke({ onAfterAdd }) {
           </Svg>
         )}
         <Text
-          className={studied ? "text-primary" : "text-body-secondary"}
+          className={
+            studied
+              ? "text-primary dark:text-primary-dark"
+              : "text-body-secondary dark:text-body-secondary-dark"
+          }
           style={{
             fontFamily: studied ? "Inter_600SemiBold" : "Inter_500Medium",
             fontSize: 15,
@@ -92,10 +98,10 @@ export default function StudyBespoke({ onAfterAdd }) {
 
       {/* Duração */}
       <View>
-        <View className="flex-row items-center justify-between rounded-2xl border border-border-subtle bg-white px-5 py-4">
+        <View className="flex-row items-center justify-between rounded-2xl border border-border-subtle dark:border-border-subtle-dark bg-white dark:bg-card-dark px-5 py-4">
           <View className="gap-0.5">
             <Text
-              className="text-xs uppercase tracking-wider text-label"
+              className="text-xs uppercase tracking-wider text-label dark:text-label-dark"
               style={{ fontFamily: "JetBrainsMono_500Medium" }}
             >
               duração
@@ -104,14 +110,14 @@ export default function StudyBespoke({ onAfterAdd }) {
               value={duration}
               onChangeText={setDuration}
               placeholder="00:45"
-              placeholderTextColor="#9CA3AF"
+              placeholderTextColor={t.iconDim}
               keyboardType="numbers-and-punctuation"
               maxLength={5}
               accessibilityLabel="Duração"
               style={{
                 fontFamily: "JetBrainsMono_500Medium",
                 fontSize: 24,
-                color: "#0F1419",
+                color: t.ink,
                 padding: 0,
                 minWidth: 80,
               }}
@@ -119,7 +125,7 @@ export default function StudyBespoke({ onAfterAdd }) {
           </View>
         </View>
         <Text
-          className="ml-1 mt-2 text-xs text-label"
+          className="ml-1 mt-2 text-xs text-label dark:text-label-dark"
           style={{ fontFamily: "JetBrainsMono_400Regular" }}
         >
           quanto puder é suficiente
@@ -129,7 +135,7 @@ export default function StudyBespoke({ onAfterAdd }) {
       {/* Foco (opcional) */}
       <View className="mt-2">
         <Text
-          className="mb-3 text-xs uppercase tracking-wider text-label"
+          className="mb-3 text-xs uppercase tracking-wider text-label dark:text-label-dark"
           style={{ fontFamily: "JetBrainsMono_500Medium" }}
         >
           No que estudou
@@ -146,12 +152,12 @@ export default function StudyBespoke({ onAfterAdd }) {
                 onPress={() => setFocus(selected ? null : f)}
                 className={`rounded-full px-3.5 py-2 ${
                   selected
-                    ? "border-2 border-primary bg-tint-blue"
-                    : "border border-border-strong bg-white"
+                    ? "border-2 border-primary dark:border-primary-dark bg-tint-blue dark:bg-tint-blue-dark"
+                    : "border border-border-strong dark:border-border-strong-dark bg-white dark:bg-card-dark"
                 }`}
               >
                 <Text
-                  className={`text-xs ${selected ? "text-primary" : "text-body-secondary"}`}
+                  className={`text-xs ${selected ? "text-primary dark:text-primary-dark" : "text-body-secondary dark:text-body-secondary-dark"}`}
                   style={{
                     fontFamily: selected
                       ? "Inter_600SemiBold"
@@ -167,9 +173,9 @@ export default function StudyBespoke({ onAfterAdd }) {
       </View>
 
       {/* Info card */}
-      <View className="rounded-2xl bg-surface-subtle px-4 py-3">
+      <View className="rounded-2xl bg-surface-subtle dark:bg-surface-subtle-dark px-4 py-3">
         <Text
-          className="text-sm text-body-secondary"
+          className="text-sm text-body-secondary dark:text-body-secondary-dark"
           style={{ fontFamily: "Inter_400Regular" }}
         >
           15 minutos já contam. Quando puder.
@@ -184,11 +190,13 @@ export default function StudyBespoke({ onAfterAdd }) {
         disabled={!canSave}
         onPress={handleSave}
         className={`mt-2 items-center rounded-2xl py-4 ${
-          canSave ? "bg-primary active:opacity-70" : "bg-border-strong"
+          canSave
+            ? "bg-primary dark:bg-primary-dark active:opacity-70"
+            : "bg-border-strong dark:bg-border-strong-dark"
         }`}
       >
         <Text
-          className="text-base text-white"
+          className="text-base text-white dark:text-on-primary-dark"
           style={{ fontFamily: "Inter_600SemiBold" }}
         >
           Registrar

--- a/components/metrics/WaterQuickAdd.jsx
+++ b/components/metrics/WaterQuickAdd.jsx
@@ -68,7 +68,7 @@ export default function WaterQuickAdd({ onAfterAdd }) {
       <View className="items-center gap-3">
         <View className="flex-row items-baseline gap-1.5">
           <Text
-            className="text-primary"
+            className="text-primary dark:text-primary-dark"
             style={{
               fontFamily: "JetBrainsMono_500Medium",
               fontSize: 72,
@@ -81,21 +81,21 @@ export default function WaterQuickAdd({ onAfterAdd }) {
             })}
           </Text>
           <Text
-            className="text-label"
+            className="text-label dark:text-label-dark"
             style={{ fontFamily: "JetBrainsMono_500Medium", fontSize: 20 }}
           >
             L
           </Text>
         </View>
         <Text
-          className="text-xs text-label"
+          className="text-xs text-label dark:text-label-dark"
           style={{ fontFamily: "Inter_400Regular" }}
         >
           de {GOAL_ML / 1000} L hoje
         </Text>
         <View className="h-1.5 w-full overflow-hidden rounded-full bg-border-subtle">
           <View
-            className="h-full rounded-full bg-primary"
+            className="h-full rounded-full bg-primary dark:bg-primary-dark"
             style={{ width: `${pct}%` }}
           />
         </View>
@@ -104,7 +104,7 @@ export default function WaterQuickAdd({ onAfterAdd }) {
       {/* Quick add chips */}
       <View>
         <Text
-          className="mb-3 text-xs uppercase tracking-wider text-label"
+          className="mb-3 text-xs uppercase tracking-wider text-label dark:text-label-dark"
           style={{ fontFamily: "JetBrainsMono_500Medium" }}
         >
           Adicionar
@@ -116,16 +116,16 @@ export default function WaterQuickAdd({ onAfterAdd }) {
                 accessibilityRole="button"
                 accessibilityLabel={`Adicionar ${qa.label}`}
                 onPress={() => handleAdd(qa.amount)}
-                className="gap-0.5 rounded-2xl border border-border-strong bg-white p-4 active:opacity-70"
+                className="gap-0.5 rounded-2xl border border-border-strong dark:border-border-strong-dark bg-white dark:bg-card-dark p-4 active:opacity-70"
               >
                 <Text
-                  className="text-base text-ink"
+                  className="text-base text-ink dark:text-ink-dark"
                   style={{ fontFamily: "Inter_500Medium" }}
                 >
                   + {qa.label}
                 </Text>
                 <Text
-                  className="text-xs text-label"
+                  className="text-xs text-label dark:text-label-dark"
                   style={{ fontFamily: "Inter_400Regular" }}
                 >
                   {qa.hint}
@@ -140,7 +140,7 @@ export default function WaterQuickAdd({ onAfterAdd }) {
       {waterToday.length > 0 && (
         <View>
           <Text
-            className="mb-2.5 text-xs uppercase tracking-wider text-label"
+            className="mb-2.5 text-xs uppercase tracking-wider text-label dark:text-label-dark"
             style={{ fontFamily: "JetBrainsMono_500Medium" }}
           >
             Registros de hoje
@@ -149,13 +149,13 @@ export default function WaterQuickAdd({ onAfterAdd }) {
             {waterToday.map((r) => (
               <View key={r.id} className="flex-row justify-between">
                 <Text
-                  className="text-xs text-body-secondary"
+                  className="text-xs text-body-secondary dark:text-body-secondary-dark"
                   style={{ fontFamily: "Inter_400Regular" }}
                 >
                   {formatTime(r.createdAt)}
                 </Text>
                 <Text
-                  className="text-xs text-ink"
+                  className="text-xs text-ink dark:text-ink-dark"
                   style={{ fontFamily: "JetBrainsMono_400Regular" }}
                 >
                   {r.quantity} ml

--- a/constants/themeTokens.js
+++ b/constants/themeTokens.js
@@ -1,0 +1,56 @@
+// @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
+//
+// Helper pra tokens de cor que não dão pra expressar como className Tailwind:
+// hex passado como prop de SVG (`stroke`, `fill`, MetricIcon `color`),
+// `placeholderTextColor` de TextInput, `backgroundColor` inline. Espelha os
+// tokens do design v2 (light) + do Turno 3 (dark). Usa `useColorScheme` do
+// NativeWind pra respeitar o toggle manual + o `prefers-color-scheme` do OS.
+//
+// Para classes utilitárias (`bg-*`, `text-*`, `border-*`), continue usando
+// `className="... dark:..."` — este helper existe SÓ pros callsites que não
+// aceitam className.
+
+import { useColorScheme } from "nativewind";
+
+const LIGHT = {
+  primary: "#2E5A88",
+  onPrimary: "#F8F9FA",
+  accentToday: "#4CAF50",
+  ink: "#0F1419",
+  label: "#6B7280",
+  bodySecondary: "#4B5563",
+  iconDim: "#9CA3AF",
+  bgApp: "#F8F9FA",
+  bgCard: "#FFFFFF",
+  surfaceSubtle: "#F3F4F6",
+  borderSubtle: "#E5E7EB",
+  borderStrong: "#D1D5DB",
+  tintBlue: "#EAF3FB",
+  tintRed: "#FEF3F2",
+  tintGreen: "#F0FDF4",
+  tintYellow: "#FFFBEB",
+};
+
+const DARK = {
+  primary: "#5B8FC7",
+  onPrimary: "#0F1419",
+  accentToday: "#5FC463",
+  ink: "#ECEEF1",
+  label: "#7C8592",
+  bodySecondary: "#A8AFB8",
+  iconDim: "#7C8592",
+  bgApp: "#12161B",
+  bgCard: "#1A1F26",
+  surfaceSubtle: "#232932",
+  borderSubtle: "#2A303A",
+  borderStrong: "#3A4250",
+  tintBlue: "#1E2A38",
+  tintRed: "#332020",
+  tintGreen: "#1C2A22",
+  tintYellow: "#2F2A1A",
+};
+
+export function useThemeTokens() {
+  const { colorScheme } = useColorScheme();
+  return colorScheme === "dark" ? DARK : LIGHT;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -24,6 +24,32 @@ module.exports = {
         "surface-subtle": "#F3F4F6",
         "icon-dim": "#9CA3AF",
         "tint-blue": "#EAF3FB",
+        "tint-red": "#FEF3F2",
+        "tint-green": "#F0FDF4",
+        "tint-yellow": "#FFFBEB",
+        // Contrapartes dark do design v2 (M5-B Turno 3). Regras:
+        // near-black quente (#12161B), NUNCA preto puro. Elevação por
+        // luminância, não sombra: card = app + 4L, subtle = app + 8L.
+        // Brand desloca +25L (2E5A88 → 5B8FC7), texto sobre brand vira ink.
+        // Verde "hoje" +6L (4CAF50 → 5FC463). Tints são versões dessaturadas
+        // do próprio hue sobre bg. Bordas obrigatórias em todo card no dark
+        // (ausência de borda faz card desaparecer).
+        "app-dark": "#12161B",
+        "card-dark": "#1A1F26",
+        "ink-dark": "#ECEEF1",
+        "label-dark": "#7C8592",
+        "body-secondary-dark": "#A8AFB8",
+        "border-subtle-dark": "#2A303A",
+        "border-strong-dark": "#3A4250",
+        "surface-subtle-dark": "#232932",
+        "icon-dim-dark": "#7C8592",
+        "tint-blue-dark": "#1E2A38",
+        "tint-red-dark": "#332020",
+        "tint-green-dark": "#1C2A22",
+        "tint-yellow-dark": "#2F2A1A",
+        "primary-dark": "#5B8FC7",
+        "on-primary-dark": "#0F1419",
+        "secondary-dark": "#5FC463",
       },
       // Escala de tipografia canônica do M5 — px direto (não rem) pra não
       // depender de font-size base do html, que no bundle web tinha um truque


### PR DESCRIPTION
Aplica as regras do Turno 3 do Claude Design (mockup 3a·1) — mapeamento token-a-token light → dark para todas as telas do design v2.

## Princípios canônicos (do design)

1. **Nunca preto puro.** App bg = `#12161B` (near-black quente). OLED-black gera vibration em texto de baixo peso.
2. **Elevação por luminância**, não por sombra. Card = bg.app + ~4L. Modal = bg.app + ~8L.
3. **Brand desloca +25L**: `#2E5A88` → `#5B8FC7`. Texto sobre brand vira `#0F1419` (near-black).
4. **Tints de métrica** viram versões dessaturadas do próprio hue sobre a bg (~12% opacity equivalente).
5. **Bordas visíveis obrigatórias**. No dark, ausência de borda faz card sumir.
6. **Verde "hoje" mais quente**: `#4CAF50` → `#5FC463`. Mesmo hue, +6L pra sobreviver contra o near-black.
7. **Trigger**: `prefers-color-scheme: dark` do OS + override manual do toggle em Ajustes.

## O que entra

### `tailwind.config.js`
14 tokens novos com sufixo `-dark`:
- Surfaces: `app-dark`, `card-dark`, `surface-subtle-dark`
- Text: `ink-dark`, `label-dark`, `body-secondary-dark`, `icon-dim-dark`
- Borders: `border-subtle-dark`, `border-strong-dark`
- Brand: `primary-dark`, `on-primary-dark`, `secondary-dark`
- Metric tints: `tint-blue-dark`, `tint-red-dark`, `tint-green-dark`, `tint-yellow-dark`

Também adiciona os tints faltantes do light (`tint-red`, `tint-green`, `tint-yellow`) pra completar o par.

### `constants/themeTokens.js` (novo)
Helper `useThemeTokens()` retorna o palette do `colorScheme` atual (nativewind `useColorScheme`). Existe **só** pros callsites que não aceitam className:
- Hex passado como prop de SVG (`stroke`, `fill`, MetricIcon `color`, Icon1c `strokeColor`/`dotColor`)
- Inline `style={{ backgroundColor, color }}`
- `placeholderTextColor` de TextInput

Pra classes utilitárias (`bg-*`/`text-*`/`border-*`) continua-se usando `className="... dark:..."`.

### 13 componentes v2 atualizados
Todo Tailwind class ganhou variant dark (`bg-white dark:bg-card-dark`, `text-ink dark:text-ink-dark`, `border-border-subtle dark:border-border-subtle-dark`, etc). SVG/inline hex passaram a consumir `useThemeTokens`:
- Home, Semana, Ajustes
- MetricCard, MetricRegisterHeader, WeekStrip, RetomadaState, UpdateBanner
- WaterQuickAdd, SleepBespoke, ExerciseBespoke, FeedingBespoke, StudyBespoke

Botão "Registrar" em bg brand mantém `text-white dark:text-on-primary-dark` (near-black em cima do brand deslocado do dark é o padrão do token spec).

## Fora

- **Componentes M5 baseline** (não-v2): mantêm o dark antigo (`dark:bg-dark-background` = `#333333`). Trocar quebraria consistência de telas que ainda não migraram (Histórico, Feedback, Roadmap, Admin, Login, Callback). Follow-up: migrar essas telas pro design v2 numa próxima onda.
- **3ª opção "Sistema" no seletor de tema** (Ajustes): hoje só light/dark via Switch — o default (antes de togglar) já segue o OS.
- **Constants/Colors.js**: intocado. `dark.background` fica `#333333` pra não afetar telas M5.

## Test plan

- [x] `tsc --noEmit` limpo.
- [x] `eslint` limpo.
- [x] `prettier --check` limpo.
- [x] `npm test` 63/63.
- [ ] Preview: Ajustes → toggle "Tema escuro" → conferir que Home, Semana, cada tela de registro, Retomada e banners consumem os tokens dark (near-black bg, brand mais claro, tints dessaturados, bordas visíveis).

Refs #242 (fatia 5), #240 (fatia 3), #241 (fatia 4).