### PR TITLE
feat(release): gate staging before OTA reaches testers

### DIFF
--- a/.github/workflows/promote-update.yaml
+++ b/.github/workflows/promote-update.yaml
@@ -1,0 +1,90 @@
+name: Promote Update
+
+# Promove o último OTA de `staging` pra `preview` — ou seja, libera pros 6
+# testers o que já foi validado no BoT staging.
+#
+# Roda só sob demanda (`workflow_dispatch`) de propósito: o gate existe pra
+# VOCÊ escolher o momento e o lote. Merges na main se acumulam em staging até
+# alguém rodar isto aqui.
+#
+# Mecanismo: `eas update:republish` copia um grupo de update de uma branch pra
+# outra. O APK dos testers não muda — ele é assado com o CANAL `preview`, e o
+# canal aponta pra branch `preview`. Ninguém reinstala nada.
+#
+# Ver docs/10-canais-e-promocao.md.
+
+on:
+  workflow_dispatch:
+    inputs:
+      message:
+        description: "Nota da promoção (aparece no histórico de updates)"
+        required: false
+        default: "Promoção de staging para os testers"
+
+jobs:
+  promote:
+    name: staging -> preview
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "lts/jod"
+
+      - run: npm ci
+
+      - uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      # Resolve o grupo explicitamente em vez de deixar o republish escolher:
+      # deixa registrado no log QUAL update foi promovido, e falha claro se a
+      # staging estiver vazia.
+      - name: Descobre o último update de staging
+        id: alvo
+        run: |
+          JSON=$(eas update:list --branch staging --limit 1 --json --non-interactive)
+          GROUP=$(echo "$JSON" | jq -r '.currentPage[0].group // empty')
+          DESC=$(echo "$JSON" | jq -r '.currentPage[0].message // "(sem mensagem)"')
+          if [ -z "$GROUP" ]; then
+            echo "Nenhum update na branch staging — nada a promover." >&2
+            exit 1
+          fi
+          echo "group=$GROUP" >> "$GITHUB_OUTPUT"
+          {
+            echo "desc<<EOF"
+            echo "$DESC"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Promove pra preview
+        env:
+          GROUP: ${{ steps.alvo.outputs.group }}
+          MSG: ${{ inputs.message }}
+        run: |
+          eas update:republish \
+            --group "$GROUP" \
+            --destination-branch preview \
+            --message "$MSG" \
+            --non-interactive
+
+      - name: Resumo
+        env:
+          GROUP: ${{ steps.alvo.outputs.group }}
+          DESC: ${{ steps.alvo.outputs.desc }}
+        run: |
+          {
+            echo "## Promovido pros testers"
+            echo ""
+            echo "Grupo \`${GROUP}\` saiu de \`staging\` e entrou em \`preview\`."
+            echo ""
+            echo "Update promovido:"
+            echo ""
+            echo '```'
+            echo "${DESC}"
+            echo '```'
+            echo ""
+            echo "Os 6 testers recebem na próxima abertura do app. Se algo der errado, rode esta workflow de novo apontando pro grupo bom anterior — ou use \`eas update:roll-back-to-embedded\`."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-update.yaml
+++ b/.github/workflows/publish-update.yaml
@@ -1,12 +1,27 @@
 name: Publish Update
 
+# Todo merge na main publica OTA na branch `staging` — NÃO direto pros
+# testers. Quem serve os testers é a branch `preview`, que só recebe update
+# via promoção manual (`promote-update.yaml`).
+#
+# Antes daqui, esta workflow publicava direto na `preview`: merge na main
+# chegava nos 6 testers em segundos, sem gate. O histórico cobrou o preço —
+# o #126 passou por CI verde e foi pra produção via OTA, o #218 deixou os
+# testers em crash loop, e as duas quebras de fonte no Android (#239, #249)
+# passaram por CI E pelo preview da Vercel porque só se manifestam no APK.
+#
+# `--environment preview` é o conjunto de env vars do EAS (Supabase etc.),
+# não o canal — staging e produção compartilham o mesmo backend de propósito.
+#
+# Ver docs/10-canais-e-promocao.md.
+
 on:
   push:
     branches: [main]
 
 jobs:
   publish:
-    name: Publica OTA no canal preview
+    name: Publica OTA na branch staging
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -22,7 +37,19 @@ jobs:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
 
-      - name: Publica OTA
+      - name: Publica OTA em staging
         env:
           MSG: ${{ github.event.head_commit.message }}
-        run: eas update --branch preview --environment preview --message "$MSG" --non-interactive
+        run: eas update --branch staging --environment preview --message "$MSG" --non-interactive
+
+      - name: Lembrete de promoção
+        run: |
+          {
+            echo "## OTA publicada em \`staging\`"
+            echo ""
+            echo "Os testers **não** recebem ainda — a branch \`preview\` está congelada até você promover."
+            echo ""
+            echo "Pra validar: abra o **BoT staging** no seu aparelho (canal \`staging\`)."
+            echo ""
+            echo "Pra liberar pros testers: rode a workflow **Promote Update**."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/app.config.js
+++ b/app.config.js
@@ -1,0 +1,41 @@
+// Variante de app por ambiente.
+//
+// O `app.json` continua sendo a fonte de verdade da config — o Expo o carrega
+// primeiro e entrega o resultado aqui como `config`. Este arquivo só BIFURCA
+// a identidade quando `APP_VARIANT=staging` (setado pelo profile `staging` do
+// eas.json).
+//
+// ## Por que uma identidade separada
+//
+// O APK de staging precisa conviver com o de produção NO MESMO aparelho — é
+// isso que permite validar uma mudança nativa antes dela chegar nos testers.
+// Dois apps só coexistem no Android se tiverem `applicationId` diferente.
+//
+// O `scheme` também bifurca, e não é detalhe: com os dois instalados sob o
+// mesmo `backontrack://`, o Android não sabe qual abrir no callback do magic
+// link — o login cairia no app errado (ou num seletor). Ver
+// docs/10-canais-e-promocao.md § Supabase.
+//
+// O que NÃO muda: `slug`, `extra.eas.projectId` e `updates.url`. Os dois
+// variantes são o mesmo projeto EAS e batem no mesmo servidor de update; o
+// que os separa é o CANAL (`preview` vs `staging`), definido no eas.json.
+
+const IS_STAGING = process.env.APP_VARIANT === "staging";
+
+module.exports = ({ config }) => {
+  if (!IS_STAGING) return config;
+
+  return {
+    ...config,
+    name: "BoT staging",
+    scheme: "backontrack-staging",
+    android: {
+      ...config.android,
+      package: `${config.android.package}.staging`,
+    },
+    ios: {
+      ...config.ios,
+      bundleIdentifier: `${config.ios.bundleIdentifier}.staging`,
+    },
+  };
+};

--- a/docs/10-canais-e-promocao.md
+++ b/docs/10-canais-e-promocao.md
@@ -1,0 +1,100 @@
+# Canais de update e promoção
+
+Como uma mudança sai da `main` e chega no celular dos testers.
+
+## O problema que isto resolve
+
+Até aqui existia **um** canal (`preview`) apontando pra **uma** branch (`preview`), e todo merge na `main` publicava direto nela. Na prática o build chamado "preview" **era** produção: um merge chegava nos 6 testers em segundos, sem nenhum gate.
+
+O histórico do projeto cobrou o preço disso:
+
+- **#126** — regressão introduzida ao corrigir o #108. Passou por CI verde e foi pra produção via OTA; só apareceu quando um humano testou.
+- **#218** — dep nativa nova sem bump de `version` deixou os testers em **crash loop**.
+- **#239 / #249** — quebras de renderização de fonte no Android. Passaram por CI **e** pelo preview da Vercel, porque só se manifestam no APK nativo.
+
+O ponto comum: nada disso é pegável por lint, teste ou preview web. Precisa rodar no APK — e antes disso, precisa existir um lugar onde rodar que não seja o celular do tester.
+
+## Como funciona agora
+
+```
+merge na main
+     │
+     ▼
+branch  staging  ──────> canal staging ──> BoT staging (seu aparelho)
+     │
+     │  [workflow "Promote Update", manual]
+     ▼
+branch  preview  ──────> canal preview ──> Back on Track (6 testers)
+```
+
+Duas coisas fazem isso funcionar sem ninguém reinstalar nada:
+
+1. **O APK é assado com um _canal_, não com uma branch.** O canal aponta pra uma branch, e esse mapeamento vive no servidor. O APK 1.2.0 que os testers já têm segue no canal `preview`; mudamos só o que alimenta a branch `preview`.
+2. **`eas update:republish` copia um grupo de update entre branches.** Promover não é rebuildar nem republicar do zero — é apontar pro mesmo artefato já validado.
+
+## O fluxo do dia a dia
+
+**1. Merge na main** → `publish-update.yaml` publica em `staging` automaticamente. Testers não recebem nada.
+
+**2. Validar** → abrir o **BoT staging** no aparelho. Ele convive com o app de produção (applicationId diferente), então dá pra comparar lado a lado.
+
+**3. Promover** → rodar a workflow **Promote Update** (aba Actions, `workflow_dispatch`). Ela pega o último grupo de `staging` e republica em `preview`. Os testers recebem na próxima abertura do app.
+
+Merges se acumulam em staging até você promover — dá pra soltar um lote coerente em vez de pingar mudança solta.
+
+## Rollback
+
+Promoveu algo ruim? A workflow sempre pega o **último** de staging, então ela não serve pra voltar. Na mão:
+
+```bash
+# 1. achar o grupo bom anterior, na branch que os testers consomem
+eas update:list --branch preview --limit 5
+
+# 2. republicar ele por cima
+eas update:republish --group <GRUPO_BOM> --destination-branch preview \
+  --message "rollback: volta pro <descrição>"
+```
+
+Se o problema for mais grave (crash no boot, fronteira de módulo nativo), o martelo é mandar todo mundo de volta pro bundle embutido no APK:
+
+```bash
+eas update:roll-back-to-embedded --branch preview --runtime-version 1.2.0 --platform android
+```
+
+⚠️ **Ordem importa**: o expo-updates usa o **último** update da branch. Um `roll-back-to-embedded` é superado pela próxima promoção. Corrija o bug de verdade antes de promover de novo.
+
+## O APK de staging
+
+Cortado sob demanda — só quando uma mudança **nativa** precisa de validação (dep nova, plugin, ícone, splash). Mudança só-JS não precisa: o OTA de staging chega sozinho no BoT staging que você já tem instalado.
+
+```bash
+eas build --platform android --profile staging
+```
+
+O profile `staging` do `eas.json` seta `APP_VARIANT=staging`, e o `app.config.js` bifurca a identidade a partir daí:
+
+|               | produção                             | staging                  |
+| ------------- | ------------------------------------ | ------------------------ |
+| nome          | Back on Track                        | BoT staging              |
+| applicationId | `com.matheushnascimento.backOnTrack` | `…backOnTrack.staging`   |
+| scheme        | `backontrack://`                     | `backontrack-staging://` |
+| canal         | `preview`                            | `staging`                |
+
+O que **não** muda: `slug`, `projectId` do EAS e `updates.url`. É o mesmo projeto EAS batendo no mesmo servidor — o canal é que separa.
+
+### Por que o scheme também bifurca
+
+Com os dois apps instalados sob o mesmo `backontrack://`, o Android não sabe qual abrir no callback do magic link — o login cairia no app errado, ou num seletor.
+
+**Passo manual necessário** (uma vez, no dashboard do Supabase → Authentication → URL Configuration → Additional Redirect URLs):
+
+```
+backontrack-staging://**
+```
+
+Sem isso, login **no BoT staging** cai no fallback da Site URL e mostra `otp_expired`. O app de produção não é afetado.
+
+## Ver também
+
+- [04-roadmap-milestones.md](./04-roadmap-milestones.md) — M6 (sync) e M8 (estabilização/loja)
+- A regra de **bump de `version` quando entra dep nativa** continua valendo, e é independente disto: OTA não atravessa fronteira de módulo nativo. Um APK de staging valida a mudança, mas não dispensa o bump.

--- a/eas.json
+++ b/eas.json
@@ -15,6 +15,16 @@
         "buildType": "apk"
       }
     },
+    "staging": {
+      "distribution": "internal",
+      "channel": "staging",
+      "env": {
+        "APP_VARIANT": "staging"
+      },
+      "android": {
+        "buildType": "apk"
+      }
+    },
     "production": {
       "autoIncrement": true
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
     "jest.config.js",
     "tailwind.config.js",
     "eslint.config.mjs",
+    "app.config.js",
     "scripts",
     "plugins",
     "api"


### PR DESCRIPTION
Resolve o incômodo do "preview que na prática é produção".

## O problema

Canal `preview` → branch `preview`, e todo merge na `main` publicava direto nela. **Um merge chegava nos 6 testers em segundos, sem gate.** O nome "preview" dava uma falsa sensação de estágio intermediário que não existia.

O histórico cobrou o preço:

| | o que aconteceu |
|---|---|
| **#126** | regressão passou por CI verde e foi pra produção via OTA; só apareceu quando um humano testou |
| **#218** | dep nativa sem bump de `version` deixou os testers em **crash loop** |
| **#239 / #249** | quebras de fonte no Android — passaram por CI **e** pelo preview da Vercel, porque só se manifestam no APK |

O ponto comum: nada disso é pegável por lint, teste ou preview web.

## A solução — e por que sai de graça

```
merge na main ──> branch staging ──> canal staging ──> BoT staging (seu aparelho)
                       │
                  [Promote Update, manual]
                       ▼
                 branch preview ──> canal preview ──> Back on Track (6 testers)
```

**Ninguém reinstala nada.** O detalhe que torna isso barato: o APK é assado com um **canal**, e o canal aponta pra uma **branch** — esse mapeamento vive no servidor do EAS. O APK 1.2.0 que os testers já têm segue no canal `preview`; mudou só o que alimenta a branch `preview`.

## O que entra

- **`publish-update.yaml`** publica em `staging`, não mais em `preview`. Ganhou um resumo lembrando que os testers ainda não receberam.
- **`promote-update.yaml`** (novo, `workflow_dispatch`) — resolve o último grupo de staging e faz `eas update:republish` pra preview. Resolve o grupo **explicitamente** em vez de deixar o republish escolher: registra no log qual update foi promovido e falha claro se staging estiver vazia.
- **`eas.json`** ganha profile `staging` (canal `staging`, `APP_VARIANT=staging`).
- **`app.config.js`** (novo) bifurca a identidade quando `APP_VARIANT=staging`. O `app.json` segue fonte de verdade — o config só forka. Excluído do `checkJs` junto dos outros configs de tooling (ADR-002).

| | produção | staging |
|---|---|---|
| nome | Back on Track | BoT staging |
| applicationId | `com.matheushnascimento.backOnTrack` | `…backOnTrack.staging` |
| scheme | `backontrack://` | `backontrack-staging://` |
| canal | `preview` | `staging` |

Não mudam: `slug`, `projectId` do EAS, `updates.url`. Mesmo projeto, mesmo servidor — o canal é que separa.

## ⚠️ Passo manual necessário (Supabase)

O `scheme` bifurca **porque precisa**: com os dois apps sob o mesmo `backontrack://`, o Android não sabe qual abrir no callback do magic link — o login cairia no app errado.

Antes de logar no BoT staging, adicionar no dashboard (**Authentication → URL Configuration → Additional Redirect URLs**):

```
backontrack-staging://**
```

Sem isso o login **no staging** cai no fallback da Site URL e mostra `otp_expired`. **O app de produção não é afetado.**

## Sequência pós-merge

1. Merge deste PR → `publish-update.yaml` publica na branch `staging` (criada na hora pelo EAS). A branch `preview` **congela** no estado atual — testers seguem no que já têm.
2. Adicionar o redirect no Supabase.
3. Cortar o APK de staging: `eas build --platform android --profile staging`. Instalar no seu aparelho (convive com o de produção).
4. Daí em diante: merge → valida no BoT staging → **Promote Update** quando quiser liberar.

## Test plan

- [x] `tsc`, `eslint`, `prettier`, `npm test` (74/74) limpos.
- [x] `expo config` resolve as duas variantes corretamente (produção e `APP_VARIANT=staging`) — nome, scheme, package e version conferidos.
- [ ] Após merge: conferir que a run do `publish-update.yaml` criou a branch `staging` e publicou nela.
- [ ] Conferir que a branch `preview` **não** recebeu nada (`eas update:list --branch preview`).
- [ ] Rodar **Promote Update** e conferir que o grupo aparece em `preview`.

Docs completas em [`docs/10-canais-e-promocao.md`](docs/10-canais-e-promocao.md), incluindo rollback.