### PR TITLE
fix(ui): persist theme choice and repair back button after reload

### DIFF
--- a/app/_layout.jsx
+++ b/app/_layout.jsx
@@ -18,10 +18,14 @@ import {
 import { useRegistrosPersistencia } from "@/infra/persistence";
 import { SessionProvider } from "@/infra/session";
 import { useRegistrosSync } from "@/infra/sync";
+import { useRestoreThemePreference } from "@/infra/theme";
 import UpdateBanner from "@/components/UpdateBanner";
 
 export default function RootLayout() {
   useRegistrosPersistencia();
+  // Restaura claro/escuro escolhido em Ajustes. Sem isso o toggle só valia
+  // até o próximo reload (o NativeWind guarda em memória). Ver infra/theme.js.
+  useRestoreThemePreference();
   // Fontes do design v2 (M5-B fatia 0). Carrega em background; se ainda não
   // tiver terminado, sistema serve o fallback e a UI re-renderiza quando
   // ficarem prontas. Não bloqueia boot pra não introduzir splash extra —

--- a/app/admin.jsx
+++ b/app/admin.jsx
@@ -15,10 +15,10 @@ import {
   TextInput,
   View,
 } from "react-native";
-import { router } from "expo-router";
 import Svg, { Path } from "react-native-svg";
 import { useTable } from "tinybase/ui-react";
 
+import { goBack } from "@/constants/navigation";
 import MyView from "@/components/MyView";
 
 import { confirmAction, notify } from "@/constants/dialogs";
@@ -99,7 +99,7 @@ export default function Admin() {
           <Pressable
             accessibilityRole="button"
             accessibilityLabel="Voltar"
-            onPress={() => router.back()}
+            onPress={() => goBack()}
             className="flex-row items-center gap-1 rounded-full p-1 pr-2 active:opacity-70"
           >
             <Svg width={18} height={18} viewBox="0 0 24 24" fill="none">

--- a/app/ajustes.jsx
+++ b/app/ajustes.jsx
@@ -14,11 +14,13 @@ import { useColorScheme } from "nativewind";
 import Svg, { Path } from "react-native-svg";
 import { useValue } from "tinybase/ui-react";
 
+import { goBack } from "@/constants/navigation";
 import MyView from "@/components/MyView";
 
 import { clearAll, setDisplayName, store } from "@/infra/database";
 import { useSession } from "@/infra/session";
 import { AUTH_ENABLED } from "@/infra/supabase";
+import { saveThemePreference } from "@/infra/theme";
 import { confirmAction } from "@/constants/dialogs";
 import { getEnvironmentInfo } from "@/constants/environment";
 import { useThemeTokens } from "@/constants/themeTokens";
@@ -52,7 +54,7 @@ const METAS = [
 ];
 
 export default function Ajustes() {
-  const { colorScheme, toggleColorScheme } = useColorScheme();
+  const { colorScheme, setColorScheme } = useColorScheme();
   const { user, signOut } = useSession();
   const isDark = colorScheme === "dark";
   const t = useThemeTokens();
@@ -80,7 +82,7 @@ export default function Ajustes() {
           <Pressable
             accessibilityRole="button"
             accessibilityLabel="Voltar"
-            onPress={() => router.back()}
+            onPress={() => goBack()}
             className="flex-row items-center gap-1 rounded-full p-1 pr-2 active:opacity-70"
           >
             <Svg width={18} height={18} viewBox="0 0 24 24" fill="none">
@@ -154,7 +156,11 @@ export default function Ajustes() {
             valueChevron
             onPress={() => setNameModalOpen(true)}
           />
-          {/* Tema com switch inline (mesmo controle do MenuModal antigo) */}
+          {/* Tema com switch inline. Usa `setColorScheme` com o valor que o
+              Switch entrega, não `toggleColorScheme()`: quando o usuário
+              ainda não escolheu, o colorScheme pode vir indefinido e o
+              "flip a partir do atual" fica ambíguo. E persiste a escolha —
+              sem isso o tema voltava pro sistema a cada reload. */}
           <View className="flex-row items-center justify-between border-t border-surface-subtle px-4 py-3">
             <Text
               className="text-sm text-ink dark:text-ink-dark"
@@ -164,7 +170,11 @@ export default function Ajustes() {
             </Text>
             <Switch
               value={isDark}
-              onValueChange={() => toggleColorScheme()}
+              onValueChange={(next) => {
+                const scheme = next ? "dark" : "light";
+                setColorScheme(scheme);
+                saveThemePreference(scheme);
+              }}
               accessibilityLabel="Alternar tema escuro"
             />
           </View>

--- a/app/feedback.jsx
+++ b/app/feedback.jsx
@@ -12,6 +12,7 @@ import {
 import { router } from "expo-router";
 import Svg, { Path } from "react-native-svg";
 
+import { goBack } from "@/constants/navigation";
 import MyView from "@/components/MyView";
 
 import { FEEDBACK_ENDPOINT, FEEDBACK_KEY } from "@/constants/feedback";
@@ -84,7 +85,7 @@ export default function Feedback() {
           <Pressable
             accessibilityRole="button"
             accessibilityLabel="Voltar"
-            onPress={() => router.back()}
+            onPress={() => goBack()}
             className="flex-row items-center gap-1 rounded-full p-1 pr-2 active:opacity-70"
           >
             <Svg width={18} height={18} viewBox="0 0 24 24" fill="none">

--- a/app/history.jsx
+++ b/app/history.jsx
@@ -2,10 +2,10 @@
 //#region imports
 import { useMemo, useState } from "react";
 import { Pressable, ScrollView, Text, View } from "react-native";
-import { router } from "expo-router";
 import Svg, { Path } from "react-native-svg";
 import { useTable } from "tinybase/ui-react";
 
+import { goBack } from "@/constants/navigation";
 import MyView from "@/components/MyView";
 import { HistoryCard } from "@/components/MyHistory";
 
@@ -77,7 +77,7 @@ export default function History() {
           <Pressable
             accessibilityRole="button"
             accessibilityLabel="Voltar"
-            onPress={() => router.back()}
+            onPress={() => goBack()}
             className="flex-row items-center gap-1 rounded-full p-1 pr-2 active:opacity-70"
           >
             <Svg width={18} height={18} viewBox="0 0 24 24" fill="none">

--- a/app/login.jsx
+++ b/app/login.jsx
@@ -5,6 +5,7 @@ import { Pressable, ScrollView, Text, TextInput, View } from "react-native";
 import { router } from "expo-router";
 import Svg, { Path } from "react-native-svg";
 
+import { goBack } from "@/constants/navigation";
 import MyView from "@/components/MyView";
 
 import { useSession } from "@/infra/session";
@@ -56,7 +57,7 @@ export default function Login() {
           <Pressable
             accessibilityRole="button"
             accessibilityLabel="Voltar"
-            onPress={() => router.back()}
+            onPress={() => goBack()}
             className="flex-row items-center gap-1 rounded-full p-1 pr-2 active:opacity-70"
           >
             <Svg width={18} height={18} viewBox="0 0 24 24" fill="none">

--- a/app/roadmap.jsx
+++ b/app/roadmap.jsx
@@ -1,9 +1,9 @@
 // @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
 //#region imports
 import { Pressable, ScrollView, Text, View } from "react-native";
-import { router } from "expo-router";
 import Svg, { Path } from "react-native-svg";
 
+import { goBack } from "@/constants/navigation";
 import MyView from "@/components/MyView";
 
 import { parseRoadmap, getDigest } from "@/constants/roadmap";
@@ -39,7 +39,7 @@ export default function Roadmap() {
           <Pressable
             accessibilityRole="button"
             accessibilityLabel="Voltar"
-            onPress={() => router.back()}
+            onPress={() => goBack()}
             className="flex-row items-center gap-1 rounded-full p-1 pr-2 active:opacity-70"
           >
             <Svg width={18} height={18} viewBox="0 0 24 24" fill="none">

--- a/app/semana.jsx
+++ b/app/semana.jsx
@@ -1,10 +1,10 @@
 // @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
 import { useMemo } from "react";
 import { Pressable, ScrollView, Text, View } from "react-native";
-import { router } from "expo-router";
 import Svg, { Path } from "react-native-svg";
 import { useTable } from "tinybase/ui-react";
 
+import { goBack } from "@/constants/navigation";
 import MyView from "@/components/MyView";
 import WeekStrip from "@/components/WeekStrip";
 
@@ -35,7 +35,7 @@ export default function Semana() {
           <Pressable
             accessibilityRole="button"
             accessibilityLabel="Voltar"
-            onPress={() => router.back()}
+            onPress={() => goBack()}
             className="flex-row items-center gap-1 rounded-full p-1 pr-2 active:opacity-70"
           >
             <Svg width={18} height={18} viewBox="0 0 24 24" fill="none">

--- a/components/MetricRegisterHeader.jsx
+++ b/components/MetricRegisterHeader.jsx
@@ -1,8 +1,8 @@
 // @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
 import { Pressable, Text, View } from "react-native";
 import Svg, { Path } from "react-native-svg";
-import { router } from "expo-router";
 
+import { goBack } from "@/constants/navigation";
 import MetricIcon from "./MetricIcon";
 import { useThemeTokens } from "@/constants/themeTokens";
 
@@ -36,7 +36,7 @@ export default function MetricRegisterHeader({
         <Pressable
           accessibilityRole="button"
           accessibilityLabel="Voltar"
-          onPress={() => router.back()}
+          onPress={() => goBack()}
           className="flex-row items-center gap-1 rounded-md p-1"
         >
           <Svg

--- a/components/metrics/FeedingBespoke.jsx
+++ b/components/metrics/FeedingBespoke.jsx
@@ -1,7 +1,6 @@
 // @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
 import { useEffect, useMemo, useState } from "react";
 import { Pressable, Text, TextInput, View } from "react-native";
-import { router } from "expo-router";
 import { useTable } from "tinybase/ui-react";
 
 import {
@@ -12,6 +11,7 @@ import {
   store,
   update,
 } from "@/infra/database";
+import { goBack } from "@/constants/navigation";
 import getDate from "@/constants/getDate";
 import { useThemeTokens } from "@/constants/themeTokens";
 
@@ -199,7 +199,7 @@ function FeedingCreate({ onAfterAdd }) {
       <Pressable
         accessibilityRole="button"
         accessibilityLabel="Concluir e voltar"
-        onPress={() => router.back()}
+        onPress={() => goBack()}
         className="mt-1 items-center rounded-2xl bg-primary dark:bg-primary-dark py-4 active:opacity-70"
       >
         <Text

--- a/constants/navigation.js
+++ b/constants/navigation.js
@@ -1,0 +1,29 @@
+// Navegação "voltar" resiliente a entrada direta na rota.
+//
+// `router.back()` puro é um NO-OP quando não existe entrada anterior na stack.
+// Isso acontece sempre que a rota é o PRIMEIRO destino da sessão:
+//
+//   - reload do bundle pelo expo-updates (o app volta na rota em que estava,
+//     mas com a stack zerada);
+//   - refresh do navegador no web (idem);
+//   - deep link direto (`backontrack://admin`, magic link do auth);
+//   - Fast Refresh no dev.
+//
+// Nesses casos o botão "Voltar" ficava morto — o usuário via o controle,
+// tocava, e nada acontecia. Aqui a Home vira o destino de fallback: sempre
+// existe pra onde voltar.
+
+import { router } from "expo-router";
+
+/**
+ * Volta uma tela; se não houver histórico, navega pra Home.
+ * @param {string} [fallback] rota alvo quando a stack está vazia
+ * @returns {void}
+ */
+export function goBack(fallback = "/") {
+  if (router.canGoBack()) {
+    router.back();
+    return;
+  }
+  router.replace(fallback);
+}

--- a/infra/theme.js
+++ b/infra/theme.js
@@ -1,0 +1,72 @@
+// @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
+//
+// Persistência da preferência de tema (claro/escuro).
+//
+// O `toggleColorScheme()` do NativeWind vive só em memória: mudava a UI na
+// hora, mas qualquer reload (OTA do expo-updates, refresh do navegador, Fast
+// Refresh, fechar e abrir o app) voltava pro tema do sistema. Aqui a escolha
+// vai pro AsyncStorage e é restaurada no boot.
+//
+// **Por que AsyncStorage e não o TinyBase store**: o store SINCRONIZA entre
+// devices (M6). Tema é preferência POR APARELHO — o celular pode estar no
+// escuro à noite enquanto o tablet segue claro. Guardar no store faria uma
+// escolha vazar pra outro device. AsyncStorage é local por definição.
+//
+// **Sem preferência salva = segue o sistema.** Só gravamos quando o usuário
+// toca no toggle; até lá o NativeWind fica no default `system` e respeita o
+// `prefers-color-scheme` do OS. É a regra 8 do Turno 3 do design v2
+// (`docs/09-design-v2.md`): system + override manual em Ajustes.
+
+import { useEffect } from "react";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { useColorScheme } from "nativewind";
+
+const THEME_KEY = "backontrack.colorScheme";
+
+/**
+ * Salva a escolha explícita do usuário. Erro de escrita não quebra a UI — o
+ * tema já mudou em memória; só a persistência falha (e o próximo boot volta
+ * pro sistema, que é degradação aceitável).
+ * @param {"light" | "dark"} scheme
+ * @returns {Promise<void>}
+ */
+export async function saveThemePreference(scheme) {
+  try {
+    await AsyncStorage.setItem(THEME_KEY, scheme);
+  } catch (e) {
+    console.error("[theme] não consegui salvar a preferência:", e);
+  }
+}
+
+/**
+ * Restaura a preferência salva no primeiro render da árvore.
+ *
+ * O AsyncStorage é assíncrono, então existe um frame curto com o tema do
+ * sistema antes da restauração. Não bloqueamos o boot atrás disso (mesma
+ * decisão das fontes na fatia 0 do M5-B): travar o splash por causa de um
+ * read local custa mais que o flash custa.
+ *
+ * @returns {void}
+ */
+export function useRestoreThemePreference() {
+  const { setColorScheme } = useColorScheme();
+
+  useEffect(() => {
+    let cancelled = false;
+    AsyncStorage.getItem(THEME_KEY)
+      .then((saved) => {
+        // Sem nada salvo = usuário nunca escolheu; deixa no `system`.
+        if (cancelled || (saved !== "light" && saved !== "dark")) return;
+        setColorScheme(saved);
+      })
+      .catch((e) => {
+        console.error("[theme] não consegui ler a preferência:", e);
+      });
+    return () => {
+      cancelled = true;
+    };
+    // setColorScheme é estável entre renders (vem do NativeWind); rodar só no
+    // mount é o desejado — restauração acontece uma vez por sessão.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}


### PR DESCRIPTION
Dois bugs relatados que compartilham o mesmo gatilho: **um reload** (OTA do expo-updates, refresh do navegador, Fast Refresh, deep link).

## 1. Tema escuro não persistia

**Causa:** `toggleColorScheme()` do NativeWind vive só em memória. A UI mudava na hora, mas qualquer reload voltava pro tema do sistema.

**Fix — novo `infra/theme.js`:**
- `saveThemePreference(scheme)` grava no AsyncStorage.
- `useRestoreThemePreference()` restaura no boot, chamado no `RootLayout`.

**Por que AsyncStorage e não o TinyBase store:** o store **sincroniza entre devices** (M6). Tema é preferência **por-aparelho** — o celular pode estar no escuro à noite enquanto o tablet segue claro. Gravar no store faria a escolha de um device vazar pro outro.

**Sem preferência salva = segue o sistema.** Só grava quando o usuário toca no toggle; até lá o NativeWind fica no default `system` e respeita o `prefers-color-scheme` do OS. Preserva a regra 8 do Turno 3 (`docs/09-design-v2.md`).

Ajustes passa a usar `setColorScheme(next)` com o valor que o Switch entrega, em vez de `toggleColorScheme()` — quando o usuário ainda não escolheu, `colorScheme` vem indefinido e "flip a partir do atual" fica ambíguo.

**Trade-off aceito:** o AsyncStorage é assíncrono, então existe um frame curto com o tema do sistema antes da restauração. Não bloqueei o boot atrás disso — mesma decisão das fontes na fatia 0 do M5-B: travar o splash por um read local custa mais que o flash.

## 2. Botão voltar morto após reload

**Causa:** `router.back()` é NO-OP quando não existe entrada anterior na stack. Isso acontece sempre que a rota é o **primeiro destino da sessão** — que é exatamente o caso do reload: o app volta na rota em que estava (ex: água), mas com a stack zerada. O usuário via o controle "Voltar", tocava, e nada acontecia.

**Fix — novo `constants/navigation.js`:**

```js
export function goBack(fallback = "/") {
  if (router.canGoBack()) {
    router.back();
    return;
  }
  router.replace(fallback);
}
```

Aplicado nos **9 callsites**: 7 telas (admin, ajustes, login, roadmap, semana, history, feedback), o `MetricRegisterHeader` (usado pelas 5 telas de registro) e o "Concluir" da alimentação.

## Test plan

- [x] `tsc --noEmit`, `eslint`, `prettier --check`, `npm test` (74/74) limpos.
- [ ] **Tema:** Ajustes → ligar "Tema escuro" → forçar reload (fechar/abrir o app, ou refresh no web) → deve continuar escuro. Desligar → reload → deve continuar claro. Nunca ter tocado no toggle → segue o tema do OS.
- [ ] **Voltar:** entrar na tela de água → reload → tocar "Voltar" → deve ir pra Home (antes: morto). Fluxo normal (Home → água → Voltar) segue igual.
- [ ] Conferir também nas outras telas com back: Semana, Ajustes, Histórico, Feedback, Roadmap.

Pure JS — chega via OTA, sem APK nova.