### PR TITLE
chore(release): distribute build v1.2.0

### DIFF
--- a/assets/latest-apk-version.json
+++ b/assets/latest-apk-version.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.1.1",
-  "installUrl": "https://expo.dev/accounts/matheushnascimento/projects/backOnTrack/builds/31173d89-2af7-4a7e-8a09-f4f0b84d574b"
+  "version": "1.2.0",
+  "installUrl": "https://expo.dev/accounts/matheushnascimento/projects/backOnTrack/builds/90e3594b-1a75-4ef5-9c85-148aa0243a6e"
 }

--- a/constants/distribution.js
+++ b/constants/distribution.js
@@ -12,7 +12,7 @@
 // Internet, mas trava no Chrome). Ciclo 3, #74.
 
 export const EAS_INSTALL_URL =
-  "https://expo.dev/accounts/matheushnascimento/projects/backOnTrack/builds/31173d89-2af7-4a7e-8a09-f4f0b84d574b";
+  "https://expo.dev/accounts/matheushnascimento/projects/backOnTrack/builds/90e3594b-1a75-4ef5-9c85-148aa0243a6e";
 
 export const APK_URL =
   "https://github.com/matheushnascimento/backOnTrack/releases/latest/download/backOnTrack.apk";


### PR DESCRIPTION
Distribui o build APK 1.2.0 cortado pelo release.yaml:

- `constants/distribution.js` — card "Obter o app" aponta pro novo `builds/<id>`.
- `assets/latest-apk-version.json` — dispara banner NATIVE_OUTDATED nos testers em 1.1.1 (fetch de raw.githubusercontent.com no launch).

Após mergear: Vercel redeploya web com o link novo; próximo launch dos testers em APK 1.1.1 vê banner "Nova versão do app disponível" → tap abre página EAS de instalação da 1.2.0. Vamos então rodar `notify-testers` pra completar o aviso via WhatsApp.

Refs #246 (splash + bump 1.2.0), #244 (banner NATIVE_OUTDATED).