### PR TITLE
feat(design-v2): migrate admin (testers) screen to v2 tokens

### DIFF
--- a/app/_layout.jsx
+++ b/app/_layout.jsx
@@ -74,10 +74,7 @@ function AppTree() {
           options={{ title: "Feedback", headerShown: true }}
         />
         {/* Rota de admin (testers) — acesso só por deep link backontrack://admin */}
-        <Stack.Screen
-          name="admin"
-          options={{ title: "Admin", headerShown: true }}
-        />
+        <Stack.Screen name="admin" options={{ title: "Admin" }} />
         <Stack.Screen
           name="login"
           options={{ title: "Entrar", headerShown: true }}

--- a/app/admin.jsx
+++ b/app/admin.jsx
@@ -6,20 +6,28 @@
 // esta tela aparece vazia; só o aparelho do admin popula.
 //#region imports
 import { useMemo, useState } from "react";
-import { Platform, ScrollView, Share, Text, View } from "react-native";
+import {
+  Platform,
+  Pressable,
+  ScrollView,
+  Share,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import { router } from "expo-router";
+import Svg, { Path } from "react-native-svg";
 import { useTable } from "tinybase/ui-react";
 
 import MyView from "@/components/MyView";
-import MyButton from "@/components/MyButton";
-import MyInput from "@/components/MyInput";
-import Card from "@/components/Card";
-import SectionLabel from "@/components/SectionLabel";
 
 import { confirmAction, notify } from "@/constants/dialogs";
 import { getTesters, addTester, removeTester, store } from "@/infra/database";
+import { useThemeTokens } from "@/constants/themeTokens";
 //#endregion
 
 export default function Admin() {
+  const t = useThemeTokens();
   const [name, setName] = useState("");
   const [phone, setPhone] = useState("");
 
@@ -62,9 +70,10 @@ export default function Admin() {
       2,
     );
     try {
-      // No web o destino é a máquina de dev (colar no scripts/testers.json), e a
-      // Web Share API nem existe em boa parte do desktop — clipboard é o certo.
-      // No native, o share sheet é o caminho natural pra tirar o JSON do device.
+      // No web o destino é a máquina de dev (colar no scripts/testers.json), e
+      // a Web Share API nem existe em boa parte do desktop — clipboard é o
+      // certo. No native, o share sheet é o caminho natural pra tirar o JSON
+      // do device.
       if (Platform.OS === "web") {
         await globalThis.navigator.clipboard.writeText(json);
         notify("Lista copiada", "Cole em scripts/testers.json.");
@@ -72,85 +81,242 @@ export default function Admin() {
       }
       await Share.share({ message: json });
     } catch (e) {
-      notify("Não deu pra exportar", String(e?.message ?? e));
+      // Erro de share/clipboard não vaza pro usuário — só console.
+      console.error("[admin] export falhou:", e);
+      notify("Não deu pra exportar", "Tenta de novo em instantes.");
     }
   }
 
   return (
-    <MyView
-      safe={true}
-      className="flex-1 bg-light-background dark:bg-dark-background"
-    >
+    <MyView safe={true} className="flex-1 bg-light-background dark:bg-app-dark">
       <ScrollView
-        contentContainerStyle={{ padding: 16, gap: 16, alignItems: "center" }}
+        contentContainerStyle={{ padding: 20, gap: 20 }}
         showsVerticalScrollIndicator={false}
         keyboardShouldPersistTaps="handled"
       >
-        {/* Adicionar tester */}
-        <Card className="gap-4">
-          <Text className="font-bold text-2xl text-light-text dark:text-dark-text">
+        {/* Nav */}
+        <View className="flex-row items-center justify-between">
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Voltar"
+            onPress={() => router.back()}
+            className="flex-row items-center gap-1 rounded-full p-1 pr-2 active:opacity-70"
+          >
+            <Svg width={18} height={18} viewBox="0 0 24 24" fill="none">
+              <Path
+                d="M15 6l-6 6 6 6"
+                stroke={t.primary}
+                strokeWidth={2.4}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </Svg>
+            <Text
+              className="text-base text-primary dark:text-primary-dark"
+              style={{ fontFamily: "Inter_500Medium" }}
+            >
+              Voltar
+            </Text>
+          </Pressable>
+        </View>
+
+        {/* Header */}
+        <View className="gap-1 px-1">
+          <Text
+            className="text-xs tracking-wider text-label dark:text-label-dark"
+            style={{ fontFamily: "JetBrainsMono_500Medium" }}
+          >
+            ADMIN
+          </Text>
+          <Text
+            className="text-2xl text-ink dark:text-ink-dark"
+            style={{ fontFamily: "Inter_600SemiBold" }}
+          >
             Testers
           </Text>
-          <MyInput
+          <Text
+            className="text-sm text-body-secondary dark:text-body-secondary-dark"
+            style={{ fontFamily: "Inter_400Regular", marginTop: 2 }}
+          >
+            Lista local do aparelho, consumida pelo sender WhatsApp.
+          </Text>
+        </View>
+
+        {/* Adicionar tester */}
+        <View className="gap-4">
+          <Text
+            className="text-xs uppercase tracking-wider text-label dark:text-label-dark"
+            style={{ fontFamily: "JetBrainsMono_500Medium" }}
+          >
+            Adicionar
+          </Text>
+          <V2Field
             label="Nome"
             placeholder="Nome do tester"
             value={name}
             onChangeText={setName}
-            containerClassName="w-full"
-            className="w-full"
             autoCapitalize="words"
+            tokens={t}
           />
-          <MyInput
+          <V2Field
             label="Número (com DDI)"
             placeholder="+55 11 99999-9999"
             value={phone}
             onChangeText={setPhone}
-            containerClassName="w-full"
-            className="w-full"
             keyboardType="phone-pad"
+            tokens={t}
           />
-          <MyButton title="Adicionar" onPress={handleAdd} disabled={!canAdd} />
-        </Card>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Adicionar tester"
+            accessibilityState={{ disabled: !canAdd }}
+            disabled={!canAdd}
+            onPress={handleAdd}
+            className={`items-center rounded-2xl py-4 ${
+              canAdd
+                ? "bg-primary dark:bg-primary-dark active:opacity-70"
+                : "bg-border-strong dark:bg-border-strong-dark"
+            }`}
+          >
+            <Text
+              className="text-base text-white dark:text-on-primary-dark"
+              style={{ fontFamily: "Inter_600SemiBold" }}
+            >
+              Adicionar
+            </Text>
+          </Pressable>
+        </View>
 
         {/* Lista */}
-        <Card className="gap-3">
-          <SectionLabel>NA LISTA ({testers.length})</SectionLabel>
+        <View className="gap-2.5">
+          <Text
+            className="text-xs uppercase tracking-wider text-label dark:text-label-dark"
+            style={{ fontFamily: "JetBrainsMono_500Medium" }}
+          >
+            Na lista · {testers.length}
+          </Text>
           {testers.length === 0 ? (
-            <Text className="text-base text-light-text opacity-60 dark:text-dark-text">
-              Nenhum tester ainda.
-            </Text>
+            <View className="rounded-2xl border border-border-subtle dark:border-border-subtle-dark bg-white dark:bg-card-dark px-5 py-6">
+              <Text
+                className="text-center text-sm text-body-secondary dark:text-body-secondary-dark"
+                style={{ fontFamily: "Inter_400Regular" }}
+              >
+                Nenhum tester ainda.
+              </Text>
+            </View>
           ) : (
-            <MyView safe={false} className="gap-2">
-              {testers.map((t) => (
-                <View key={t.id} className="flex-row items-center gap-2">
-                  <View className="flex-1">
-                    <Text className="text-base text-light-text dark:text-dark-text">
-                      {t.name}
-                    </Text>
-                    <Text className="text-sm text-light-text opacity-60 dark:text-dark-text">
-                      {t.phone}
-                    </Text>
-                  </View>
-                  <MyButton
-                    title="Remover"
-                    onPress={() => handleRemove(t)}
-                    className="bg-danger px-3 py-1"
-                  />
+            testers.map((tester) => (
+              <View
+                key={tester.id}
+                className="flex-row items-center gap-3 rounded-2xl border border-border-subtle dark:border-border-subtle-dark bg-white dark:bg-card-dark p-4"
+              >
+                <View className="flex-1 gap-0.5">
+                  <Text
+                    className="text-base text-ink dark:text-ink-dark"
+                    style={{ fontFamily: "Inter_500Medium" }}
+                  >
+                    {tester.name}
+                  </Text>
+                  <Text
+                    className="text-xs text-body-secondary dark:text-body-secondary-dark"
+                    style={{ fontFamily: "JetBrainsMono_400Regular" }}
+                  >
+                    {tester.phone}
+                  </Text>
                 </View>
-              ))}
-            </MyView>
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel={`Remover ${tester.name}`}
+                  onPress={() => handleRemove(tester)}
+                  className="rounded-xl border border-border-strong dark:border-border-strong-dark bg-white dark:bg-card-dark px-3 py-2 active:opacity-70"
+                >
+                  <Text
+                    className="text-sm text-danger"
+                    style={{ fontFamily: "Inter_500Medium" }}
+                  >
+                    Remover
+                  </Text>
+                </Pressable>
+              </View>
+            ))
           )}
-        </Card>
+        </View>
 
         {/* Exportar */}
-        <Card className="gap-2">
-          <SectionLabel>SENDER</SectionLabel>
-          <Text className="text-sm text-light-text opacity-70 dark:text-dark-text">
-            Exporta a lista em JSON pra colar em `scripts/testers.json`.
+        <View className="gap-2">
+          <Text
+            className="text-xs uppercase tracking-wider text-label dark:text-label-dark"
+            style={{ fontFamily: "JetBrainsMono_500Medium" }}
+          >
+            Sender
           </Text>
-          <MyButton title="Exportar lista" onPress={handleExport} />
-        </Card>
+          <Text
+            className="text-sm text-body-secondary dark:text-body-secondary-dark"
+            style={{ fontFamily: "Inter_400Regular" }}
+          >
+            Exporta a lista em JSON pra colar em{" "}
+            <Text style={{ fontFamily: "JetBrainsMono_400Regular" }}>
+              scripts/testers.json
+            </Text>
+            .
+          </Text>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Exportar lista"
+            onPress={handleExport}
+            className="items-center rounded-2xl border border-border-strong dark:border-border-strong-dark bg-white dark:bg-card-dark py-4 active:opacity-70"
+          >
+            <Text
+              className="text-base text-primary dark:text-primary-dark"
+              style={{ fontFamily: "Inter_500Medium" }}
+            >
+              Exportar lista
+            </Text>
+          </Pressable>
+        </View>
       </ScrollView>
     </MyView>
+  );
+}
+
+/**
+ * @param {{ label: string, placeholder: string, value: string,
+ *   onChangeText: (v: string) => void, autoCapitalize?: string,
+ *   keyboardType?: string, tokens: any }} props
+ */
+function V2Field({
+  label,
+  placeholder,
+  value,
+  onChangeText,
+  autoCapitalize,
+  keyboardType,
+  tokens,
+}) {
+  return (
+    <View>
+      <Text
+        className="mb-3 text-xs uppercase tracking-wider text-label dark:text-label-dark"
+        style={{ fontFamily: "JetBrainsMono_500Medium" }}
+      >
+        {label}
+      </Text>
+      <TextInput
+        value={value}
+        onChangeText={onChangeText}
+        placeholder={placeholder}
+        placeholderTextColor={tokens.iconDim}
+        autoCapitalize={autoCapitalize}
+        keyboardType={keyboardType}
+        accessibilityLabel={label}
+        className="rounded-2xl border border-border-subtle dark:border-border-subtle-dark bg-white dark:bg-card-dark px-4"
+        style={{
+          fontFamily: "Inter_400Regular",
+          fontSize: 15,
+          color: tokens.ink,
+          paddingVertical: 14,
+        }}
+      />
+    </View>
   );
 }


### PR DESCRIPTION
4ª de 6 telas M5 baseline migrando pro visual v2 (após #250 histórico, #251 feedback, #252 roadmap).

## O que muda em `app/admin.jsx`

- **Nav bar back arrow** (era header nativo do stack via `headerShown:true`).
- **Header em 3 linhas**: label mono "ADMIN", h1 "Testers", subtitle explicando escopo (lista local, consumida pelo sender WhatsApp).
- **Seção "Adicionar"**: `V2Field` helper local (label mono + TextInput bg-card border-subtle rounded-2xl), botão primary. Removido o Card wrapper — seções agora com label mono na cor label + espaço direto.
- **Seção "Na lista · N"**: cards por-tester com nome (Inter_500) + phone (mono 400), botão Remover destrutivo à direita (border-strong + text-danger, mesmo padrão do Excluir do HistoryCard).
- **Seção "Sender"**: copy + botão secundário (border-strong + text-primary) pra exportar. Erro de export não vaza cru — só console + notify genérico.
- **Empty state** em card branco com copy "Nenhum tester ainda."

## Wiring

- `app/_layout.jsx`: `/admin` já não precisa de `headerShown:true`.

## Fora

- 2 telas restantes na fila: Login → Callback.

## Test plan

- [x] `tsc`, `eslint`, `prettier`, tests limpos.
- [ ] Preview: acessar via deep link `backontrack://admin` (não linkado nos Utilitários por design). Adicionar tester → aparece na lista. Remover → confirm dialog. Exportar → copia pra clipboard (web) ou abre share sheet (native).

Refs #252 (roadmap), #109 (admin original).