### PR TITLE
feat(design-v2): migrate auth/callback screen to v2 tokens

### DIFF
--- a/app/auth/callback.jsx
+++ b/app/auth/callback.jsx
@@ -1,13 +1,12 @@
 // @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
 import { useEffect, useState } from "react";
-import { ActivityIndicator, ScrollView, Text } from "react-native";
+import { ActivityIndicator, Pressable, ScrollView, Text, View } from "react-native";
 import { router, useLocalSearchParams } from "expo-router";
 
 import MyView from "@/components/MyView";
-import MyButton from "@/components/MyButton";
-import Card from "@/components/Card";
 
 import { supabase } from "@/infra/supabase";
+import { useThemeTokens } from "@/constants/themeTokens";
 
 // Callback do magic link do Supabase (M6 auth fatia A, #207, ADR-010).
 // Deep link `backontrack://auth/callback?code=...` (native) OU
@@ -15,20 +14,21 @@ import { supabase } from "@/infra/supabase";
 // sessão via PKCE, redireciona pra /.
 
 export default function AuthCallback() {
+  const t = useThemeTokens();
   const { code, error, error_description } = useLocalSearchParams();
   const [status, setStatus] = useState("exchanging");
-  const [errorMsg, setErrorMsg] = useState("");
 
   useEffect(() => {
     // Supabase pode redirecionar com `?error=...` em vez de `?code=...`
-    // (ex: link expirado, config errada) — surface direto.
+    // (ex: link expirado, config errada) — vira status error; detalhe fica
+    // no console pra debug sem vazar shape do backend pro usuário.
     if (error) {
-      setErrorMsg(String(error_description ?? error));
+      console.error("[callback] supabase error:", error, error_description);
       setStatus("error");
       return;
     }
     if (!supabase) {
-      setErrorMsg("Auth não configurada.");
+      console.error("[callback] supabase não configurado");
       setStatus("error");
       return;
     }
@@ -41,7 +41,7 @@ export default function AuthCallback() {
           router.replace("/");
         })
         .catch((e) => {
-          setErrorMsg(String(e?.message ?? e));
+          console.error("[callback] exchangeCodeForSession falhou:", e);
           setStatus("error");
         });
       return;
@@ -58,7 +58,7 @@ export default function AuthCallback() {
     });
     const timeoutId = setTimeout(() => {
       sub.subscription.unsubscribe();
-      setErrorMsg("Link inválido ou sem código de autenticação.");
+      console.error("[callback] timeout esperando sessão (hash-flow)");
       setStatus("error");
     }, 3000);
     return () => {
@@ -68,31 +68,56 @@ export default function AuthCallback() {
   }, [code, error, error_description]);
 
   return (
-    <MyView
-      safe={true}
-      className="flex-1 bg-light-background dark:bg-dark-background"
-    >
+    <MyView safe={true} className="flex-1 bg-light-background dark:bg-app-dark">
       <ScrollView
-        contentContainerStyle={{ padding: 16, gap: 16, alignItems: "center" }}
+        contentContainerStyle={{
+          padding: 20,
+          gap: 20,
+          flexGrow: 1,
+          justifyContent: "center",
+        }}
       >
         {status === "exchanging" ? (
-          <Card className="gap-3 items-center">
-            <ActivityIndicator />
-            <Text className="text-base text-light-text dark:text-dark-text">
+          <View className="items-center gap-4">
+            <ActivityIndicator color={t.primary} />
+            <Text
+              className="text-base text-body-secondary dark:text-body-secondary-dark"
+              style={{ fontFamily: "Inter_400Regular" }}
+            >
               Autenticando…
             </Text>
-          </Card>
+          </View>
         ) : (
-          <Card className="gap-3">
-            <Text className="font-bold text-xl text-light-text dark:text-dark-text">
-              Não deu certo
-            </Text>
-            <Text className="text-sm text-danger">{errorMsg}</Text>
-            <MyButton
-              title="Tentar de novo"
+          <View className="gap-5">
+            <View className="gap-2 rounded-2xl border border-border-subtle dark:border-border-subtle-dark bg-white dark:bg-card-dark p-5">
+              <Text
+                className="text-lg text-ink dark:text-ink-dark"
+                style={{ fontFamily: "Inter_600SemiBold" }}
+              >
+                Não deu certo
+              </Text>
+              <Text
+                className="text-sm text-body-secondary dark:text-body-secondary-dark"
+                style={{ fontFamily: "Inter_400Regular" }}
+              >
+                O link pode ter expirado ou já foi usado. Peça um novo pela
+                tela de entrar.
+              </Text>
+            </View>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Tentar de novo"
               onPress={() => router.replace("/login")}
-            />
-          </Card>
+              className="items-center rounded-2xl bg-primary dark:bg-primary-dark py-4 active:opacity-70"
+            >
+              <Text
+                className="text-base text-white dark:text-on-primary-dark"
+                style={{ fontFamily: "Inter_600SemiBold" }}
+              >
+                Tentar de novo
+              </Text>
+            </Pressable>
+          </View>
         )}
       </ScrollView>
     </MyView>

--- a/app/auth/callback.jsx
+++ b/app/auth/callback.jsx
@@ -1,6 +1,12 @@
 // @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
 import { useEffect, useState } from "react";
-import { ActivityIndicator, Pressable, ScrollView, Text, View } from "react-native";
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  Text,
+  View,
+} from "react-native";
 import { router, useLocalSearchParams } from "expo-router";
 
 import MyView from "@/components/MyView";
@@ -100,8 +106,8 @@ export default function AuthCallback() {
                 className="text-sm text-body-secondary dark:text-body-secondary-dark"
                 style={{ fontFamily: "Inter_400Regular" }}
               >
-                O link pode ter expirado ou já foi usado. Peça um novo pela
-                tela de entrar.
+                O link pode ter expirado ou já foi usado. Peça um novo pela tela
+                de entrar.
               </Text>
             </View>
             <Pressable


### PR DESCRIPTION
6ª e **última** tela M5 baseline migrando pro visual v2 — fecha a onda (após #250/#251/#252/#253/#254).

## O que muda em `app/auth/callback.jsx`

Lógica de auth **preservada integralmente**: PKCE (`exchangeCodeForSession`) + fallback hash-flow (`onAuthStateChange` com timeout 3s) + cleanup no useEffect return. Só o visual muda.

- **MyView** `bg-app-dark`, **ScrollView centered** (`flexGrow:1 + justifyContent:center`) — era items-center no top.
- **Estado exchanging**: ActivityIndicator com `color={tokens.primary}` (era default) + copy "Autenticando…" em body-secondary.
- **Estado error**: card branco/border-subtle com title Inter_600 "Não deu certo" + copy body-secondary humana ("O link pode ter expirado ou já foi usado. Peça um novo pela tela de entrar."). Antes mostrava a `message` do erro cru na UI — agora só console.
- **Botão primary** "Tentar de novo" → `/login`.

Detalhe técnico só no console (prefixado `[callback]`) pra debug — mesma regra #216 do login preservada.

## Wiring

- `app/_layout.jsx` do callback já estava com `headerShown:false`; sem mudança lá.

## Fecha a onda

Com este PR, todas as 6 telas M5 baseline (histórico, feedback, roadmap, admin, login, callback) rodam no vocabulário v2 completo. Todos os componentes v2 e M5-migrated respeitam dark mode Turno 3.

Próximo passo: decisões arquiteturais em aberto (tab bar Hoje/Semana/Ajustes, metas editáveis por-usuário, "Sistema" no seletor de tema, lembretes).

## Test plan

- [x] `tsc`, `eslint`, `prettier`, tests limpos.
- [ ] Preview: forçar login pra ver o exchanging (bem rápido) → sucesso redireciona pra /. Testar link expirado (esperar >24h ou reusar link) → estado error com botão "Tentar de novo".

Refs #254 (login), #216 (regra de não vazar erro cru), #207 (auth original).