### PR TITLE
feat(design-v2): migrate login screen to v2 tokens

### DIFF
--- a/app/_layout.jsx
+++ b/app/_layout.jsx
@@ -69,10 +69,7 @@ function AppTree() {
         <Stack.Screen name="feedback" options={{ title: "Feedback" }} />
         {/* Rota de admin (testers) — acesso só por deep link backontrack://admin */}
         <Stack.Screen name="admin" options={{ title: "Admin" }} />
-        <Stack.Screen
-          name="login"
-          options={{ title: "Entrar", headerShown: true }}
-        />
+        <Stack.Screen name="login" options={{ title: "Entrar" }} />
         {/* Callback do magic link — headless, autopropulsão pra /. */}
         <Stack.Screen
           name="auth/callback"

--- a/app/ajustes.jsx
+++ b/app/ajustes.jsx
@@ -165,11 +165,23 @@ export default function Ajustes() {
           <Row label="Sobre" value={`v${ENV.appVersion}`} valueMono disabled />
         </Section>
 
-        {/* Conta (só logado) */}
-        {AUTH_ENABLED && user && (
+        {/* Conta: sempre visível quando auth tá configurada. Concentra o
+            fluxo de entrar/sair — a Home não tem mais botão Entrar isolado
+            (era redundante e piscava durante o auto-load da sessão). */}
+        {AUTH_ENABLED && (
           <Section title="Conta">
-            <Row label="Logado como" value={user.email} disabled />
-            <Row label="Sair" onPress={signOut} destructive />
+            {user ? (
+              <>
+                <Row label="Logado como" value={user.email} disabled />
+                <Row label="Sair" onPress={signOut} destructive />
+              </>
+            ) : (
+              <Row
+                label="Entrar"
+                valueChevron
+                onPress={() => router.navigate("/login")}
+              />
+            )}
           </Section>
         )}
 

--- a/app/index.jsx
+++ b/app/index.jsx
@@ -14,7 +14,6 @@ import RetomadaState from "@/components/RetomadaState";
 import { getToday, store } from "@/infra/database";
 import { useSession } from "@/infra/session";
 import { useThemeTokens } from "@/constants/themeTokens";
-import { AUTH_ENABLED } from "@/infra/supabase";
 import { CATEGORY_MAP } from "@/components/categoryUtils";
 import { minutesToHHMM } from "@/constants/duration";
 //#endregion
@@ -237,24 +236,11 @@ export default function Home() {
         {/* Obter o app (só web: QR no desktop, download no celular) */}
         <InstallApp />
 
-        {/* Entrar isolado só quando deslogado + auth configurada. Sair vai
-            pra tela de Ajustes junto com "Logado como". */}
-        {AUTH_ENABLED && !user && (
-          <View className="rounded-2xl border border-border-subtle dark:border-border-subtle-dark bg-white dark:bg-card-dark p-4">
-            <Pressable
-              accessibilityRole="button"
-              onPress={() => router.navigate("/login")}
-              className="items-center rounded-xl bg-primary dark:bg-primary-dark py-3"
-            >
-              <Text
-                className="text-sm text-white dark:text-on-primary-dark"
-                style={{ fontFamily: "Inter_500Medium" }}
-              >
-                Entrar
-              </Text>
-            </Pressable>
-          </View>
-        )}
+        {/* Login/logout ficam TODOS em Ajustes → Conta (Entrar quando !user,
+            Sair quando user). Ter um botão Entrar aqui na Home também era
+            redundante — e como useSession pode devolver `user: null` durante
+            o auto-load da sessão, o gate `!user` piscava o botão logo depois
+            de logar. Concentrar em Ajustes elimina o flicker e centraliza. */}
       </ScrollView>
     </MyView>
   );

--- a/app/login.jsx
+++ b/app/login.jsx
@@ -1,21 +1,21 @@
 // @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
 import { useState } from "react";
 import * as Linking from "expo-linking";
-import { ScrollView, Text } from "react-native";
+import { Pressable, ScrollView, Text, TextInput, View } from "react-native";
 import { router } from "expo-router";
+import Svg, { Path } from "react-native-svg";
 
 import MyView from "@/components/MyView";
-import MyButton from "@/components/MyButton";
-import MyInput from "@/components/MyInput";
-import Card from "@/components/Card";
 
 import { useSession } from "@/infra/session";
 import { AUTH_ENABLED, supabase } from "@/infra/supabase";
+import { useThemeTokens } from "@/constants/themeTokens";
 
 // Login por magic link (M6 auth fatia A, #207, ADR-010).
 // Sync continua anônimo por baixo — só a fatia B passa a usar o JWT.
 
 export default function Login() {
+  const t = useThemeTokens();
   const { user } = useSession();
   const [email, setEmail] = useState("");
   const [status, setStatus] = useState("idle"); // idle | sending | sent | error
@@ -45,89 +45,192 @@ export default function Login() {
   }
 
   return (
-    <MyView
-      safe={true}
-      className="flex-1 bg-light-background dark:bg-dark-background"
-    >
+    <MyView safe={true} className="flex-1 bg-light-background dark:bg-app-dark">
       <ScrollView
-        contentContainerStyle={{ padding: 16, gap: 16, alignItems: "center" }}
+        contentContainerStyle={{ padding: 20, gap: 20 }}
+        showsVerticalScrollIndicator={false}
         keyboardShouldPersistTaps="handled"
       >
+        {/* Nav: back */}
+        <View className="flex-row items-center justify-between">
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Voltar"
+            onPress={() => router.back()}
+            className="flex-row items-center gap-1 rounded-full p-1 pr-2 active:opacity-70"
+          >
+            <Svg width={18} height={18} viewBox="0 0 24 24" fill="none">
+              <Path
+                d="M15 6l-6 6 6 6"
+                stroke={t.primary}
+                strokeWidth={2.4}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </Svg>
+            <Text
+              className="text-base text-primary dark:text-primary-dark"
+              style={{ fontFamily: "Inter_500Medium" }}
+            >
+              Voltar
+            </Text>
+          </Pressable>
+        </View>
+
         {!AUTH_ENABLED ? (
-          <Card className="gap-2">
-            <Text className="font-bold text-xl text-light-text dark:text-dark-text">
-              Login indisponível
-            </Text>
-            <Text className="text-base text-light-text opacity-70 dark:text-dark-text">
-              O app não foi configurado com credenciais do Supabase
-              (EXPO_PUBLIC_SUPABASE_URL / EXPO_PUBLIC_SUPABASE_ANON_KEY). Isso é
-              esperado enquanto a fatia A do M6 auth não sobe pra você.
-            </Text>
-          </Card>
+          <SoftMessage
+            title="Login indisponível"
+            body="O app não foi configurado com credenciais do Supabase. Isso é esperado enquanto a fatia A do M6 auth não sobe pra você."
+          />
         ) : user ? (
-          <Card className="gap-3">
-            <Text className="font-bold text-xl text-light-text dark:text-dark-text">
-              Já está logado
-            </Text>
-            <Text className="text-base text-light-text opacity-70 dark:text-dark-text">
-              {user.email}
-            </Text>
-            <MyButton
-              title="Voltar ao início"
+          <View className="gap-4">
+            <SoftMessage title="Já está logado" body={user.email} bodyMono />
+            <PrimaryAction
+              label="Voltar ao início"
               onPress={() => router.navigate("/")}
             />
-          </Card>
+          </View>
         ) : status === "sent" ? (
-          <Card className="gap-3">
-            <Text className="font-bold text-2xl text-light-text dark:text-dark-text">
-              Verifique seu email 📬
-            </Text>
-            <Text className="text-base text-light-text opacity-70 dark:text-dark-text">
-              Enviamos um link mágico pra {email}. Toque no link do email pra
-              entrar — o app abre logado sozinho.
-            </Text>
-            <MyButton
-              title="Não recebi, enviar de novo"
+          <View className="gap-4">
+            <SoftMessage
+              title="Verifique seu email 📬"
+              body={`Enviamos um link mágico pra ${email}. Toque no link do email pra entrar — o app abre logado sozinho.`}
+            />
+            <SecondaryAction
+              label="Não recebi, enviar de novo"
               onPress={() => setStatus("idle")}
             />
-          </Card>
+          </View>
         ) : (
-          <Card className="gap-4">
-            <Text className="font-bold text-2xl text-light-text dark:text-dark-text">
-              Entrar
-            </Text>
-            <Text className="text-sm text-light-text opacity-70 dark:text-dark-text">
-              Sem senha: mandamos um link pro seu email; abrindo o link, você
-              entra.
-            </Text>
+          <View className="gap-5">
+            <View className="gap-1 px-1">
+              <Text
+                className="text-2xl text-ink dark:text-ink-dark"
+                style={{ fontFamily: "Inter_600SemiBold" }}
+              >
+                Entrar
+              </Text>
+              <Text
+                className="text-sm text-body-secondary dark:text-body-secondary-dark"
+                style={{ fontFamily: "Inter_400Regular", marginTop: 2 }}
+              >
+                Sem senha: mandamos um link pro seu email; abrindo o link, você
+                entra.
+              </Text>
+            </View>
 
-            <MyInput
-              label="Email"
-              placeholder="seu@email.com"
-              value={email}
-              onChangeText={setEmail}
-              containerClassName="w-full"
-              className="w-full"
-              autoCapitalize="none"
-              autoComplete="email"
-              keyboardType="email-address"
-            />
+            <View>
+              <Text
+                className="mb-3 text-xs uppercase tracking-wider text-label dark:text-label-dark"
+                style={{ fontFamily: "JetBrainsMono_500Medium" }}
+              >
+                Email
+              </Text>
+              <TextInput
+                value={email}
+                onChangeText={setEmail}
+                placeholder="seu@email.com"
+                placeholderTextColor={t.iconDim}
+                autoCapitalize="none"
+                autoComplete="email"
+                keyboardType="email-address"
+                accessibilityLabel="Email"
+                className="rounded-2xl border border-border-subtle dark:border-border-subtle-dark bg-white dark:bg-card-dark px-4"
+                style={{
+                  fontFamily: "Inter_400Regular",
+                  fontSize: 15,
+                  color: t.ink,
+                  paddingVertical: 14,
+                }}
+              />
+            </View>
 
             {status === "error" && (
-              <Text className="text-sm text-danger">
+              <Text
+                className="text-sm text-danger"
+                style={{ fontFamily: "Inter_400Regular" }}
+              >
                 Não consegui enviar o link agora. Confere o email e tenta de
                 novo em alguns minutos.
               </Text>
             )}
 
-            <MyButton
-              title={status === "sending" ? "Enviando…" : "Enviar magic link"}
+            <PrimaryAction
+              label={status === "sending" ? "Enviando…" : "Enviar magic link"}
               onPress={handleSend}
               disabled={!canSend}
             />
-          </Card>
+          </View>
         )}
       </ScrollView>
     </MyView>
+  );
+}
+
+/** @param {{ title: string, body: string, bodyMono?: boolean }} props */
+function SoftMessage({ title, body, bodyMono }) {
+  return (
+    <View className="gap-2 rounded-2xl border border-border-subtle dark:border-border-subtle-dark bg-white dark:bg-card-dark p-5">
+      <Text
+        className="text-lg text-ink dark:text-ink-dark"
+        style={{ fontFamily: "Inter_600SemiBold" }}
+      >
+        {title}
+      </Text>
+      <Text
+        className="text-sm text-body-secondary dark:text-body-secondary-dark"
+        style={{
+          fontFamily: bodyMono
+            ? "JetBrainsMono_400Regular"
+            : "Inter_400Regular",
+        }}
+      >
+        {body}
+      </Text>
+    </View>
+  );
+}
+
+/** @param {{ label: string, onPress: () => void, disabled?: boolean }} props */
+function PrimaryAction({ label, onPress, disabled }) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      accessibilityState={{ disabled: !!disabled }}
+      disabled={disabled}
+      onPress={onPress}
+      className={`items-center rounded-2xl py-4 ${
+        disabled
+          ? "bg-border-strong dark:bg-border-strong-dark"
+          : "bg-primary dark:bg-primary-dark active:opacity-70"
+      }`}
+    >
+      <Text
+        className="text-base text-white dark:text-on-primary-dark"
+        style={{ fontFamily: "Inter_600SemiBold" }}
+      >
+        {label}
+      </Text>
+    </Pressable>
+  );
+}
+
+/** @param {{ label: string, onPress: () => void }} props */
+function SecondaryAction({ label, onPress }) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      onPress={onPress}
+      className="items-center rounded-2xl border border-border-strong dark:border-border-strong-dark bg-white dark:bg-card-dark py-4 active:opacity-70"
+    >
+      <Text
+        className="text-base text-primary dark:text-primary-dark"
+        style={{ fontFamily: "Inter_500Medium" }}
+      >
+        {label}
+      </Text>
+    </Pressable>
   );
 }


### PR DESCRIPTION
5ª de 6 telas M5 baseline migrando pro visual v2 (após #250/#251/#252/#253).

## O que muda em `app/login.jsx`

Fluxo de auth **preservado integralmente** (`signInWithOtp` + `emailRedirectTo` via `Linking.createURL`, catch com console.error + status genérico). Só o visual muda.

- **Nav bar back arrow** (era header nativo do stack via `headerShown:true`).
- **Header h1** "Entrar" + subtitle body-secondary explicando o fluxo.
- **TextInput email bespoke inline** (label mono uppercase + campo v2 border-subtle rounded-2xl).
- **Botão primary** "Enviar magic link".
- **Erro inline** em text-danger (mensagem genérica — regra #216 preservada; detalhe técnico só console).
- **4 estados unificados via helpers locais**: `SoftMessage` (card branco/border-subtle), `PrimaryAction`, `SecondaryAction`:
  - `AUTH_ENABLED` off → SoftMessage explicativo.
  - Já logado → SoftMessage com email em mono + PrimaryAction "Voltar ao início".
  - Enviado → SoftMessage "Verifique seu email 📬" + SecondaryAction "Não recebi".
  - Idle → form + PrimaryAction.

## Wiring

- `app/_layout.jsx`: `/login` já não precisa de `headerShown:true`.

## Fora

- Última tela na fila: Callback (headless-ish, mais simples).

## Test plan

- [x] `tsc`, `eslint`, `prettier`, tests limpos.
- [ ] Preview: hamburger→Ajustes→(desloga) → "Entrar" na Home. Todos os 4 estados. Enviar magic link real e conferir email + fluxo do callback (que ainda tá M5).

Refs #253 (admin), #216 (regra de não vazar erro cru).