### PR TITLE
feat(home): display name preference with clean email fallback

### DIFF
--- a/app/ajustes.jsx
+++ b/app/ajustes.jsx
@@ -1,12 +1,22 @@
 // @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
-import { Pressable, ScrollView, Switch, Text, View } from "react-native";
+import { useState } from "react";
+import {
+  Modal,
+  Pressable,
+  ScrollView,
+  Switch,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
 import { router } from "expo-router";
 import { useColorScheme } from "nativewind";
 import Svg, { Path } from "react-native-svg";
+import { useValue } from "tinybase/ui-react";
 
 import MyView from "@/components/MyView";
 
-import { clearAll } from "@/infra/database";
+import { clearAll, setDisplayName, store } from "@/infra/database";
 import { useSession } from "@/infra/session";
 import { AUTH_ENABLED } from "@/infra/supabase";
 import { confirmAction } from "@/constants/dialogs";
@@ -46,6 +56,9 @@ export default function Ajustes() {
   const { user, signOut } = useSession();
   const isDark = colorScheme === "dark";
   const t = useThemeTokens();
+
+  const displayName = useValue("displayName", store);
+  const [nameModalOpen, setNameModalOpen] = useState(false);
 
   function handleClear() {
     confirmAction({
@@ -133,6 +146,14 @@ export default function Ajustes() {
 
         {/* App */}
         <Section title="App">
+          {/* Nome preferido pra saudação da Home. Se vazio, a Home cai no
+              primeiro nome do email do usuário logado. */}
+          <Row
+            label="Como quer ser chamado"
+            value={displayName || "definir"}
+            valueChevron
+            onPress={() => setNameModalOpen(true)}
+          />
           {/* Tema com switch inline (mesmo controle do MenuModal antigo) */}
           <View className="flex-row items-center justify-between border-t border-surface-subtle px-4 py-3">
             <Text
@@ -212,7 +233,140 @@ export default function Ajustes() {
           </Text>
         ) : null}
       </ScrollView>
+
+      {nameModalOpen && (
+        <NameEditModal
+          current={displayName || ""}
+          onClose={() => setNameModalOpen(false)}
+        />
+      )}
     </MyView>
+  );
+}
+
+/** @param {{ current: string, onClose: () => void }} props */
+function NameEditModal({ current, onClose }) {
+  const t = useThemeTokens();
+  const [value, setValue] = useState(current);
+
+  function handleSave() {
+    setDisplayName(value);
+    onClose();
+  }
+
+  return (
+    <Modal transparent animationType="fade" visible onRequestClose={onClose}>
+      <Pressable
+        style={{
+          flex: 1,
+          justifyContent: "center",
+          alignItems: "center",
+          backgroundColor: "rgba(0,0,0,0.4)",
+          padding: 16,
+        }}
+        onPress={onClose}
+      >
+        <View
+          onStartShouldSetResponder={() => true}
+          style={{
+            backgroundColor: t.bgCard,
+            borderRadius: 20,
+            padding: 20,
+            gap: 14,
+            maxWidth: 360,
+            width: "100%",
+          }}
+        >
+          <Text
+            style={{
+              color: t.ink,
+              fontFamily: "Inter_600SemiBold",
+              fontSize: 18,
+            }}
+          >
+            Como quer ser chamado?
+          </Text>
+          <Text
+            style={{
+              color: t.bodySecondary,
+              fontFamily: "Inter_400Regular",
+              fontSize: 13,
+              marginTop: -4,
+            }}
+          >
+            Aparece na saudação da Home. Deixar em branco volta ao primeiro nome
+            do email.
+          </Text>
+          <TextInput
+            value={value}
+            onChangeText={setValue}
+            placeholder="Ana"
+            placeholderTextColor={t.iconDim}
+            autoFocus
+            maxLength={40}
+            accessibilityLabel="Nome preferido"
+            style={{
+              fontFamily: "Inter_500Medium",
+              fontSize: 20,
+              color: t.ink,
+              borderBottomWidth: 1,
+              borderBottomColor: t.borderSubtle,
+              paddingVertical: 6,
+            }}
+          />
+          <View
+            style={{
+              flexDirection: "row",
+              justifyContent: "flex-end",
+              gap: 8,
+              marginTop: 4,
+            }}
+          >
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Cancelar"
+              onPress={onClose}
+              style={{
+                paddingHorizontal: 18,
+                paddingVertical: 10,
+                borderRadius: 12,
+              }}
+            >
+              <Text
+                style={{
+                  color: t.bodySecondary,
+                  fontFamily: "Inter_500Medium",
+                  fontSize: 15,
+                }}
+              >
+                Cancelar
+              </Text>
+            </Pressable>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Salvar"
+              onPress={handleSave}
+              style={{
+                paddingHorizontal: 20,
+                paddingVertical: 10,
+                borderRadius: 12,
+                backgroundColor: t.primary,
+              }}
+            >
+              <Text
+                style={{
+                  color: t.onPrimary,
+                  fontFamily: "Inter_600SemiBold",
+                  fontSize: 15,
+                }}
+              >
+                Salvar
+              </Text>
+            </Pressable>
+          </View>
+        </View>
+      </Pressable>
+    </Modal>
   );
 }
 

--- a/app/index.jsx
+++ b/app/index.jsx
@@ -3,7 +3,7 @@
 import { useMemo, useState } from "react";
 import { Pressable, ScrollView, Text, View } from "react-native";
 import { router } from "expo-router";
-import { useTable } from "tinybase/ui-react";
+import { useTable, useValue } from "tinybase/ui-react";
 
 import MyView from "@/components/MyView";
 import InstallApp from "@/components/InstallApp";
@@ -30,15 +30,28 @@ function formatValue(unit, total) {
   return `${total} ${unit}`;
 }
 
-// Saudação por horário. Design v2 usa "Bom dia, Ana." — nome vem do email
-// do usuário logado; deslogado usa só o cumprimento.
-function getGreeting(user) {
+// Saudação por horário. Design v2 usa "Bom dia, Ana." — o nome vem do
+// `displayName` que o usuário definiu em Ajustes; se não houver, cai no
+// primeiro nome do email (localpart até o primeiro `.`, pra que
+// "matheus.mhddn@gmail.com" vire "Matheus" e não "Matheus.mhddn"). Deslogado
+// sem displayName usa só o cumprimento.
+function getGreeting(user, displayName) {
   const h = new Date().getHours();
   const g = h < 12 ? "Bom dia" : h < 18 ? "Boa tarde" : "Boa noite";
-  if (!user?.email) return `${g}.`;
-  const raw = user.email.split("@")[0];
-  const name = raw.charAt(0).toUpperCase() + raw.slice(1).toLowerCase();
+  const name = pickName(user, displayName);
+  if (!name) return `${g}.`;
   return `${g}, ${name}.`;
+}
+
+function pickName(user, displayName) {
+  const stored = String(displayName ?? "").trim();
+  if (stored) return stored;
+  const email = user?.email;
+  if (!email) return "";
+  const localpart = String(email).split("@")[0] || "";
+  const first = localpart.split(".")[0] || "";
+  if (!first) return "";
+  return first.charAt(0).toUpperCase() + first.slice(1).toLowerCase();
 }
 
 // Dias corridos desde o último registro em qualquer métrica. Null se o store
@@ -94,6 +107,7 @@ export default function Home() {
   // tela lia a store ainda vazia e nunca era avisada quando os dados chegavam,
   // então a Home só mostrava algo depois de ir a outra tela e voltar (#108).
   const records = useTable("records", store);
+  const displayName = useValue("displayName", store);
   // `records` é gatilho de propósito: muda quando a tabela muda (inclui o fim do
   // autoLoad) e força o getToday a reler. O exhaustive-deps não vê que os dois
   // olham os mesmos dados e sugere remover — o que reintroduziria o #108.
@@ -195,7 +209,7 @@ export default function Home() {
               className="text-2xl text-ink dark:text-ink-dark"
               style={{ fontFamily: "Inter_600SemiBold" }}
             >
-              {getGreeting(user)}
+              {getGreeting(user, displayName)}
             </Text>
             <View
               className="items-center justify-center rounded-lg bg-primary dark:bg-primary-dark"

--- a/infra/database.js
+++ b/infra/database.js
@@ -31,6 +31,10 @@ export const store = createMergeableStore()
     // Room ID por install pra sync WS (M6 fatia 3, #202). Gerado no 1º launch
     // (ver infra/persistence.js). Default vazio = sync ainda não inicializado.
     syncRoomId: { type: "string", default: "" },
+    // Como o usuário quer ser chamado no cumprimento da Home. Preferido em
+    // relação à derivação do email — que quando presente cai no primeiro nome
+    // (antes do primeiro ponto). Editável em Ajustes.
+    displayName: { type: "string", default: "" },
   });
 
 // Espalha `details` (JSON) de volta pro topo. É espalhado por último de
@@ -143,6 +147,16 @@ export function getToday() {
 export function clearAll() {
   // Só os registros — a lista de testers (admin) sobrevive ao "limpar dados".
   store.delTable(TABLE);
+}
+
+// --- Display name (Home greeting) ---
+
+export function getDisplayName() {
+  return String(store.getValue("displayName") || "");
+}
+
+export function setDisplayName(name) {
+  store.setValue("displayName", String(name ?? "").trim());
 }
 
 // --- Sync (M6 fatia 3, #202) ---


### PR DESCRIPTION
Fix pequeno na saudação da Home. Emails com pontos no localpart (ex: `matheus.mhddn@gmail.com`) apareciam como "Bom dia, Matheus.mhddn." — feio e não faz sentido pra ninguém.

## Mudança

Duas coisas:

1. **Preferência de nome no store** (`infra/database.js`)
   - Novo value `displayName` no `setValuesSchema` (default `""`).
   - Helpers `getDisplayName()` / `setDisplayName()`.
   - Como faz parte do store, o valor sincroniza pra outros devices do mesmo usuário via M6.

2. **Fallback do email mais limpo** (`app/index.jsx`)
   - `pickName(user, displayName)`: usa `displayName` se presente, senão pega só o **primeiro nome** do email (localpart até o primeiro `.`).
   - `"matheus.mhddn@gmail.com"` → `"Matheus"` (em vez de `"Matheus.mhddn"`).
   - `displayName` ganha até quando o usuário tá deslogado — se ele definiu, vale.
   - Home lê o valor via `useValue("displayName", store)` — reativo, muda na hora após salvar.

3. **Row + modal em Ajustes** (`app/ajustes.jsx`)
   - Row "Como quer ser chamado" na seção "App" (não CONTA, porque a preferência vale mesmo deslogado).
   - Toque abre um `NameEditModal` com `TextInput` autofocus + Cancelar/Salvar.
   - Salvar em branco volta pro fallback do email; o hint no modal explica isso.

## Test plan

- [x] `npm run lint:eslint:check`
- [x] `npm run lint:prettier:check`
- [x] `npm run lint:types:check`
- [x] `npm test` (63/63)
- [ ] Repro manual: Ajustes → "Como quer ser chamado" → digitar "Matheus" → Salvar → Home mostra "Bom dia, Matheus."
- [ ] Deixar em branco → Home volta pro fallback do email (primeiro nome).
- [ ] Deslogar (se auth ligado) e confirmar que o `displayName` continua sendo respeitado.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QB3HffYrtgd1FhQxHc53eQ)_