### PR TITLE
fix(ajustes): stop Row label/value text from clipping on Android

### DIFF
--- a/app/ajustes.jsx
+++ b/app/ajustes.jsx
@@ -519,20 +519,27 @@ function Row({
             accessibilityLabel: label,
           }
         : {})}
-      className={`flex-row items-center justify-between border-t border-surface-subtle px-4 py-3 ${
+      className={`flex-row items-center justify-between gap-3 border-t border-surface-subtle px-4 py-3 ${
         onPress && !disabled ? "active:opacity-70" : ""
       }`}
     >
+      {/* Sem flex/shrink explícito, RN não encolhe ninguém por padrão (ao
+          contrário do CSS web) — label + value longos (ex: "Logado como" +
+          email, ou o nome customizado do usuário) podiam somar mais que a
+          largura da row e cortar sem reticências no Android. `label` fica no
+          tamanho natural (são strings curtas e fixas do app); `value` é o
+          lado que recebe conteúdo do usuário, então é ele que ganha o
+          container flex-1 + Text com shrink pra ellipsize de verdade. */}
       <Text
         className={`text-sm ${destructive ? "text-danger dark:text-danger" : "text-ink dark:text-ink-dark"}`}
         style={{ fontFamily: "Inter_400Regular" }}
       >
         {label}
       </Text>
-      <View className="flex-row items-center gap-1">
+      <View className="flex-1 flex-row items-center justify-end gap-1">
         {value ? (
           <Text
-            className="text-sm text-body-secondary dark:text-body-secondary-dark"
+            className="shrink text-sm text-body-secondary dark:text-body-secondary-dark"
             style={{
               fontFamily: valueMono
                 ? "JetBrainsMono_400Regular"


### PR DESCRIPTION
Reportado no BoT staging: texto cortando na tela de Ajustes.

## Causa

O `Row` (usado em quase toda a Ajustes — Metas do dia, Como quer ser chamado, Logado como, Sobre etc.) não dava `flex`/`shrink` pra nenhum dos dois lados. React Native **não encolhe filhos por padrão** (ao contrário do CSS web, onde `flex-shrink: 1` é o default) — então quando `label + value` somavam mais que a largura da row, o texto simplesmente cortava sem reticências. Fica mais visível no Android pelo mesmo bug de advance-width já catalogado em #239/#249.

O caso mais exposto: **"Logado como" + email longo**, ou o **nome customizado** (até 40 chars) que o usuário digita no modal "Como quer ser chamado". `value` já tinha `numberOfLines={1}`, mas sem um container com largura delimitada por flex, isso não tem efeito nenhum em RN.

## Fix

- `label` fica no tamanho natural — são strings curtas e fixas do próprio app, não precisam encolher.
- O container do `value` vira `flex-1 justify-end`, e o `Text` do value ganha `shrink` — agora o `numberOfLines={1}` de fato tem uma largura pra respeitar e ellipsiza quando não cabe.

## Test plan

- [x] `eslint`, `prettier`, `tsc`, `npm test` (74/74) limpos.
- [x] No BoT staging: abrir Ajustes logado com um email longo → "Logado como" mostra o email com `...` no fim, sem cortar.
- [ ] Definir um nome customizado longo (30+ chars) → row "Como quer ser chamado" ellipsiza em vez de cortar.
- [ ] Conferir que as outras rows (Metas do dia, Sobre, Semana, Histórico etc.) continuam com o mesmo visual de antes — o fix não deve mudar nada quando o conteúdo já cabia.