### PR TITLE
fix(retomada): text truncation in shortcut labels and Depois link

### DIFF
--- a/components/RetomadaState.jsx
+++ b/components/RetomadaState.jsx
@@ -94,7 +94,10 @@ export default function RetomadaState({ daysSinceLast, onDismiss }) {
         </View>
       </View>
 
-      {/* Link "Depois" */}
+      {/* Link "Depois" — sem `underline` porque no Android + custom font o
+          decoration bugava o advance width e clipava a última letra
+          ("Depoi"). Cor label + peso regular já hierarquiza como link
+          secundário; visualmente basta. */}
       <View className="items-center">
         <Pressable
           accessibilityRole="button"
@@ -103,7 +106,7 @@ export default function RetomadaState({ daysSinceLast, onDismiss }) {
           className="p-4 active:opacity-70"
         >
           <Text
-            className="text-sm text-label dark:text-label-dark underline"
+            className="text-sm text-label dark:text-label-dark"
             style={{ fontFamily: "Inter_400Regular" }}
           >
             Depois
@@ -136,8 +139,12 @@ function ShortcutButton({ metric, label, dim, onPress }) {
           …
         </Text>
       )}
+      {/* flex-1 força o Text a preencher o espaço restante do Pressable
+          (flex-row) em vez de depender da intrinsic width medida do
+          NativeText — Android + Inter custom estava truncando labels no
+          meio ("Um copo" em vez de "Um copo d'água"). */}
       <Text
-        className={`text-sm ${dim ? "text-body-secondary dark:text-body-secondary-dark" : "text-ink dark:text-ink-dark"}`}
+        className={`flex-1 text-sm ${dim ? "text-body-secondary dark:text-body-secondary-dark" : "text-ink dark:text-ink-dark"}`}
         style={{ fontFamily: "Inter_400Regular" }}
       >
         {label}


### PR DESCRIPTION
Bugs de layout/font no RetomadaState relatados via screenshot (dark mode, mas presente em light tb):

## 1. Labels dos atalhos truncados no meio

- "Um copo" (esperado: "Um copo d'água")
- "Como foi a última" (esperado: "Como foi a última noite")
- "Ver todas as" (esperado: "Ver todas as métricas")

**Causa:** Text num flex-row sem `flex-1` depende da intrinsic width medida pelo NativeText. Android + Inter custom estava errando essa medida — RN encolhia o Text sem ellipsis, cortando no último word boundary que "cabia".

**Fix:** `flex-1` no Text força a preencher o espaço restante do Pressable (row: [icon 18px] [gap 12px] [text flex-1]). Sem dependência de intrinsic — o layout resolve o wrapping naturalmente.

## 2. "Depoi" (falta o "s")

**Causa:** Mesmo class de bug do #239. `underline` (via className Tailwind → `textDecorationLine: 'underline'`) bugava o advance width no Android + Inter custom (mesma família das causas anteriores: font-weight sintético, letterSpacing negativo).

**Fix:** Remove `underline`. Cor `text-label` + peso regular já hierarquiza como link secundário sem precisar do decoration.

## Test plan

- [x] `tsc`, `eslint`, `prettier`, tests limpos.
- [ ] Preview: abrir retomada (registrar → limpar tudo pra reset OU aguardar 3+ dias). Todos os 4 textos aparecem completos.

Pure JS — chega via OTA. Refs #239 (fix anterior de font clipping), #242 (fatia 5 que introduziu o RetomadaState).