### PR TITLE
fix(sync): accept ES256 tokens so logged-in clients can sync again

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -90,36 +90,57 @@ Se apertar (concorrência alta, integridade, queries futuras), trocar por SQLite
 
 ## Autenticação (M6 fatia B, #211, ADR-010)
 
-O server valida JWT do Supabase se o cliente mandar `?token=<JWT>` na URL. HS256 verificado com `crypto` nativo (zero dep). Enforça `jwt.sub === pathId` — quem sabe o path sem o token do dono não conecta (403).
+O server valida JWT do Supabase se o cliente mandar `?token=<JWT>` na URL, com `crypto` nativo (zero dep). Enforça `jwt.sub === pathId` — quem sabe o path sem o token do dono não conecta (403).
 
-Duas envs controlam o comportamento:
+**Dois algoritmos são aceitos:**
 
-| Env                   | Default    | Efeito                                                                                                      |
-| --------------------- | ---------- | ----------------------------------------------------------------------------------------------------------- |
-| `AUTH_MODE`           | `optional` | `optional`: aceita anônimo se sem token. `required`: rejeita sem token (401).                               |
-| `SUPABASE_JWT_SECRET` | vazio      | Secret HS256 do projeto Supabase. Obrigatório se `AUTH_MODE=required` OU se algum cliente mandar `?token=`. |
+- **ES256** — o que o Supabase assina hoje. Chaves assimétricas ECC P-256, com `kid` no header. A chave pública vem do JWKS do projeto (`$SUPABASE_URL/auth/v1/.well-known/jwks.json`), cacheada em memória por `kid`. `kid` desconhecido dispara refetch (throttle de 60s pra token forjado não virar DoS contra o endpoint).
+- **HS256** — legado, secret simétrico compartilhado. Mantido pra compat e pros testes.
 
-**Onde pegar o `SUPABASE_JWT_SECRET`:** Supabase Dashboard → Project Settings → API → **JWT Settings** → "JWT Secret". Rotate lá também se precisar. É diferente da `anon key` (que é pública, vai no bundle do app); o JWT Secret NUNCA deve ir pro cliente.
+Envs que controlam o comportamento:
+
+| Env                   | Default    | Efeito                                                                                                             |
+| --------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------ |
+| `AUTH_MODE`           | `optional` | `optional`: aceita anônimo se sem token. `required`: rejeita sem token (401).                                      |
+| `SUPABASE_URL`        | vazio      | URL base do projeto (ex.: `https://abc.supabase.co`). Necessária pra validar **ES256** — dela sai o endpoint JWKS. |
+| `SUPABASE_JWT_SECRET` | vazio      | Secret **HS256** legado. Só necessária se o projeto ainda assina com HS256.                                        |
+
+`AUTH_MODE=required` exige **pelo menos uma** das duas (`SUPABASE_URL` ou `SUPABASE_JWT_SECRET`); sem nenhuma o server aborta no boot. Com `AUTH_MODE=optional` e nenhuma das duas, um cliente que mandar `?token=` leva 500 (recusar é mais seguro que aceitar sem checar).
+
+> ⚠️ **Migração ES256 (agosto/2026).** O Supabase migrou pra chaves assimétricas e passou a assinar com ES256. O server só aceitava HS256, então rejeitava **todo** cliente logado com `401 unsupported alg: ES256` — sync silenciosamente morto em web e mobile (falha só aparecia no console do navegador). Se o seu `.env` só tem `SUPABASE_JWT_SECRET`, **adicione `SUPABASE_URL`** e recrie o container.
+
+**Onde pegar cada uma:**
+
+- `SUPABASE_URL`: Dashboard → Project Settings → API → **Project URL**. É pública (a mesma que vai no bundle do app).
+- `SUPABASE_JWT_SECRET` (legado): Dashboard → Project Settings → API → **JWT Settings** → "JWT Secret". NUNCA deve ir pro cliente.
 
 Adicionar ao `.env` local do server:
 
 ```bash
 cd server
 echo 'AUTH_MODE=optional' >> .env
-echo 'SUPABASE_JWT_SECRET=<colar-o-secret-aqui>' >> .env
+echo 'SUPABASE_URL=https://<project-ref>.supabase.co' >> .env
 chmod 600 .env
 docker compose up -d --build
 ```
 
+Confere no log do boot qual verificador subiu:
+
+```
+[sync] listening on ws://0.0.0.0:8787 — data dir: /data — auth: optional (ES256 via jwks)
+```
+
 ### Matriz de comportamento
 
-| Requisição                          | `AUTH_MODE=optional` | `AUTH_MODE=required` |
-| ----------------------------------- | -------------------- | -------------------- |
-| Sem `?token=`                       | ✅ aceita anônimo    | ❌ 401               |
-| `?token=` válido + `sub === pathId` | ✅ aceita            | ✅ aceita            |
-| `?token=` válido + `sub !== pathId` | ❌ 403               | ❌ 403               |
-| `?token=` assinatura inválida       | ❌ 401               | ❌ 401               |
-| `?token=` expirado                  | ❌ 401               | ❌ 401               |
+| Requisição                             | `AUTH_MODE=optional` | `AUTH_MODE=required` |
+| -------------------------------------- | -------------------- | -------------------- |
+| Sem `?token=`                          | ✅ aceita anônimo    | ❌ 401               |
+| `?token=` válido + `sub === pathId`    | ✅ aceita            | ✅ aceita            |
+| `?token=` válido + `sub !== pathId`    | ❌ 403               | ❌ 403               |
+| `?token=` assinatura inválida          | ❌ 401               | ❌ 401               |
+| `?token=` expirado                     | ❌ 401               | ❌ 401               |
+| `?token=` ES256 com `kid` fora do JWKS | ❌ 401               | ❌ 401               |
+| `?token=` alg não suportado (RS256…)   | ❌ 401               | ❌ 401               |
 
 ### Rollout
 

--- a/server/server.js
+++ b/server/server.js
@@ -6,8 +6,17 @@
 // persistida como JSON no volume ($DATA_DIR, default ./data).
 //
 // Auth (M6 fatia B, #211, ADR-010): quando o cliente manda `?token=<JWT>` na
-// URL, o server valida HS256 com `SUPABASE_JWT_SECRET` e enforça que o `sub`
-// do JWT bate com o pathId — quem sabe o path sem o token do dono não conecta.
+// URL, o server valida a assinatura e enforça que o `sub` do JWT bate com o
+// pathId — quem sabe o path sem o token do dono não conecta.
+//
+// Dois algoritmos são aceitos:
+//   - **ES256** (padrão atual do Supabase): chaves assimétricas ECC P-256. A
+//     chave pública vem do JWKS do projeto (`$SUPABASE_URL/auth/v1/.well-known
+//     /jwks.json`), selecionada pelo `kid` do header. Cache em memória, com
+//     refetch quando aparece um `kid` desconhecido (cobre rotação de chave).
+//   - **HS256** (legado): secret simétrico compartilhado em
+//     `SUPABASE_JWT_SECRET`. Mantido pra projetos que ainda não migraram e
+//     pros testes.
 //
 // AUTH_MODE controla o que fazer com conexões SEM token:
 //   - "optional" (default): aceita anônimo (compat com clientes atuais que
@@ -18,7 +27,12 @@
 // TLS termina no cloudflared do host (ver compose.yml + README). Este processo
 // só fala WS plano na rede interna.
 
-import { createHmac, timingSafeEqual } from "node:crypto";
+import {
+  createHmac,
+  createPublicKey,
+  timingSafeEqual,
+  verify,
+} from "node:crypto";
 import { mkdirSync } from "node:fs";
 import { join, resolve } from "node:path";
 
@@ -31,6 +45,15 @@ const PORT = Number(process.env.PORT ?? 8787);
 const DATA_DIR = resolve(process.env.DATA_DIR ?? "./data");
 const AUTH_MODE = process.env.AUTH_MODE ?? "optional";
 const JWT_SECRET = process.env.SUPABASE_JWT_SECRET ?? "";
+// URL base do projeto Supabase (ex.: https://abc.supabase.co). Necessária pra
+// validar tokens ES256 — é dela que sai o endpoint JWKS.
+const SUPABASE_URL = (process.env.SUPABASE_URL ?? "").replace(/\/+$/, "");
+const JWKS_URL = SUPABASE_URL
+  ? `${SUPABASE_URL}/auth/v1/.well-known/jwks.json`
+  : "";
+
+// Um dos dois é suficiente pra validar token: JWKS (ES256) ou secret (HS256).
+const CAN_VERIFY = Boolean(JWKS_URL || JWT_SECRET);
 
 if (!["optional", "required"].includes(AUTH_MODE)) {
   console.error(
@@ -38,9 +61,9 @@ if (!["optional", "required"].includes(AUTH_MODE)) {
   );
   process.exit(1);
 }
-if (AUTH_MODE === "required" && !JWT_SECRET) {
+if (AUTH_MODE === "required" && !CAN_VERIFY) {
   console.error(
-    "[sync] fatal: AUTH_MODE=required requires SUPABASE_JWT_SECRET",
+    "[sync] fatal: AUTH_MODE=required requires SUPABASE_URL (ES256) or SUPABASE_JWT_SECRET (HS256)",
   );
   process.exit(1);
 }
@@ -61,23 +84,81 @@ function base64UrlDecode(str) {
   return Buffer.from(b64, "base64");
 }
 
-// Verifica HS256 JWT contra JWT_SECRET. Retorna o payload decodificado.
-// Lança em qualquer inconsistência (formato, alg, assinatura, expiração, sub).
-function verifyJwt(token) {
+// Cache de chaves públicas do JWKS, indexado por `kid`. O Supabase rotaciona
+// chaves raramente; um kid desconhecido dispara refetch (com throttle pra um
+// token forjado não virar vetor de DoS contra o endpoint).
+const jwksCache = new Map();
+let jwksFetchedAt = 0;
+const JWKS_MIN_REFETCH_MS = 60_000;
+
+async function fetchJwks() {
+  if (!JWKS_URL) throw new Error("SUPABASE_URL not set, cannot verify ES256");
+  const now = Date.now();
+  if (now - jwksFetchedAt < JWKS_MIN_REFETCH_MS && jwksCache.size > 0) {
+    // Refetch recente demais — usa o cache atual (kid segue desconhecido).
+    return;
+  }
+  jwksFetchedAt = now;
+  const res = await fetch(JWKS_URL);
+  if (!res.ok) throw new Error(`jwks fetch failed: ${res.status}`);
+  const { keys } = await res.json();
+  if (!Array.isArray(keys)) throw new Error("jwks has no keys array");
+  jwksCache.clear();
+  for (const jwk of keys) {
+    if (!jwk.kid) continue;
+    try {
+      jwksCache.set(jwk.kid, createPublicKey({ key: jwk, format: "jwk" }));
+    } catch (e) {
+      console.warn(`[sync] skipping unusable jwk kid=${jwk.kid}: ${e.message}`);
+    }
+  }
+  console.log(`[sync] jwks loaded: ${jwksCache.size} key(s)`);
+}
+
+async function getPublicKey(kid) {
+  if (!kid) throw new Error("no kid in header");
+  if (!jwksCache.has(kid)) await fetchJwks();
+  const key = jwksCache.get(kid);
+  if (!key) throw new Error(`unknown kid: ${kid}`);
+  return key;
+}
+
+// Verifica JWT (ES256 via JWKS, ou HS256 via secret). Retorna o payload
+// decodificado. Lança em qualquer inconsistência (formato, alg, assinatura,
+// expiração, sub).
+async function verifyJwt(token) {
   const parts = token.split(".");
   if (parts.length !== 3) throw new Error("malformed jwt");
   const [headerB64, payloadB64, sigB64] = parts;
 
   const header = JSON.parse(base64UrlDecode(headerB64).toString("utf8"));
-  if (header.alg !== "HS256") throw new Error(`unsupported alg: ${header.alg}`);
-
   const signingInput = `${headerB64}.${payloadB64}`;
-  const expected = createHmac("sha256", JWT_SECRET)
-    .update(signingInput)
-    .digest();
   const actual = base64UrlDecode(sigB64);
-  if (expected.length !== actual.length || !timingSafeEqual(expected, actual)) {
-    throw new Error("invalid signature");
+
+  if (header.alg === "ES256") {
+    const key = await getPublicKey(header.kid);
+    // Assinatura JWT ES256 é R||S cru (64 bytes), não DER — daí o
+    // dsaEncoding ieee-p1363, senão o Node rejeita tudo como inválido.
+    const ok = verify(
+      "sha256",
+      Buffer.from(signingInput),
+      { key, dsaEncoding: "ieee-p1363" },
+      actual,
+    );
+    if (!ok) throw new Error("invalid signature");
+  } else if (header.alg === "HS256") {
+    if (!JWT_SECRET) throw new Error("HS256 token but no SUPABASE_JWT_SECRET");
+    const expected = createHmac("sha256", JWT_SECRET)
+      .update(signingInput)
+      .digest();
+    if (
+      expected.length !== actual.length ||
+      !timingSafeEqual(expected, actual)
+    ) {
+      throw new Error("invalid signature");
+    }
+  } else {
+    throw new Error(`unsupported alg: ${header.alg}`);
   }
 
   const payload = JSON.parse(base64UrlDecode(payloadB64).toString("utf8"));
@@ -96,27 +177,31 @@ const wss = new WebSocketServer({
     const token = url.searchParams.get("token");
 
     if (token) {
-      if (!JWT_SECRET) {
+      if (!CAN_VERIFY) {
         // Cliente mandou token mas o server não pode validar. Recusar é mais
         // seguro que aceitar sem checar.
         console.error(
-          "[sync] rejecting: token sent but SUPABASE_JWT_SECRET not set",
+          "[sync] rejecting: token sent but neither SUPABASE_URL nor SUPABASE_JWT_SECRET set",
         );
-        return callback(false, 500, "server missing SUPABASE_JWT_SECRET");
+        return callback(false, 500, "server cannot verify tokens");
       }
-      try {
-        const payload = verifyJwt(token);
-        if (payload.sub !== pathId) {
-          console.warn(
-            `[sync] rejecting: jwt.sub="${payload.sub}" != pathId="${pathId}"`,
-          );
-          return callback(false, 403, "sub != pathId");
-        }
-        return callback(true);
-      } catch (e) {
-        console.warn(`[sync] rejecting: invalid token: ${e.message}`);
-        return callback(false, 401, `invalid token: ${e.message}`);
-      }
+      // verifyJwt é async (JWKS pode precisar de fetch) — o callback do
+      // verifyClient aceita resolução assíncrona.
+      verifyJwt(token)
+        .then((payload) => {
+          if (payload.sub !== pathId) {
+            console.warn(
+              `[sync] rejecting: jwt.sub="${payload.sub}" != pathId="${pathId}"`,
+            );
+            return callback(false, 403, "sub != pathId");
+          }
+          return callback(true);
+        })
+        .catch((e) => {
+          console.warn(`[sync] rejecting: invalid token: ${e.message}`);
+          callback(false, 401, `invalid token: ${e.message}`);
+        });
+      return;
     }
 
     if (AUTH_MODE === "required") {
@@ -136,6 +221,13 @@ createWsServer(wss, (pathId) =>
   ),
 );
 
+const verifiers = [
+  JWKS_URL ? "ES256 via jwks" : null,
+  JWT_SECRET ? "HS256 via secret" : null,
+]
+  .filter(Boolean)
+  .join(" + ");
+
 console.log(
-  `[sync] listening on ws://0.0.0.0:${PORT} — data dir: ${DATA_DIR} — auth: ${AUTH_MODE}${JWT_SECRET ? " (secret loaded)" : ""}`,
+  `[sync] listening on ws://0.0.0.0:${PORT} — data dir: ${DATA_DIR} — auth: ${AUTH_MODE}${verifiers ? ` (${verifiers})` : ""}`,
 );

--- a/tests/sync-server-auth.test.js
+++ b/tests/sync-server-auth.test.js
@@ -5,8 +5,14 @@
 // handshake HTTP → WebSocket. Testa o CÓDIGO da auth, sem depender de rede.
 
 import { spawn } from "node:child_process";
-import { createHmac } from "node:crypto";
+import {
+  createHmac,
+  generateKeyPairSync,
+  randomUUID,
+  sign as cryptoSign,
+} from "node:crypto";
 import { mkdtempSync, rmSync } from "node:fs";
+import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
@@ -41,6 +47,45 @@ function signJwt(payload, { secret = JWT_SECRET, alg = "HS256" } = {}) {
     createHmac("sha256", secret).update(signingInput).digest(),
   );
   return `${signingInput}.${sig}`;
+}
+
+// --- Helpers ES256 (o que o Supabase usa hoje) ----------------------------
+
+/** Gera par ECC P-256 + o JWK público com um kid. */
+function makeEs256Key(kid = randomUUID()) {
+  const { publicKey, privateKey } = generateKeyPairSync("ec", {
+    namedCurve: "P-256",
+  });
+  const jwk = { ...publicKey.export({ format: "jwk" }), kid, alg: "ES256" };
+  return { kid, jwk, privateKey };
+}
+
+/** Assina um JWT ES256. Assinatura é R||S cru (ieee-p1363), como manda o JWS. */
+function signEs256({ payload, kid, privateKey }) {
+  const header = b64url(JSON.stringify({ alg: "ES256", kid, typ: "JWT" }));
+  const body = b64url(JSON.stringify(payload));
+  const signingInput = `${header}.${body}`;
+  const sig = cryptoSign("sha256", Buffer.from(signingInput), {
+    key: privateKey,
+    dsaEncoding: "ieee-p1363",
+  });
+  return `${signingInput}.${b64urlSig(sig)}`;
+}
+
+/** Sobe um http server servindo /auth/v1/.well-known/jwks.json. */
+async function startJwksServer(jwks) {
+  const server = createServer((req, res) => {
+    if (req.url === "/auth/v1/.well-known/jwks.json") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ keys: jwks }));
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+  await new Promise((r) => server.listen(0, "127.0.0.1", r));
+  const { port } = server.address();
+  return { server, url: `http://127.0.0.1:${port}` };
 }
 
 function futureExp(seconds = 3600) {
@@ -220,5 +265,89 @@ describe("AUTH_MODE=required (fase final, após migração)", () => {
     const token = signJwt({ sub: "alice", exp: futureExp() });
     const res = await tryConnect(server.port, "alice", token);
     expect(res).toEqual({ open: true });
+  });
+});
+
+// --- ES256 via JWKS (o que o Supabase assina hoje) ------------------------
+//
+// Regressão do bug real: o Supabase migrou pra chaves assimétricas e passou a
+// assinar com ES256+kid. O server só aceitava HS256, então rejeitava TODO
+// cliente logado com 401 — sync silenciosamente morto em web e mobile.
+
+describe("ES256 via JWKS", () => {
+  let server;
+  let jwksServer;
+  let key;
+  let otherKey;
+
+  beforeAll(async () => {
+    key = makeEs256Key();
+    otherKey = makeEs256Key();
+    // Só a chave "boa" é publicada no JWKS; a outra serve pra forjar token.
+    jwksServer = await startJwksServer([key.jwk]);
+    server = await startServer({
+      AUTH_MODE: "required",
+      SUPABASE_URL: jwksServer.url,
+    });
+  }, 10000);
+
+  afterAll(async () => {
+    await stopServer(server);
+    if (jwksServer) await new Promise((r) => jwksServer.server.close(r));
+  });
+
+  test("ES256 válido + sub === pathId: aceita", async () => {
+    const token = signEs256({
+      payload: { sub: "alice", exp: futureExp() },
+      kid: key.kid,
+      privateKey: key.privateKey,
+    });
+    const res = await tryConnect(server.port, "alice", token);
+    expect(res).toEqual({ open: true });
+  });
+
+  test("ES256 válido + sub !== pathId: rejeita com 403", async () => {
+    const token = signEs256({
+      payload: { sub: "alice", exp: futureExp() },
+      kid: key.kid,
+      privateKey: key.privateKey,
+    });
+    const res = await tryConnect(server.port, "bob", token);
+    expect(res.open).toBe(false);
+    expect(res.code).toBe(403);
+  });
+
+  test("ES256 assinado por chave fora do JWKS: rejeita com 401", async () => {
+    // kid conhecido, chave privada errada — assinatura não confere.
+    const token = signEs256({
+      payload: { sub: "alice", exp: futureExp() },
+      kid: key.kid,
+      privateKey: otherKey.privateKey,
+    });
+    const res = await tryConnect(server.port, "alice", token);
+    expect(res.open).toBe(false);
+    expect(res.code).toBe(401);
+  });
+
+  test("ES256 com kid desconhecido: rejeita com 401", async () => {
+    const token = signEs256({
+      payload: { sub: "alice", exp: futureExp() },
+      kid: otherKey.kid,
+      privateKey: otherKey.privateKey,
+    });
+    const res = await tryConnect(server.port, "alice", token);
+    expect(res.open).toBe(false);
+    expect(res.code).toBe(401);
+  });
+
+  test("ES256 expirado: rejeita com 401", async () => {
+    const token = signEs256({
+      payload: { sub: "alice", exp: pastExp() },
+      kid: key.kid,
+      privateKey: key.privateKey,
+    });
+    const res = await tryConnect(server.port, "alice", token);
+    expect(res.open).toBe(false);
+    expect(res.code).toBe(401);
   });
 });


### PR DESCRIPTION
Sync estava **morto pra todo cliente logado**, em web e mobile, sem nenhum sinal na UI.

## Causa raiz

Log do console em produção, logo após o login:

```
WebSocket connection to 'wss://backontrack-sync.mhdn.com.br/00c5fe3b-…?token=eyJhbGciOiJFUzI1NiIsImtpZCI6…' failed:
```

Decodificando o header do JWT:

```json
{ "alg": "ES256", "kid": "bfb23fdb-30c9-4df1-9428-3634c9c20e54", "typ": "JWT" }
```

E `server/server.js:72` (antes desta mudança):

```js
if (header.alg !== "HS256") throw new Error(`unsupported alg: ${header.alg}`);
```

O Supabase migrou pra **chaves assimétricas** e passou a assinar com ES256 (ECC P-256, com `kid`). O server só sabia validar HS256 contra o `SUPABASE_JWT_SECRET` compartilhado, então `verifyJwt` lançava antes de olhar qualquer outra coisa e o `verifyClient` recusava com 401.

O `sub` do token (`00c5fe3b-…`) **bate exatamente** com o pathId — derivação de sala sempre esteve certa. Só a verificação de assinatura que quebrou.

Como a falha do WS é engolida por um `console.warn` em `infra/sync.js`, o app seguia funcionando normalmente e ninguém percebia que nada estava subindo.

## Mudança

`verifyJwt` passa a ramificar em `header.alg`:

- **ES256** — busca a chave pública no JWKS do projeto (`$SUPABASE_URL/auth/v1/.well-known/jwks.json`), cacheia por `kid`, e refetcha quando aparece um `kid` desconhecido (throttle de 60s pra token forjado não virar DoS contra o endpoint). Assinatura verificada com `dsaEncoding: "ieee-p1363"` — JWS ES256 usa R||S cru, não DER; sem isso o Node rejeita tudo como inválido.
- **HS256** — inalterado, segue validando contra `SUPABASE_JWT_SECRET`.

Ajustes de contorno:

- `verifyClient` resolve a verificação assíncrona pelo callback (JWKS pode precisar de fetch).
- `AUTH_MODE=required` agora aceita **uma das duas** envs (`SUPABASE_URL` ou `SUPABASE_JWT_SECRET`) em vez de exigir a do HS256.
- Token chegando sem nenhuma das duas configuradas → 500 (recusar é mais seguro que aceitar sem checar).
- Log de boot diz qual verificador subiu: `auth: optional (ES256 via jwks)`.

## Dados

Nada foi perdido. Os registros continuam no store local de cada cliente e replicam pra cima assim que o server aceitar a conexão.

## Deploy necessário

O `.env` do server precisa ganhar `SUPABASE_URL`:

```bash
cd server
echo 'SUPABASE_URL=https://<project-ref>.supabase.co' >> .env
docker compose up -d --build
```

Confirmar no log: `[sync] listening on … auth: optional (ES256 via jwks)`.

## Test plan

- [x] `npm run lint:eslint:check`
- [x] `npm run lint:prettier:check`
- [x] `npm run lint:types:check`
- [x] `npm test` — 68/68 (5 testes novos)

Os 5 novos cobrem o caminho ES256 com um JWKS servido por http local e par ECC gerado no teste: aceite com `sub === pathId`, 403 com `sub` divergente, 401 com assinatura de chave fora do JWKS, 401 com `kid` desconhecido, 401 com token expirado.

- [ ] Deploy no homeserver + confirmar log de boot.
- [ ] Logar no web, confirmar que o WS abre (101 no Network) e os registros do celular aparecem.

## Follow-up sugerido

Este bug ficou invisível porque não existe UI de status de sync — já listado como pendente do M6 no roadmap, junto com auto-reconnect. Vale abrir issue própria; um indicador teria transformado isso de "descoberta por acaso semanas depois" em "vi na hora".

---
_Generated by [Claude Code](https://claude.ai/code/session_01QB3HffYrtgd1FhQxHc53eQ)_