### PR TITLE
fix(splash): install expo-splash-screen plugin (bump 1.2.0)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,33 +54,47 @@ jobs:
             --title "Back on Track ${{ inputs.tag }}" \
             --notes "${{ inputs.notes }}"
 
-      # Aponta a EAS_INSTALL_URL pro build recém-criado. Não commita na main
-      # (ruleset exige PR) nem abre o PR via API (PR do GITHUB_TOKEN não dispara
-      # o linting.yaml `on: pull_request`, travando os checks). Empurra a branch
-      # e deixa um link pro humano abrir o PR — aí o CI roda normal. Issue #92.
-      - name: Atualiza EAS_INSTALL_URL (branch + link de PR)
+      # Aponta EAS_INSTALL_URL (card "Obter o app") + latest-apk-version.json
+      # (banner NATIVE_OUTDATED do UpdateBanner) pro build recém-criado. Não
+      # commita na main (ruleset exige PR) nem abre PR via API (PR do
+      # GITHUB_TOKEN não dispara `on: pull_request`, travando os checks).
+      # Empurra a branch e deixa link pro humano abrir o PR — aí o CI roda.
+      # Ver [[repo-ci-constraints]].
+      - name: Atualiza EAS_INSTALL_URL + latest-apk-version.json (branch + link de PR)
         env:
           BUILD_ID: ${{ steps.build.outputs.build_id }}
           TAG: ${{ inputs.tag }}
         run: |
           EAS_URL="https://expo.dev/accounts/matheushnascimento/projects/backOnTrack/builds/${BUILD_ID}"
+          APP_VERSION=$(jq -r '.expo.version' app.json)
+
+          # constants/distribution.js — card "Obter o app"
           sed -i -E "s#(projects/backOnTrack/builds/)[a-f0-9-]+#\1${BUILD_ID}#" constants/distribution.js
-          if git diff --quiet constants/distribution.js; then
-            echo "EAS_INSTALL_URL já aponta pro build atual — nada a fazer." >> "$GITHUB_STEP_SUMMARY"
+
+          # assets/latest-apk-version.json — banner NATIVE_OUTDATED (dispara
+          # nos testers em versão anterior). Reescreve o arquivo inteiro pra
+          # garantir schema estável (jq -n em vez de sed).
+          jq -n --arg v "$APP_VERSION" --arg u "$EAS_URL" \
+            '{version: $v, installUrl: $u}' \
+            > assets/latest-apk-version.json
+
+          if git diff --quiet constants/distribution.js assets/latest-apk-version.json; then
+            echo "Distribuição já aponta pro build atual — nada a fazer." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
-          BRANCH="chore/eas-install-url-${TAG}"
+
+          BRANCH="chore/release-${TAG}"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
-          git add constants/distribution.js
-          git commit -m "chore(install): aponta a instalação pro build ${TAG}"
+          git add constants/distribution.js assets/latest-apk-version.json
+          git commit -m "chore(release): distribute build ${TAG} (${APP_VERSION})"
           git push -u origin "$BRANCH"
           PR_URL="https://github.com/matheushnascimento/backOnTrack/compare/main...${BRANCH}?expand=1"
           {
-            echo "## EAS_INSTALL_URL do novo build"
+            echo "## Distribuição do build ${TAG} (v${APP_VERSION})"
             echo ""
-            echo "Build \`${TAG}\` → ${EAS_URL}"
+            echo "Build EAS: ${EAS_URL}"
             echo ""
-            echo "Branch \`${BRANCH}\` empurrada. **[Abrir o PR](${PR_URL})** e mergear pra atualizar o card \"Obter o app\"."
+            echo "Branch \`${BRANCH}\` empurrada com update pro card \"Obter o app\" **e** pro banner NATIVE_OUTDATED. **[Abrir o PR](${PR_URL})** e mergear."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "name": "Back on Track",
     "slug": "backOnTrack",
     "scheme": "backontrack",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",
@@ -11,14 +11,8 @@
     "runtimeVersion": {
       "policy": "appVersion"
     },
-
     "updates": {
       "url": "https://u.expo.dev/d0a4dfc2-3743-440f-b129-b76e31351707"
-    },
-    "splash": {
-      "image": "./assets/splash-icon.png",
-      "resizeMode": "contain",
-      "backgroundColor": "#F8F9FA"
     },
     "ios": {
       "supportsTablet": true,
@@ -30,14 +24,30 @@
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#F8F9FA"
       },
-      "edgeToEdgeEnabled": true,
       "package": "com.matheushnascimento.backOnTrack"
     },
     "web": {
       "bundler": "metro",
       "favicon": "./assets/favicon.png"
     },
-    "plugins": ["expo-router", "expo-sqlite", "./plugins/withArm64Only.js"],
+    "plugins": [
+      "expo-router",
+      "expo-sqlite",
+      "./plugins/withArm64Only.js",
+      [
+        "expo-splash-screen",
+        {
+          "image": "./assets/splash-icon.png",
+          "imageWidth": 200,
+          "resizeMode": "contain",
+          "backgroundColor": "#F8F9FA",
+          "dark": {
+            "image": "./assets/splash-icon.png",
+            "backgroundColor": "#12161B"
+          }
+        }
+      ]
+    ],
     "extra": {
       "router": {},
       "eas": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "expo-dev-client": "~57.0.5",
         "expo-linking": "~57.0.1",
         "expo-router": "^57.0.2",
+        "expo-splash-screen": "~57.0.5",
         "expo-sqlite": "~57.0.0",
         "expo-status-bar": "~57.0.0",
         "expo-updates": "~57.0.6",
@@ -2273,15 +2274,15 @@
       }
     },
     "node_modules/@expo/config-plugins": {
-      "version": "57.0.2",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-57.0.2.tgz",
-      "integrity": "sha512-85wEk9NKzdT25+UWEaSgF7gp9uR/GmtvrvQtGqZmyhFgVRNL2H3GdJOL4/50vyZh4JK69Hl7fWKGtARTN3B8Ag==",
+      "version": "57.0.6",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-57.0.6.tgz",
+      "integrity": "sha512-7CmKrS5Rnu8aSZyNlxH2qzA7Ls1HEa4EQvEVOAkHDKPr1e4Cg/nz7I7dUl09QDTVjMvkKYDH4Th0DuAsgqASaw==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config-types": "^57.0.1",
-        "@expo/json-file": "~11.0.0",
-        "@expo/plist": "^0.8.0",
-        "@expo/require-utils": "^57.0.1",
+        "@expo/config-types": "^57.0.2",
+        "@expo/json-file": "~11.0.1",
+        "@expo/plist": "^0.8.1",
+        "@expo/require-utils": "^57.0.4",
         "@expo/sdk-runtime-versions": "^1.0.0",
         "chalk": "^4.1.2",
         "debug": "^4.3.5",
@@ -2381,9 +2382,9 @@
       }
     },
     "node_modules/@expo/config-types": {
-      "version": "57.0.1",
-      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-57.0.1.tgz",
-      "integrity": "sha512-fo7d/Ym28uwGzdTV2leEvpsb9t+7i8YHjy471m31+cmDt4BRd/l7e94JHyrXAq4SWOBVus16S0JLqm89SRCCdw==",
+      "version": "57.0.2",
+      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-57.0.2.tgz",
+      "integrity": "sha512-ewW08OonrcRIsRKIlFvvcmmafE5zemb1ocu3HkNwtVPyRtj2w42pZCAkMIROYpcVBaPnc3mDT9UZDzwXWC3i6g==",
       "license": "MIT"
     },
     "node_modules/@expo/config/node_modules/glob": {
@@ -2724,12 +2725,12 @@
       }
     },
     "node_modules/@expo/image-utils": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.11.1.tgz",
-      "integrity": "sha512-0JueH4vdgAZQmhlSYFvTQzt4b4NO5cnByDuApw7bMUIjhwLRnT46Ki3ritMrzJMQaO2lLK2flInZbsZbOuy8nw==",
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.11.4.tgz",
+      "integrity": "sha512-pn/4770DIEOcYZr484uazuwg20FX/qaDkeMRF6J+oxejynDmEmO8wLsCudaNShFE0BhyKGQTYrs2rsRhqrqESw==",
       "license": "MIT",
       "dependencies": {
-        "@expo/require-utils": "^57.0.1",
+        "@expo/require-utils": "^57.0.4",
         "@expo/spawn-async": "^1.8.0",
         "chalk": "^4.0.0",
         "getenv": "^2.0.0",
@@ -2818,9 +2819,9 @@
       }
     },
     "node_modules/@expo/json-file": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-11.0.0.tgz",
-      "integrity": "sha512-pHJCETqFL5x5BzNV6cEPwjwuECgGmnl0bNmfHIJ6LM1tlh2eVXi5HEdit3zby/JO/B8Otk5cgcqtJXgvvUat3A==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-11.0.1.tgz",
+      "integrity": "sha512-zxHWj4MKKMAL29ZQSY/Fssx4Thluk40JmuGNaeS078wy/NhlFhnVi+rHHunulE3xJAJ0CM73m8VK2+GkF9eRwQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.20.0",
@@ -3223,9 +3224,9 @@
       }
     },
     "node_modules/@expo/plist": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.8.0.tgz",
-      "integrity": "sha512-24JlUJI4PwHN4PLydlzFEzCdiqybfaV5t04QBkOg8em3AjvHKbMgBGlKreiuOoc0rNa3DZ21ZqL+xLGMBLQNKQ==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.8.1.tgz",
+      "integrity": "sha512-3gTReGIUm0oRaMClsAJYxBnVPCl6fVpsl8HS+DTVxDhW4GyVyxg9E/Znm3BvcHtUJ51RJJI14pC1wvrNilCRHw==",
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.8",
@@ -3252,9 +3253,9 @@
       }
     },
     "node_modules/@expo/require-utils": {
-      "version": "57.0.1",
-      "resolved": "https://registry.npmjs.org/@expo/require-utils/-/require-utils-57.0.1.tgz",
-      "integrity": "sha512-uXen5/4x7j60I5slShgZr5QEtJDBK8homFiNLDnDrNrxZhrRHXASo0H6JArs3/1PDzw1wahzhGWg2WKuYyZd0A==",
+      "version": "57.0.4",
+      "resolved": "https://registry.npmjs.org/@expo/require-utils/-/require-utils-57.0.4.tgz",
+      "integrity": "sha512-e7xbg/9BTQcsZE/oErafZXtI7kh5IgfasLJ97J5sFSzX2cA74pDvdlhW1KHVSaDkQyQv6h1LSLhsY7dEeOk7hw==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.20.0",
@@ -3262,7 +3263,7 @@
         "@babel/plugin-transform-modules-commonjs": "^7.24.8"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0 || ^5.0.0-0 || ^6.0.0"
+        "typescript": "^5.0.0 || ^5.0.0-0 || ^6.0.0 || ^7.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -11079,6 +11080,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.16.0"
+      }
+    },
+    "node_modules/expo-splash-screen": {
+      "version": "57.0.5",
+      "resolved": "https://registry.npmjs.org/expo-splash-screen/-/expo-splash-screen-57.0.5.tgz",
+      "integrity": "sha512-ZN0LDXlhHRNFjXTYZDojXk8IfaoUIu7qa3hhoBTXgyj1UB/iewGlH6+M3Nvhun2lY2d/+xhwqMhv0hIRoBo09Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config-plugins": "~57.0.6",
+        "@expo/image-utils": "^0.11.4",
+        "xml2js": "0.6.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-sqlite": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "expo-dev-client": "~57.0.5",
     "expo-linking": "~57.0.1",
     "expo-router": "^57.0.2",
+    "expo-splash-screen": "~57.0.5",
     "expo-sqlite": "~57.0.0",
     "expo-status-bar": "~57.0.0",
     "expo-updates": "~57.0.6",


### PR DESCRIPTION
Splash aparece esticado porque a config top-level `"splash": {...}` em `app.json` é **schema legado** — no SDK 51+ (rodamos SDK 57), o Expo espera o **plugin `expo-splash-screen`** registrado. Sem plugin, cai num splash default e o asset renderiza sem os controles de tamanho/posição corretos.

## Fix

- **Instala `expo-splash-screen`** via `npx expo install`.
- **Registra como plugin** em `app.json` com config completa:
  - `imageWidth: 200` — renderiza o ícone pequeno e centralizado (evita esticar mesmo que o asset seja 1024×1024).
  - `resizeMode: contain`
  - `backgroundColor: #F8F9FA` (light)
  - `dark.backgroundColor: #12161B` (near-black do design v2)
- **Remove** a config top-level `splash` (ignorada no schema atual).
- **Remove** `android.edgeToEdgeEnabled: true` — Android 16 tornou edge-to-edge obrigatório e o Expo emite warning se ainda estiver setado.

## Bump nativo → 1.1.1 → 1.2.0

Instalar dep nativa nova + adicionar plugin nativo = OTA não cobre (`runtimeVersion.policy: appVersion`). Regra registrada na memória (ver `dev-utilities-cycles.md`): bump `version` no mesmo PR OU cortar APK junto. Este PR bumpa; próxima release cortada distribui.

## Loop automatizado de distribuição

**`release.yaml`** ganhou uma segunda escrita: além de `constants/distribution.js` (card "Obter o app"), também atualiza `assets/latest-apk-version.json` (schema `{version, installUrl}`, consumido pelo banner NATIVE_OUTDATED do PR #244).

Fluxo pós-merge:
1. Cortar APK 1.2.0: `gh workflow run release.yaml -f tag=v0.1.0-beta.6 -f notes="splash + dark mode"`.
2. Workflow builda, publica release, e empurra branch `chore/release-v0.1.0-beta.6` com **dois** arquivos atualizados.
3. Humano abre + merga esse PR.
4. Push na main dispara `publish-update.yaml` → OTA em runtime 1.2.0 (novo).
5. Testers em 1.1.1: banner NATIVE_OUTDATED aparece no launch seguinte com tap → página de instalação do EAS 1.2.0.

Sem esse fechamento, cada bump nativo exigia PR manual pra atualizar o JSON — errar isso deixa os testers no escuro.

## Test plan

- [x] `tsc --noEmit` limpo.
- [x] `eslint` limpo.
- [x] `prettier --check` limpo.
- [x] `npm test` 63/63.
- [ ] Após merge: cortar APK 1.2.0 pelo release.yaml. Instalar no device. Splash deve aparecer com o Icon 1c pequeno centralizado sobre `#F8F9FA` (ou `#12161B` se OS em dark).

Refs #229 (identidade 1c), #218 (regra do bump nativo), #244 (banner NATIVE_OUTDATED).