### PR TITLE
fix(nav): slide Ajustes in from the left, matching the hamburger icon

### DIFF
--- a/app/_layout.jsx
+++ b/app/_layout.jsx
@@ -67,7 +67,13 @@ function AppTree() {
         <Stack.Screen name="export" options={{ title: "Exportação" }} />
         <Stack.Screen name="history" options={{ title: "Histórico" }} />
         <Stack.Screen name="semana" options={{ title: "Semana" }} />
-        <Stack.Screen name="ajustes" options={{ title: "Ajustes" }} />
+        {/* Aberta pelo hamburger (canto esquerdo) — entra da esquerda pra
+            casar com o ícone, em vez do slide-from-right padrão de "avançar
+            no conteúdo" que as outras telas usam. */}
+        <Stack.Screen
+          name="ajustes"
+          options={{ title: "Ajustes", animation: "slide_from_left" }}
+        />
         <Stack.Screen name="feedback" options={{ title: "Feedback" }} />
         {/* Rota de admin (testers) — acesso só por deep link backontrack://admin */}
         <Stack.Screen name="admin" options={{ title: "Admin" }} />


### PR DESCRIPTION
Ajustes é aberta pelo ícone de hamburger no canto esquerdo, mas usava o `slide_from_right` padrão do Stack — a mesma transição de "avançar no conteúdo" que Semana/Histórico/Roadmap usam. A tela entrava pelo lado oposto ao do ícone que a abriu, quebrando a expectativa de "menu abrindo".

## Fix

`Stack.Screen("ajustes")` ganha `animation: "slide_from_left"`. Escopo pontual — só essa rota muda. As demais mantêm o padrão, que é correto pra elas (chevron rows dentro de Ajustes navegam "pra frente", faz sentido entrar da direita).

Native-stack (react-native-screens, já na dep tree) suporta a option nativamente — sem dep nova, pure JS/config. Chega via OTA.

## Test plan

- [x] `eslint`, `prettier`, `tsc` limpos.
- [ ] Tocar o hamburger na Home → Ajustes entra da esquerda.
- [ ] Voltar de Ajustes → sai pela esquerda (native-stack espelha a entrada no back automaticamente).
- [ ] Conferir que Semana/Histórico/Roadmap/Feedback/Admin continuam com o slide da direita, sem mudança.