### PR TITLE
feat(notify-testers): warmer, less technical WhatsApp template

### DIFF
--- a/scripts/notify-testers.mjs
+++ b/scripts/notify-testers.mjs
@@ -71,20 +71,32 @@ function readLatestRelease() {
 }
 
 /**
+ * Monta a mensagem WhatsApp de aviso de nova APK. Tom comercial e enxuto: o
+ * tester decide em segundos se instala agora ou depois — não é changelog de
+ * dev. As **notas da release** (`-f notes=` no workflow) viram o "o que
+ * mudou" — escreva user-facing (features/fixes visíveis), não dev-facing
+ * (SDK bumps, refactors internos). A versão fica no rodapé pra referência,
+ * sem competir com a headline.
+ *
+ * Formatação WhatsApp: `*bold*` e `_italic_` renderizam no cliente.
+ *
  * @param {{ tagName: string, body?: string | null }} release
  * @param {string} homepage
  * @returns {string}
  */
 function buildMessage({ tagName, body }, homepage) {
   const novidades = (body ?? "").trim();
-  const linhas = [`🚀 Back on Track — ${tagName}`, ""];
+  const linhas = ["✨ *Back on Track* atualizou", ""];
   if (novidades) linhas.push(novidades, "");
   linhas.push(
-    "📲 Instalar / atualizar:",
+    "📲 *Baixar aqui:*",
     homepage,
     "",
-    "ℹ️ Já tem o app? Melhorias pequenas chegam sozinhas ao abrir. Baixe de " +
-      "novo só quando eu avisar que é versão nova.",
+    'Toque em "Obter o app" → botão de instalação. Seus registros ficam preservados.',
+    "",
+    `_Versão ${tagName}_`,
+    "",
+    "Tropeço na hora de instalar? Manda print aqui ou usa a tela *Feedback* do app. Obrigado por testar 🙏",
   );
   return linhas.join("\n");
 }


### PR DESCRIPTION
Reescreve o template do `buildMessage()` no `scripts/notify-testers.mjs` — de release de dev pra aviso comercial. Objetivo: o tester decidir em segundos se instala agora ou depois, não ter que decifrar changelog.

## Antes vs agora

**Antes:**
```
🚀 Back on Track — v1.1.1

<notas da release>

📲 Instalar / atualizar:
https://backontrack.mhdn.com.br

ℹ️ Já tem o app? Melhorias pequenas chegam sozinhas ao abrir. Baixe
de novo só quando eu avisar que é versão nova.
```

**Agora:**
```
✨ *Back on Track* atualizou

<notas da release>

📲 *Baixar aqui:*
https://backontrack.mhdn.com.br

Toque em "Obter o app" → botão de instalação. Seus registros ficam preservados.

_Versão v1.1.1_

Tropeço na hora de instalar? Manda print aqui ou usa a tela *Feedback* do app. Obrigado por testar 🙏
```

## O que muda

- **Headline sem número de versão** (fica no rodapé como referência italic). "✨ atualizou" lê como anúncio, não como release note.
- **Formatação WhatsApp** (`*bold*` / `_italic_`) — cliente renderiza; ajuda a hierarquia visual.
- **Reforço "seus registros ficam preservados"** — reduz hesitação de quem tem medo de perder dado ao atualizar (relato comum).
- **Removida a explicação de OTA** — hoje o banner NATIVE_OUTDATED do #244 cobre isso no app; a mensagem foca só no ato de instalar.
- **Comentário no JSDoc reforça**: escrever `-f notes=` user-facing (features/fixes visíveis), não dev-facing (SDK bumps, refactors internos). Evita "expo-splash-screen plugin" cair na msg.

## Fora

- **Banners do app** (UpdateBanner): não tocados. Ficam pra outra rodada se você quiser (perguntei via AskUser; escolheu só o template WhatsApp).
- **convite.txt**: continua sendo escrito à mão por release; a linguagem lá já é warm.

## Preview real

Rodei `node scripts/notify-testers.mjs` (sem `--send`) contra a release atual (v1.1.1) e o resultado tá no commit body. Notas continuam sendo passadas do GitHub; o template só reveste.

## Test plan

- [x] `tsc --noEmit` limpo.
- [x] `eslint` limpo.
- [x] `prettier --check` limpo.
- [x] `npm test` 63/63.
- [x] Preview local rodou e ficou legível.

Refs #111 (script original), #244 (banner NATIVE_OUTDATED que assumiu a função de aviso de OTA).