### PR TITLE
fix(sync): reconnect websocket automatically after a drop

### DIFF
--- a/infra/sync-retry.js
+++ b/infra/sync-retry.js
@@ -1,0 +1,42 @@
+// @ts-nocheck -- helper puro; tipos vêm quando toda a infra/ for tipada (ADR-002)
+
+/**
+ * Backoff exponencial com full jitter pro reconnect do sync WS.
+ *
+ * Isolado num arquivo próprio pelo mesmo motivo do `sync-url.js`: é lógica
+ * pura, testável sem puxar `infra/sync.js` (que importa Supabase/AsyncStorage
+ * e não roda no jest).
+ *
+ * **Por que jitter:** quando o server reinicia, todos os clientes caem no
+ * mesmo instante. Sem jitter eles voltam juntos no mesmo milissegundo e
+ * derrubam de novo (thundering herd). Full jitter espalha cada cliente por
+ * uma janela aleatória — sorteia em `[delay/2, delay]` em vez de sempre usar
+ * o teto.
+ */
+
+export const BASE_RETRY_DELAY_MS = 1_000;
+export const MAX_RETRY_DELAY_MS = 30_000;
+
+/**
+ * Delay até a próxima tentativa.
+ *
+ * Progressão sem jitter: 1s, 2s, 4s, 8s, 16s, 30s, 30s… (teto em 30s pra a
+ * reconexão não ficar minutos parada depois de uma queda longa).
+ *
+ * @param {number} attempt Tentativas já falhadas (0 = primeira retentativa).
+ * @param {{ base?: number, max?: number, random?: () => number }} [opts]
+ * @returns {number} Milissegundos a esperar.
+ */
+export function retryDelay(attempt, opts = {}) {
+  const {
+    base = BASE_RETRY_DELAY_MS,
+    max = MAX_RETRY_DELAY_MS,
+    random = Math.random,
+  } = opts;
+  const n = Math.max(0, Math.floor(Number(attempt) || 0));
+  // 2**n cresce rápido; capar ANTES do jitter evita overflow em n alto.
+  const capped = Math.min(max, base * 2 ** Math.min(n, 30));
+  // Full jitter na metade de cima: mantém progressão perceptível sem
+  // sincronizar clientes.
+  return Math.round(capped * (0.5 + 0.5 * random()));
+}

--- a/infra/sync.js
+++ b/infra/sync.js
@@ -1,40 +1,58 @@
 // @ts-nocheck -- useSession retorna contexto tipado como never no tsc (ADR-002)
+import { useCallback, useEffect, useRef, useState } from "react";
+import { AppState } from "react-native";
 import { createWsSynchronizer } from "tinybase/synchronizers/synchronizer-ws-client";
 import { useCreateSynchronizer, useValue } from "tinybase/ui-react";
 import { SYNC_URL } from "@/constants/sync";
 import { store } from "./database";
 import { useSession } from "./session";
 import { buildSyncUrl } from "./sync-url";
+import { retryDelay } from "./sync-retry";
 
 // Re-exporta pra manter API estável (callers antigos podem importar de sync.js).
 // A implementação vive em infra/sync-url.js pra ficar testável isolado
 // (evita puxar Supabase/AsyncStorage no jest).
 export { buildSyncUrl };
 
+/** Estados possíveis de `useRegistrosSync`. */
+export const SYNC_OFF = "off";
+export const SYNC_CONNECTING = "connecting";
+export const SYNC_ONLINE = "online";
+export const SYNC_OFFLINE = "offline";
+
 /**
- * Conecta o MergeableStore ao server WS de sync.
+ * Conecta o MergeableStore ao server WS de sync, com reconexão automática.
  *
  * - **Deslogado** (session null): usa `syncRoomId` (UUID por-install) como
- *   pathId, sem `?token=`. É o comportamento pré-auth (M6 fatia 3, #202) —
- *   mantém compat enquanto o server roda em `AUTH_MODE=optional`.
+ *   pathId, sem `?token=`. É o comportamento pré-auth (M6 fatia 3, #202).
  * - **Logado** (session presente): usa `user.id` como pathId + JWT do Supabase
- *   em `?token=`. Server valida HS256 + enforça `sub === pathId` (fatia B,
- *   #211). Migração dos dados anônimos pra sala do userId acontece
- *   automaticamente na 1ª conexão: MergeableStore CRDT-merge sobe os dados
- *   locais pra sala nova (server-side JSON, [[sync-server-and-cloudflare-tunnel]]).
+ *   em `?token=`. Server valida a assinatura e enforça `sub === pathId`.
  *
- * Reconecta em toda troca de `roomId` ou `token` — cobre login, logout, e
- * refresh silencioso do token (Supabase renova em ~1h, dispara
- * `onAuthStateChange('TOKEN_REFRESHED')` que atualiza a session no provider).
+ * ## Por que a reconexão precisa observar o socket na mão
+ *
+ * `createWsSynchronizer` **resolve mesmo quando a conexão falha** — ele
+ * escuta `open` E `error` e resolve nos dois casos (ver
+ * `synchronizers/synchronizer-ws-client`). Então um 401 do server produz um
+ * synchronizer "válido" envolvendo um socket morto, e nenhum `catch` dispara.
+ * Foi assim que a quebra do ES256 passou semanas invisível: sem exceção, sem
+ * log, sem sintoma além de "os dados não aparecem no outro aparelho".
+ *
+ * Por isso escutamos `close`/`error` do WebSocket direto, em vez de confiar
+ * na promise.
+ *
+ * ## Como a reconexão funciona
+ *
+ * Ao cair, agenda nova tentativa com backoff exponencial + jitter
+ * (`sync-retry.js`). Cada tentativa recria o synchronizer inteiro — bumpar
+ * `generation` muda as deps do `useCreateSynchronizer`, que derruba o antigo
+ * e monta um novo. Voltar pro foreground (`AppState` → `active`) reconecta
+ * na hora, sem esperar o backoff: o SO costuma matar o socket em background
+ * e o usuário que reabre o app quer sync imediato.
  *
  * Depende do `useRegistrosPersistencia` já ter rodado — é ele quem carrega o
- * `syncRoomId` do disco (ou gera no 1º launch). Sem esse gate, o sync abriria
- * numa sala vazia e migraria pra outra assim que o load completasse.
+ * `syncRoomId` do disco (ou gera no 1º launch).
  *
- * Falhas de rede (offline, DNS, TLS) NÃO quebram o app: a persistência local
- * segue funcionando; o sync fica dormente até a próxima abertura. Reconexão
- * automática ficou fora de escopo (o WS do TinyBase não reconecta sozinho; se
- * cair no meio do uso, a próxima abertura sincroniza tudo).
+ * @returns {"off"|"connecting"|"online"|"offline"} Estado atual, pra UI.
  */
 export function useRegistrosSync() {
   const { user, session } = useSession();
@@ -46,25 +64,116 @@ export function useRegistrosSync() {
   const token = session?.access_token ?? null;
   const url = buildSyncUrl(SYNC_URL, roomId, token);
 
+  const [status, setStatus] = useState(url ? SYNC_CONNECTING : SYNC_OFF);
+  // Só cresce; entra nas deps pra forçar recriação do synchronizer.
+  const [generation, setGeneration] = useState(0);
+
+  // Expoente do backoff. Ref (não state) de propósito: zerar no sucesso não
+  // pode mudar deps, senão derrubaria a conexão que acabou de subir.
+  const retryExpRef = useRef(0);
+  const retryTimerRef = useRef(null);
+  // Socket da tentativa corrente. Usado pra ignorar `close` de conexões
+  // obsoletas — na troca de deps o create do novo roda ANTES do destroy do
+  // antigo, então o close do antigo chegaria depois e agendaria retry à toa.
+  const currentWsRef = useRef(null);
+  const mountedRef = useRef(true);
+
+  const clearRetry = useCallback(() => {
+    if (retryTimerRef.current) {
+      clearTimeout(retryTimerRef.current);
+      retryTimerRef.current = null;
+    }
+  }, []);
+
+  const reconnectNow = useCallback(() => {
+    clearRetry();
+    retryExpRef.current = 0;
+    setGeneration((g) => g + 1);
+  }, [clearRetry]);
+
+  // URL nova (login, logout, refresh de token) = contexto novo: zera backoff.
+  useEffect(() => {
+    retryExpRef.current = 0;
+    clearRetry();
+  }, [url, clearRetry]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      clearRetry();
+    };
+  }, [clearRetry]);
+
+  // Voltar pro foreground reconecta na hora se estiver caído — não espera o
+  // backoff, que pode estar no teto de 30s.
+  useEffect(() => {
+    // No web o AppState devolve `undefined` quando não há `document`
+    // (prerender do `expo export`) — sem a guarda, o cleanup quebraria o
+    // build. Native sempre devolve subscription.
+    const sub = AppState.addEventListener?.("change", (next) => {
+      if (next !== "active") return;
+      const ws = currentWsRef.current;
+      // readyState 1 = OPEN. Qualquer outra coisa = reconectar.
+      if (!ws || ws.readyState !== 1) reconnectNow();
+    });
+    return () => sub?.remove?.();
+  }, [reconnectNow]);
+
   useCreateSynchronizer(
     store,
     async (s) => {
-      if (!url) return undefined;
+      if (!url) {
+        setStatus(SYNC_OFF);
+        return undefined;
+      }
+      setStatus(SYNC_CONNECTING);
+
+      const ws = new WebSocket(url);
+      currentWsRef.current = ws;
+
+      const onDown = () => {
+        // Conexão obsoleta (já trocamos de socket) ou hook desmontado:
+        // não mexer em estado nem agendar nada.
+        if (currentWsRef.current !== ws || !mountedRef.current) return;
+        if (retryTimerRef.current) return; // retry já agendado
+        setStatus(SYNC_OFFLINE);
+        const delay = retryDelay(retryExpRef.current);
+        retryExpRef.current += 1;
+        retryTimerRef.current = setTimeout(() => {
+          retryTimerRef.current = null;
+          if (mountedRef.current) setGeneration((g) => g + 1);
+        }, delay);
+      };
+
+      ws.addEventListener("close", onDown);
+      ws.addEventListener("error", onDown);
+
       try {
-        // WebSocket é global tanto no RN quanto no web — sem import.
-        const ws = new WebSocket(url);
         const sync = await createWsSynchronizer(s, ws);
         await sync.startSync();
+        // Não confiar na promise: ela resolve mesmo em erro. O readyState é
+        // que diz se a conexão está de pé.
+        if (ws.readyState === 1) {
+          if (currentWsRef.current === ws && mountedRef.current) {
+            retryExpRef.current = 0;
+            setStatus(SYNC_ONLINE);
+          }
+        } else {
+          onDown();
+        }
         return sync;
       } catch (err) {
-        // Não relançar: offline não deve travar o app.
         const msg = err instanceof Error ? err.message : String(err);
         console.warn("[sync] falhou ao conectar:", msg);
+        onDown();
         return undefined;
       }
     },
-    // Rerun em qualquer mudança do URL — login/logout muda roomId+token juntos;
-    // TOKEN_REFRESHED muda só o token. Ambos precisam de reconexão.
-    [url],
+    // Reconecta em troca de URL (login/logout/token refresh) e a cada
+    // tentativa agendada pelo backoff.
+    [url, generation],
   );
+
+  return status;
 }

--- a/tests/sync-retry.test.js
+++ b/tests/sync-retry.test.js
@@ -1,0 +1,73 @@
+// @ts-nocheck -- teste; globals do jest não são tipados (ADR-002)
+// Testa o backoff do reconnect do sync WS. É o pedaço puro da correção do
+// auto-reconnect — a parte onde bug moraria (crescimento errado, teto que
+// não segura, jitter que sincroniza todo mundo, entrada negativa/absurda).
+//
+// Contexto: sem reconexão, uma queda de WS deixava o app sem sync até o
+// próximo launch. Foi o que fez a quebra do ES256 durar semanas.
+
+import {
+  retryDelay,
+  BASE_RETRY_DELAY_MS,
+  MAX_RETRY_DELAY_MS,
+} from "../infra/sync-retry";
+
+// random fixo tira o jitter da conta e deixa a progressão determinística:
+// 0.5 + 0.5*1 = 1, ou seja, o delay cheio.
+const noJitter = () => 1;
+// 0.5 + 0.5*0 = 0.5, o piso da janela.
+const minJitter = () => 0;
+
+describe("retryDelay", () => {
+  test("cresce exponencial a partir do base", () => {
+    const d = (n) => retryDelay(n, { random: noJitter });
+    expect(d(0)).toBe(BASE_RETRY_DELAY_MS); // 1s
+    expect(d(1)).toBe(BASE_RETRY_DELAY_MS * 2); // 2s
+    expect(d(2)).toBe(BASE_RETRY_DELAY_MS * 4); // 4s
+    expect(d(3)).toBe(BASE_RETRY_DELAY_MS * 8); // 8s
+  });
+
+  test("respeita o teto — queda longa não vira espera de minutos", () => {
+    const d = (n) => retryDelay(n, { random: noJitter });
+    expect(d(10)).toBe(MAX_RETRY_DELAY_MS);
+    expect(d(50)).toBe(MAX_RETRY_DELAY_MS);
+    // Sem o cap antes do 2**n, expoente alto estouraria pra Infinity.
+    expect(Number.isFinite(d(1000))).toBe(true);
+    expect(d(1000)).toBe(MAX_RETRY_DELAY_MS);
+  });
+
+  test("jitter mantém o delay em [metade, cheio] — nunca zero", () => {
+    for (const n of [0, 1, 5, 99]) {
+      const cheio = retryDelay(n, { random: noJitter });
+      const piso = retryDelay(n, { random: minJitter });
+      expect(piso).toBe(Math.round(cheio * 0.5));
+      expect(piso).toBeGreaterThan(0);
+      // Amostra real: sempre dentro da janela.
+      for (let i = 0; i < 50; i++) {
+        const real = retryDelay(n);
+        expect(real).toBeGreaterThanOrEqual(piso);
+        expect(real).toBeLessThanOrEqual(cheio);
+      }
+    }
+  });
+
+  test("jitter de fato espalha — clientes não voltam todos juntos", () => {
+    // 200 "clientes" caindo na mesma tentativa devem produzir delays variados.
+    // Sem jitter, todos retornariam o mesmo valor e derrubariam o server de novo.
+    const amostras = new Set();
+    for (let i = 0; i < 200; i++) amostras.add(retryDelay(5));
+    expect(amostras.size).toBeGreaterThan(50);
+  });
+
+  test("entrada inválida não quebra nem produz delay negativo", () => {
+    for (const bad of [-1, -999, NaN, undefined, null, "abc"]) {
+      const d = retryDelay(bad, { random: noJitter });
+      expect(d).toBe(BASE_RETRY_DELAY_MS);
+    }
+  });
+
+  test("base e max são configuráveis", () => {
+    const d = retryDelay(3, { base: 100, max: 500, random: noJitter });
+    expect(d).toBe(500); // 100*8=800, capado em 500
+  });
+});


### PR DESCRIPTION
Primeira das três fatias que atacam o motivo de a quebra do ES256 (#262) ter passado semanas invisível.

## A descoberta que motivou o desenho

`createWsSynchronizer` **não rejeita quando a conexão falha**. Ele escuta `open` E `error` e resolve nos dois casos:

```js
const onAttempt = (error) => {
  if (error) { onIgnoredError?.(error); }
  removeOpenListener();
  removeErrorListener();
  resolve(synchronizer);   // ← resolve mesmo com erro
};
```

Consequência: o 401 do server produzia um synchronizer "válido" envolvendo um socket morto. O `try/catch` que existia era código morto pra esse caminho — nem o `console.warn` disparava. Somado à falta de retry, o app ficava sem sync até o próximo launch, sem nenhum sintoma além de "os dados não aparecem no outro aparelho".

Foi exatamente o que aconteceu ontem: o deploy do servidor corrigiu o 401, mas o app só voltou a sincronizar quando o OTA forçou um reload do processo. Um force-stop teria dado o mesmo resultado — e nenhum tester tinha como saber disso.

## O que muda

- **Observa o socket, não a promise.** `close`/`error` do WebSocket disparam o retry; `readyState` é o que decide se subiu.
- **Backoff exponencial com full jitter** (`infra/sync-retry.js`): 1s → 2s → 4s → 8s → 16s → 30s (teto). Jitter sorteia em `[delay/2, delay]` pra 200 clientes não voltarem juntos quando o server reinicia.
- **Foreground reconecta na hora.** `AppState` → `active` com socket fechado pula o backoff — o SO mata o socket em background e quem reabre o app quer sync imediato.
- **Backoff zera no sucesso**, então uma queda depois de conexão saudável recupera em ~1s.
- **Hook devolve o estado** (`off`/`connecting`/`online`/`offline`) pra fatia 2 (banner de sync) consumir. Caller atual ignora — mudança compatível.

## Detalhes de implementação que não são óbvios

- **`generation` (state) separado do expoente do backoff (ref).** Zerar o expoente no sucesso não pode mexer nas deps, senão derrubaria a conexão que acabou de subir.
- **Guarda de socket obsoleto.** Na troca de deps o `create` do novo roda ANTES do `destroy` do antigo (o effect de destroy depende de `synchronizer`). Sem comparar contra `currentWsRef`, o `close` do socket antigo agendaria um retry à toa.
- **`AppState.addEventListener?.()` com optional chaining.** No `react-native-web` ele devolve `undefined` quando não há `document` (prerender do `expo export`) — sem a guarda, o cleanup quebrava o build web. Verificado no fonte do `react-native-web`.

## Fora de escopo (próximas fatias)

- **Fatia 2:** banner de estado do sync — hoje a falha segue invisível pro usuário, só muda de `console.warn` pra estado não consumido.
- **Fatia 3:** log de conexão aceita no server — sem isso não dá pra notar "zero conexões autenticadas há 3 dias" sem inspecionar arquivo de sala na mão.

## Test plan

- [x] `tests/sync-retry.test.js` (6 casos): progressão exponencial, teto, janela do jitter, dispersão real com 200 amostras, entrada inválida (`NaN`/negativo/string) sem delay negativo, base/max configuráveis.
- [x] `npm test` — 74/74 (era 68).
- [x] `tsc --noEmit`, `eslint .`, `prettier --check` limpos.
- [ ] Smoke manual pós-merge: com o app aberto, `docker compose restart sync` no homeserver e confirmar que o sync volta sozinho em segundos, sem reiniciar o app.