### PR TITLE
feat(design-v2): migrate feedback screen to v2 tokens

### DIFF
--- a/app/_layout.jsx
+++ b/app/_layout.jsx
@@ -69,10 +69,7 @@ function AppTree() {
         <Stack.Screen name="history" options={{ title: "Histórico" }} />
         <Stack.Screen name="semana" options={{ title: "Semana" }} />
         <Stack.Screen name="ajustes" options={{ title: "Ajustes" }} />
-        <Stack.Screen
-          name="feedback"
-          options={{ title: "Feedback", headerShown: true }}
-        />
+        <Stack.Screen name="feedback" options={{ title: "Feedback" }} />
         {/* Rota de admin (testers) — acesso só por deep link backontrack://admin */}
         <Stack.Screen
           name="admin"

--- a/app/feedback.jsx
+++ b/app/feedback.jsx
@@ -1,20 +1,23 @@
 // @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
 //#region imports
 import { useState } from "react";
-import { Linking, ScrollView, Text, View } from "react-native";
+import {
+  Linking,
+  Pressable,
+  ScrollView,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
 import { router } from "expo-router";
+import Svg, { Path } from "react-native-svg";
 
 import MyView from "@/components/MyView";
-import MyButton from "@/components/MyButton";
-import MyInput from "@/components/MyInput";
-import Card from "@/components/Card";
-import SectionLabel from "@/components/SectionLabel";
 
 import { FEEDBACK_ENDPOINT, FEEDBACK_KEY } from "@/constants/feedback";
 import { getEnvironmentInfo } from "@/constants/environment";
+import { useThemeTokens } from "@/constants/themeTokens";
 //#endregion
-
-const INPUT = "w-full";
 
 const CATEGORIES = ["Bug", "Sugestão", "Outro"];
 
@@ -22,12 +25,12 @@ const CATEGORIES = ["Bug", "Sugestão", "Outro"];
 const ENV = getEnvironmentInfo();
 
 export default function Feedback() {
+  const t = useThemeTokens();
   const [category, setCategory] = useState("");
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [status, setStatus] = useState("idle"); // idle | sending | ok | error
   const [result, setResult] = useState(null); // { number, url }
-  const [errorMsg, setErrorMsg] = useState("");
 
   const canSend =
     status !== "sending" && (title.trim() !== "" || description.trim() !== "");
@@ -35,7 +38,6 @@ export default function Feedback() {
   async function handleSend() {
     if (!canSend) return;
     setStatus("sending");
-    setErrorMsg("");
     try {
       const res = await fetch(FEEDBACK_ENDPOINT, {
         method: "POST",
@@ -55,7 +57,9 @@ export default function Feedback() {
       setResult(data);
       setStatus("ok");
     } catch (e) {
-      setErrorMsg(String(e?.message ?? e));
+      // Detalhe técnico só no console (mesma regra do login #216) — evita
+      // vazar shape do backend pro usuário e não ajuda quem tá vendo.
+      console.error("feedback send failed:", e);
       setStatus("error");
     }
   }
@@ -66,105 +70,274 @@ export default function Feedback() {
     setDescription("");
     setResult(null);
     setStatus("idle");
-    setErrorMsg("");
   }
 
   return (
-    <MyView
-      safe={true}
-      className="flex-1 bg-light-background dark:bg-dark-background"
-    >
+    <MyView safe={true} className="flex-1 bg-light-background dark:bg-app-dark">
       <ScrollView
-        contentContainerStyle={{ padding: 16, gap: 16, alignItems: "center" }}
+        contentContainerStyle={{ padding: 20, gap: 20 }}
         showsVerticalScrollIndicator={false}
         keyboardShouldPersistTaps="handled"
       >
-        {status === "ok" ? (
-          <Card className="gap-3">
-            <Text className="font-bold text-2xl text-light-text dark:text-dark-text">
-              Recebido! 🙌
-            </Text>
-            <Text className="text-base text-light-text opacity-70 dark:text-dark-text">
-              Abrimos o chamado #{result?.number}. Obrigado por reportar — dá
-              pra acompanhar quando quiser.
-            </Text>
-            {result?.url && (
-              <MyButton
-                title="Ver o chamado"
-                onPress={() => Linking.openURL(result.url)}
+        {/* Nav: back */}
+        <View className="flex-row items-center justify-between">
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Voltar"
+            onPress={() => router.back()}
+            className="flex-row items-center gap-1 rounded-full p-1 pr-2 active:opacity-70"
+          >
+            <Svg width={18} height={18} viewBox="0 0 24 24" fill="none">
+              <Path
+                d="M15 6l-6 6 6 6"
+                stroke={t.primary}
+                strokeWidth={2.4}
+                strokeLinecap="round"
+                strokeLinejoin="round"
               />
-            )}
-            <MyButton title="Enviar outro" onPress={resetForm} />
-            <MyButton
-              title="Voltar ao início"
-              onPress={() => router.navigate("/")}
-            />
-          </Card>
+            </Svg>
+            <Text
+              className="text-base text-primary dark:text-primary-dark"
+              style={{ fontFamily: "Inter_500Medium" }}
+            >
+              Voltar
+            </Text>
+          </Pressable>
+        </View>
+
+        {status === "ok" ? (
+          <SuccessState
+            result={result}
+            onSendAnother={resetForm}
+            onHome={() => router.navigate("/")}
+          />
         ) : (
           <>
-            <Card className="gap-1">
-              <Text className="font-bold text-2xl text-light-text dark:text-dark-text">
+            {/* Header */}
+            <View className="gap-1 px-1">
+              <Text
+                className="text-2xl text-ink dark:text-ink-dark"
+                style={{ fontFamily: "Inter_600SemiBold" }}
+              >
                 Enviar feedback
               </Text>
-              <Text className="text-sm text-light-text opacity-70 dark:text-dark-text">
+              <Text
+                className="text-sm text-body-secondary dark:text-body-secondary-dark"
+                style={{ fontFamily: "Inter_400Regular", marginTop: 2 }}
+              >
                 Achou um problema ou tem uma sugestão? Conta aqui — abrimos o
                 chamado pra você automaticamente.
               </Text>
-            </Card>
+            </View>
 
-            <Card className="gap-4">
-              {/* Categoria (opcional) */}
-              <MyView safe={false} className="gap-2">
-                <SectionLabel>CATEGORIA (OPCIONAL)</SectionLabel>
-                <View className="flex-row flex-wrap gap-2">
-                  {CATEGORIES.map((c) => (
-                    <MyButton
+            {/* Categoria (opcional) */}
+            <View>
+              <Text
+                className="mb-3 text-xs uppercase tracking-wider text-label dark:text-label-dark"
+                style={{ fontFamily: "JetBrainsMono_500Medium" }}
+              >
+                Categoria (opcional)
+              </Text>
+              <View className="flex-row flex-wrap gap-2">
+                {CATEGORIES.map((c) => {
+                  const selected = category === c;
+                  return (
+                    <Pressable
                       key={c}
-                      title={c}
-                      isSelected={category === c}
-                      onPress={() => setCategory(category === c ? "" : c)}
-                    />
-                  ))}
-                </View>
-              </MyView>
+                      accessibilityRole="button"
+                      accessibilityLabel={`Categoria: ${c}`}
+                      accessibilityState={{ selected }}
+                      onPress={() => setCategory(selected ? "" : c)}
+                      className={`rounded-full px-4 py-2 ${
+                        selected
+                          ? "border-2 border-primary dark:border-primary-dark bg-tint-blue dark:bg-tint-blue-dark"
+                          : "border border-border-strong dark:border-border-strong-dark bg-white dark:bg-card-dark"
+                      }`}
+                    >
+                      <Text
+                        className={`text-sm ${
+                          selected
+                            ? "text-primary dark:text-primary-dark"
+                            : "text-body-secondary dark:text-body-secondary-dark"
+                        }`}
+                        style={{
+                          fontFamily: selected
+                            ? "Inter_600SemiBold"
+                            : "Inter_400Regular",
+                        }}
+                      >
+                        {c}
+                      </Text>
+                    </Pressable>
+                  );
+                })}
+              </View>
+            </View>
 
-              <MyInput
-                label="Título"
-                placeholder="Resumo em uma linha"
-                value={title}
-                onChangeText={setTitle}
-                containerClassName="w-full"
-                className={INPUT}
-                maxLength={140}
-              />
+            {/* Título */}
+            <V2Field
+              label="Título"
+              placeholder="Resumo em uma linha"
+              value={title}
+              onChangeText={setTitle}
+              maxLength={140}
+              tokens={t}
+            />
 
-              <MyInput
-                label="Descrição"
-                placeholder="O que aconteceu? Se for um bug, como reproduzir?"
-                value={description}
-                onChangeText={setDescription}
-                containerClassName="w-full"
-                className={INPUT}
-                multiline
-                numberOfLines={6}
-                style={{ minHeight: 120, textAlignVertical: "top" }}
-              />
+            {/* Descrição */}
+            <V2Field
+              label="Descrição"
+              placeholder="O que aconteceu? Se for um bug, como reproduzir?"
+              value={description}
+              onChangeText={setDescription}
+              multiline
+              tokens={t}
+            />
 
-              {status === "error" && (
-                <Text className="text-sm text-danger">
-                  Não consegui enviar ({errorMsg}). Tenta de novo em instantes.
-                </Text>
-              )}
+            {status === "error" && (
+              <Text
+                className="text-sm text-danger"
+                style={{ fontFamily: "Inter_400Regular" }}
+              >
+                Não consegui enviar agora. Tenta de novo em instantes.
+              </Text>
+            )}
 
-              <MyButton
-                title={status === "sending" ? "Enviando…" : "Enviar"}
-                onPress={handleSend}
-                disabled={!canSend}
-              />
-            </Card>
+            {/* Enviar */}
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Enviar feedback"
+              accessibilityState={{ disabled: !canSend }}
+              disabled={!canSend}
+              onPress={handleSend}
+              className={`mt-2 items-center rounded-2xl py-4 ${
+                canSend
+                  ? "bg-primary dark:bg-primary-dark active:opacity-70"
+                  : "bg-border-strong dark:bg-border-strong-dark"
+              }`}
+            >
+              <Text
+                className="text-base text-white dark:text-on-primary-dark"
+                style={{ fontFamily: "Inter_600SemiBold" }}
+              >
+                {status === "sending" ? "Enviando…" : "Enviar"}
+              </Text>
+            </Pressable>
           </>
         )}
       </ScrollView>
     </MyView>
+  );
+}
+
+/**
+ * @param {{ label: string, placeholder: string, value: string,
+ *   onChangeText: (v: string) => void, maxLength?: number,
+ *   multiline?: boolean, tokens: any }} props
+ */
+function V2Field({
+  label,
+  placeholder,
+  value,
+  onChangeText,
+  maxLength,
+  multiline,
+  tokens,
+}) {
+  return (
+    <View>
+      <Text
+        className="mb-3 text-xs uppercase tracking-wider text-label dark:text-label-dark"
+        style={{ fontFamily: "JetBrainsMono_500Medium" }}
+      >
+        {label}
+      </Text>
+      <TextInput
+        value={value}
+        onChangeText={onChangeText}
+        placeholder={placeholder}
+        placeholderTextColor={tokens.iconDim}
+        maxLength={maxLength}
+        multiline={multiline}
+        numberOfLines={multiline ? 6 : 1}
+        accessibilityLabel={label}
+        className="rounded-2xl border border-border-subtle dark:border-border-subtle-dark bg-white dark:bg-card-dark px-4"
+        style={{
+          fontFamily: "Inter_400Regular",
+          fontSize: 15,
+          color: tokens.ink,
+          paddingVertical: multiline ? 12 : 14,
+          minHeight: multiline ? 120 : undefined,
+          textAlignVertical: multiline ? "top" : "center",
+        }}
+      />
+    </View>
+  );
+}
+
+/** @param {{ result: {number?: number, url?: string} | null, onSendAnother: () => void, onHome: () => void }} props */
+function SuccessState({ result, onSendAnother, onHome }) {
+  return (
+    <View className="mt-4 gap-4">
+      <View className="gap-1 px-1">
+        <Text
+          className="text-2xl text-ink dark:text-ink-dark"
+          style={{ fontFamily: "Inter_600SemiBold" }}
+        >
+          Recebido 🙌
+        </Text>
+        <Text
+          className="text-sm text-body-secondary dark:text-body-secondary-dark"
+          style={{ fontFamily: "Inter_400Regular", marginTop: 2 }}
+        >
+          {result?.number
+            ? `Abrimos o chamado #${result.number}. Obrigado por reportar — dá pra acompanhar quando quiser.`
+            : "Obrigado por reportar."}
+        </Text>
+      </View>
+
+      {result?.url && (
+        <SecondaryAction
+          label="Ver o chamado"
+          onPress={() => Linking.openURL(result.url)}
+        />
+      )}
+
+      <View className="gap-2">
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Enviar outro feedback"
+          onPress={onSendAnother}
+          className="items-center rounded-2xl bg-primary dark:bg-primary-dark py-4 active:opacity-70"
+        >
+          <Text
+            className="text-base text-white dark:text-on-primary-dark"
+            style={{ fontFamily: "Inter_600SemiBold" }}
+          >
+            Enviar outro
+          </Text>
+        </Pressable>
+        <SecondaryAction label="Voltar ao início" onPress={onHome} />
+      </View>
+    </View>
+  );
+}
+
+/** @param {{ label: string, onPress: () => void }} props */
+function SecondaryAction({ label, onPress }) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      onPress={onPress}
+      className="items-center rounded-2xl border border-border-strong dark:border-border-strong-dark bg-white dark:bg-card-dark py-4 active:opacity-70"
+    >
+      <Text
+        className="text-base text-primary dark:text-primary-dark"
+        style={{ fontFamily: "Inter_500Medium" }}
+      >
+        {label}
+      </Text>
+    </Pressable>
   );
 }


### PR DESCRIPTION
Segunda das 6 telas M5 baseline migrando pro visual v2 (após #250 histórico).

## O que muda em `app/feedback.jsx`

- **Nav bar back arrow** (era header nativo do stack via `headerShown:true`).
- **Header h1** "Enviar feedback" + subtitle body-secondary — antes vivia dentro de um Card.
- **Chips de categoria** (Bug/Sugestão/Outro) no padrão pill rounded-full do v2: selected border-2 primary + tint-blue; unselected border-strong + white. Antes eram MyButton isSelected.
- **`V2Field` helper local**: label mono uppercase (era MyInput com label bold), TextInput bg-card/border-subtle/rounded-2xl, sem separação Card+MyInput do M5.
- **Erro inline** em text-danger sem HTTP status leak — segue a regra #216 do login: detalhe técnico só no console, mensagem pro usuário genérica ("Não consegui enviar agora. Tenta de novo em instantes.").
- **Success state** em texto direto (não mais Card wrap), copy "Recebido 🙌", ações primary/secondary consistentes com o resto do v2 (SecondaryAction helper reutiliza o padrão).

## Wiring

- `app/_layout.jsx`: `/feedback` já não precisa de `headerShown:true` (tela renderiza próprio back).

## Fora

- 4 telas restantes na fila: Roadmap → Admin → Login → Callback.

## Test plan

- [x] `tsc`, `eslint`, `prettier`, tests limpos.
- [ ] Preview: abrir via hamburger→Ajustes→App→Enviar feedback. Escrever título + descrição, escolher categoria, enviar. Ver estado success com número do chamado. Testar dark mode.

Refs #250 (histórico, primeiro da onda), #216 (regra de não vazar erro cru).