### PR TITLE
feat(release): validate PRs on staging before they reach main

### DIFF
--- a/.github/workflows/promote-update.yaml
+++ b/.github/workflows/promote-update.yaml
@@ -1,10 +1,18 @@
 name: Promote Update
 
-# Promove o último OTA de `staging` pra `preview` — ou seja, libera pros 6
-# testers o que já foi validado no BoT staging.
+# Promove o último OTA de `release` pra `preview` — libera pros 6 testers.
+#
+# ## Por que a fonte é `release` e não `staging`
+#
+# `staging` é bancada de validação: recebe PRs AINDA NÃO MERGEADOS
+# (`test-pr-on-staging.yaml`), porque validar no aparelho só vale antes do
+# merge. Promover de lá poderia mandar código não-mergeado pros testers.
+#
+# `release` só é alimentada por push na main. Promover de lá é barreira
+# ESTRUTURAL contra isso — não depende de ninguém lembrar da regra.
 #
 # Roda só sob demanda (`workflow_dispatch`) de propósito: o gate existe pra
-# VOCÊ escolher o momento e o lote. Merges na main se acumulam em staging até
+# VOCÊ escolher o momento e o lote. Merges na main se acumulam em release até
 # alguém rodar isto aqui.
 #
 # Mecanismo: `eas update:republish` copia um grupo de update de uma branch pra
@@ -19,11 +27,11 @@ on:
       message:
         description: "Nota da promoção (aparece no histórico de updates)"
         required: false
-        default: "Promoção de staging para os testers"
+        default: "Promoção para os testers"
 
 jobs:
   promote:
-    name: staging -> preview
+    name: release -> preview
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -41,15 +49,15 @@ jobs:
 
       # Resolve o grupo explicitamente em vez de deixar o republish escolher:
       # deixa registrado no log QUAL update foi promovido, e falha claro se a
-      # staging estiver vazia.
-      - name: Descobre o último update de staging
+      # release estiver vazia.
+      - name: Descobre o último update de release
         id: alvo
         run: |
-          JSON=$(eas update:list --branch staging --limit 1 --json --non-interactive)
+          JSON=$(eas update:list --branch release --limit 1 --json --non-interactive)
           GROUP=$(echo "$JSON" | jq -r '.currentPage[0].group // empty')
           DESC=$(echo "$JSON" | jq -r '.currentPage[0].message // "(sem mensagem)"')
           if [ -z "$GROUP" ]; then
-            echo "Nenhum update na branch staging — nada a promover." >&2
+            echo "Nenhum update na branch release — nada a promover." >&2
             exit 1
           fi
           echo "group=$GROUP" >> "$GITHUB_OUTPUT"
@@ -78,7 +86,7 @@ jobs:
           {
             echo "## Promovido pros testers"
             echo ""
-            echo "Grupo \`${GROUP}\` saiu de \`staging\` e entrou em \`preview\`."
+            echo "Grupo \`${GROUP}\` saiu de \`release\` e entrou em \`preview\`."
             echo ""
             echo "Update promovido:"
             echo ""

--- a/.github/workflows/publish-update.yaml
+++ b/.github/workflows/publish-update.yaml
@@ -1,17 +1,26 @@
 name: Publish Update
 
-# Todo merge na main publica OTA na branch `staging` — NÃO direto pros
-# testers. Quem serve os testers é a branch `preview`, que só recebe update
-# via promoção manual (`promote-update.yaml`).
+# Todo merge na main publica OTA em DUAS branches:
 #
-# Antes daqui, esta workflow publicava direto na `preview`: merge na main
-# chegava nos 6 testers em segundos, sem gate. O histórico cobrou o preço —
-# o #126 passou por CI verde e foi pra produção via OTA, o #218 deixou os
-# testers em crash loop, e as duas quebras de fonte no Android (#239, #249)
-# passaram por CI E pelo preview da Vercel porque só se manifestam no APK.
+#   release  — linhagem só-main. Única fonte da promoção pros testers.
+#   staging  — bancada de validação, o que o BoT staging consome.
 #
-# `--environment preview` é o conjunto de env vars do EAS (Supabase etc.),
-# não o canal — staging e produção compartilham o mesmo backend de propósito.
+# ## Por que duas
+#
+# A branch `staging` também recebe PRs não-mergeados (`test-pr-on-staging.yaml`),
+# porque validar no aparelho só vale se acontecer ANTES do merge — os bugs que
+# motivaram o gate (quebra de fonte no Android, #239/#249) não aparecem no CI
+# nem no preview da Vercel, só no APK.
+#
+# Isso torna `staging` uma fonte insegura pra promoção: promover de lá poderia
+# mandar código não-mergeado pros 6 testers. Daí a `release`, que só a main
+# alimenta — é barreira estrutural, não disciplina.
+#
+# Publicar main nas duas mantém o BoT staging refletindo a main quando você não
+# está testando um PR específico, e dá o teste de integração da main mesclada.
+#
+# `--environment preview` é o conjunto de env vars do EAS (Supabase etc.), não
+# o canal — todos os ambientes compartilham o mesmo backend de propósito.
 #
 # Ver docs/10-canais-e-promocao.md.
 
@@ -21,7 +30,7 @@ on:
 
 jobs:
   publish:
-    name: Publica OTA na branch staging
+    name: main -> release + staging
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -37,7 +46,12 @@ jobs:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
 
-      - name: Publica OTA em staging
+      - name: Publica em release (fonte da promoção)
+        env:
+          MSG: ${{ github.event.head_commit.message }}
+        run: eas update --branch release --environment preview --message "$MSG" --non-interactive
+
+      - name: Publica em staging (bancada)
         env:
           MSG: ${{ github.event.head_commit.message }}
         run: eas update --branch staging --environment preview --message "$MSG" --non-interactive
@@ -45,11 +59,11 @@ jobs:
       - name: Lembrete de promoção
         run: |
           {
-            echo "## OTA publicada em \`staging\`"
+            echo "## OTA publicada em \`release\` e \`staging\`"
             echo ""
-            echo "Os testers **não** recebem ainda — a branch \`preview\` está congelada até você promover."
+            echo "Os testers **não** recebem ainda — a branch \`preview\` só muda por promoção manual."
             echo ""
-            echo "Pra validar: abra o **BoT staging** no seu aparelho (canal \`staging\`)."
+            echo "O **BoT staging** já reflete esta main (se você estava testando um PR, ele foi sobrescrito)."
             echo ""
             echo "Pra liberar pros testers: rode a workflow **Promote Update**."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/test-pr-on-staging.yaml
+++ b/.github/workflows/test-pr-on-staging.yaml
@@ -1,0 +1,94 @@
+name: Test PR on Staging
+
+# Publica o código de um PR **ainda não mergeado** na branch `staging` — é o
+# que o BoT staging consome. Serve pra validar no aparelho ANTES do merge.
+#
+# ## Por que isto existe
+#
+# O gate do #266 só publicava a main em staging, ou seja: a validação no
+# aparelho acontecia DEPOIS do merge. Protegia os testers, mas deixava a main
+# carregando o bug até sair um segundo PR de correção — foi exatamente o
+# padrão do #239 seguido do #249. Os bugs que motivaram o gate (quebra de
+# fonte no Android) só aparecem no APK: nem CI nem preview da Vercel pegam.
+# Então o lugar certo de validar é antes de mergear.
+#
+# ## Como usar
+#
+# Coloque a label `staging` no PR. A partir daí, todo push nele republica em
+# staging automaticamente — dá pra iterar (corrige, empurra, confere no
+# aparelho) sem voltar aqui. Tirar a label para de publicar.
+#
+# **Uma label por vez.** Dois PRs com a label brigariam pela mesma branch e o
+# último push venceria. O resumo da run sempre diz o que ficou carregado.
+#
+# ## O que garante que isto não vaze pros testers
+#
+# A promoção (`promote-update.yaml`) NÃO sai de `staging` — sai de `release`,
+# que só a main alimenta. Código não-mergeado não tem caminho até o canal
+# `preview`. Ver docs/10-canais-e-promocao.md.
+
+on:
+  pull_request:
+    types: [labeled, synchronize]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "Número do PR a carregar no BoT staging"
+        required: true
+
+jobs:
+  publish:
+    name: PR -> branch staging
+    # No `synchronize` o evento dispara a cada push, com ou sem label — daí a
+    # checagem explícita. O dispatch manual não depende de label.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'staging')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve o PR alvo
+        id: pr
+        env:
+          NUM: ${{ github.event_name == 'workflow_dispatch' && inputs.pr || github.event.pull_request.number }}
+        run: echo "num=$NUM" >> "$GITHUB_OUTPUT"
+
+      # `refs/pull/N/merge` é o PR JÁ MESCLADO com a main — é o que a main vai
+      # virar depois do merge. Testar o head puro esconderia conflito
+      # semântico com o que entrou na main enquanto o PR estava aberto.
+      - uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ steps.pr.outputs.num }}/merge
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "lts/jod"
+
+      - run: npm ci
+
+      - uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Publica o PR em staging
+        env:
+          NUM: ${{ steps.pr.outputs.num }}
+          TITULO: ${{ github.event.pull_request.title }}
+        run: |
+          MSG="PR #${NUM}${TITULO:+: $TITULO}"
+          eas update --branch staging --environment preview \
+            --message "$MSG" --non-interactive
+
+      - name: Resumo
+        env:
+          NUM: ${{ steps.pr.outputs.num }}
+        run: |
+          {
+            echo "## BoT staging agora roda o PR #${NUM}"
+            echo ""
+            echo "Abra o **BoT staging** no aparelho pra validar (pode precisar fechar e reabrir)."
+            echo ""
+            echo "Enquanto a label \`staging\` estiver no PR, todo push republica aqui automaticamente."
+            echo ""
+            echo "Isto **não** chega nos testers — a promoção sai da branch \`release\`, que só a main alimenta."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/10-canais-e-promocao.md
+++ b/docs/10-canais-e-promocao.md
@@ -17,34 +17,54 @@ O ponto comum: nada disso é pegável por lint, teste ou preview web. Precisa ro
 ## Como funciona agora
 
 ```
-merge na main
+PR com label `staging`  ──┐
+(ainda não mergeado)      │
+                          ├──> branch staging ──> canal staging ──> BoT staging
+merge na main  ───────────┘                                         (seu aparelho)
      │
-     ▼
-branch  staging  ──────> canal staging ──> BoT staging (seu aparelho)
-     │
-     │  [workflow "Promote Update", manual]
-     ▼
-branch  preview  ──────> canal preview ──> Back on Track (6 testers)
+     └────────────────────────> branch release
+                                     │
+                                     │  [workflow "Promote Update", manual]
+                                     ▼
+                               branch preview ──> canal preview ──> 6 testers
 ```
+
+Três branches, dois canais, dois apps no seu aparelho:
+
+| branch    | quem alimenta        | pra quê                            |
+| --------- | -------------------- | ---------------------------------- |
+| `staging` | PRs com label + main | bancada de validação (BoT staging) |
+| `release` | só main              | única fonte da promoção            |
+| `preview` | só promoção manual   | os 6 testers                       |
 
 Duas coisas fazem isso funcionar sem ninguém reinstalar nada:
 
 1. **O APK é assado com um _canal_, não com uma branch.** O canal aponta pra uma branch, e esse mapeamento vive no servidor. O APK 1.2.0 que os testers já têm segue no canal `preview`; mudamos só o que alimenta a branch `preview`.
 2. **`eas update:republish` copia um grupo de update entre branches.** Promover não é rebuildar nem republicar do zero — é apontar pro mesmo artefato já validado.
 
+### Por que `release` existe
+
+Validar no aparelho só vale **antes** do merge — os bugs que motivaram todo esse gate (quebra de fonte no Android, #239/#249) não aparecem no CI nem no preview da Vercel, só no APK. Validar depois do merge deixa a main carregando o bug até sair um segundo PR de correção, que foi exatamente o padrão do #239 → #249.
+
+Mas isso torna `staging` uma fonte insegura pra promoção: se ela recebe PRs não-mergeados, promover de lá poderia mandar código não-mergeado pros testers. A `release`, alimentada só por push na main, é **barreira estrutural** contra isso — não depende de ninguém lembrar da regra na hora de promover.
+
 ## O fluxo do dia a dia
 
-**1. Merge na main** → `publish-update.yaml` publica em `staging` automaticamente. Testers não recebem nada.
+**1. Validar um PR antes de mergear** → colocar a label `staging` no PR. A partir daí todo push nele republica em `staging` automaticamente; abra o **BoT staging** no aparelho e confira. Iterar (corrige → empurra → confere) não exige voltar no GitHub.
 
-**2. Validar** → abrir o **BoT staging** no aparelho. Ele convive com o app de produção (applicationId diferente), então dá pra comparar lado a lado.
+⚠️ **Uma label por vez.** Dois PRs com a label brigariam pela mesma branch e o último push venceria.
 
-**3. Promover** → rodar a workflow **Promote Update** (aba Actions, `workflow_dispatch`). Ela pega o último grupo de `staging` e republica em `preview`. Os testers recebem na próxima abertura do app.
+Alternativa sem label: workflow **Test PR on Staging** no `workflow_dispatch`, passando o número do PR.
 
-Merges se acumulam em staging até você promover — dá pra soltar um lote coerente em vez de pingar mudança solta.
+**2. Merge na main** → `publish-update.yaml` publica em `release` (fonte da promoção) e em `staging` (o BoT staging volta a refletir a main). Testers não recebem nada.
+
+**3. Promover** → rodar a workflow **Promote Update** (aba Actions). Ela pega o último grupo de `release` e republica em `preview`. Os testers recebem na próxima abertura do app.
+
+Merges se acumulam em `release` até você promover — dá pra soltar um lote coerente em vez de pingar mudança solta.
 
 ## Rollback
 
-Promoveu algo ruim? A workflow sempre pega o **último** de staging, então ela não serve pra voltar. Na mão:
+Promoveu algo ruim? A workflow sempre pega o **último** de `release`, então ela não serve pra voltar. Na mão:
 
 ```bash
 # 1. achar o grupo bom anterior, na branch que os testers consomem
@@ -65,7 +85,7 @@ eas update:roll-back-to-embedded --branch preview --runtime-version 1.2.0 --plat
 
 ## O APK de staging
 
-Cortado sob demanda — só quando uma mudança **nativa** precisa de validação (dep nova, plugin, ícone, splash). Mudança só-JS não precisa: o OTA de staging chega sozinho no BoT staging que você já tem instalado.
+Cortado sob demanda — só quando uma mudança **nativa** precisa de validação (dep nova, plugin, ícone, splash). Mudança só-JS não precisa: o OTA chega sozinho no BoT staging que você já tem instalado (seja de um PR com label, seja da main).
 
 ```bash
 eas build --platform android --profile staging


### PR DESCRIPTION
Corrige um furo real no gate do #266: **o BoT staging só via código depois do merge.**

## O problema

O #266 montou o gate certo pro lado dos testers, mas errado pro lado da main. A validação no aparelho acontecia **pós-merge**, então um bug native-only entrava na main e ficava lá até sair um segundo PR de correção.

Isso não é hipotético — foi exatamente o padrão do **#239 → #249**: quebra de renderização de fonte no Android, invisível pro CI e pro preview da Vercel (só aparece no APK), corrigida num PR e reincidindo em outro. Se a existência do BoT staging é validar antes de produção, ele precisa ver o código **antes do merge**, não depois.

## Desenho novo

```
PR com label `staging`  ──┐
(ainda não mergeado)      │
                          ├──> branch staging ──> canal staging ──> BoT staging
merge na main  ───────────┘
     │
     └────────────────────────> branch release
                                     │
                                     │  [Promote Update, manual]
                                     ▼
                               branch preview ──> canal preview ──> 6 testers
```

| branch | quem alimenta | pra quê |
| --- | --- | --- |
| `staging` | PRs com label + main | bancada de validação |
| `release` | **só main** | única fonte da promoção |
| `preview` | só promoção manual | os 6 testers |

## O que entra

- **`test-pr-on-staging.yaml`** (novo) — PR com a label `staging` publica na branch `staging` a cada push (`labeled` + `synchronize`), mais `workflow_dispatch` por número de PR. Faz checkout de **`refs/pull/N/merge`**, não do head puro: testa o PR **já mesclado** com a main, que é o que a main vai virar. Head puro esconderia conflito semântico com o que entrou enquanto o PR estava aberto.

- **`publish-update.yaml`** — main passa a publicar em **duas** branches, `release` e `staging`. A segunda mantém o BoT staging refletindo a main quando não há PR em teste, e dá o teste de integração da main mesclada.

- **`promote-update.yaml`** — ⚠️ **fonte muda de `staging` pra `release`.** Essa é a mudança crítica: com `staging` recebendo PR não-mergeado, promover de lá poderia mandar código não-mergeado pros testers. `release` só é alimentada por push na main, então a garantia vira **estrutural** — não depende de alguém lembrar da regra na hora de promover.

- Label **`staging`** criada no repo.

## Ergonomia

Label uma vez → todo push no PR republica sozinho. Dá pra iterar (corrige → empurra → confere no aparelho) sem voltar no GitHub.

⚠️ **Uma label por vez** — dois PRs com a label brigariam pela mesma branch e o último push venceria. O resumo de cada run diz o que ficou carregado.

## Sequência pós-merge

1. Merge deste PR → `publish-update.yaml` cria a branch `release` (primeiro publish) e atualiza `staging`.
2. A partir daí, `Promote Update` funciona (antes disso falha claro: "Nenhum update na branch release").
3. Pra testar o mecanismo: colocar a label `staging` em qualquer PR aberto e conferir no BoT staging.

## Test plan

- [x] YAML dos 5 workflows valida.
- [x] `prettier`, `eslint`, `tsc` limpos.
- [ ] Após merge: conferir que a run publicou nas duas branches (`eas update:list --branch release` e `--branch staging`).
- [ ] Colocar a label `staging` no #267 ou #268 e conferir que o BoT staging carrega o PR.
- [ ] Rodar `Promote Update` e conferir que o grupo promovido veio de `release`.

Nota: `workflow_dispatch` só aparece na UI depois do merge (só roda a partir da branch default). O caminho por label já funciona neste PR.

Docs atualizadas em [`docs/10-canais-e-promocao.md`](docs/10-canais-e-promocao.md).