### PR TITLE
fix(home): greet with first name only and wrap long names

### DIFF
--- a/app/index.jsx
+++ b/app/index.jsx
@@ -16,6 +16,7 @@ import { useSession } from "@/infra/session";
 import { useThemeTokens } from "@/constants/themeTokens";
 import { CATEGORY_MAP } from "@/components/categoryUtils";
 import { minutesToHHMM } from "@/constants/duration";
+import { getGreeting } from "@/constants/greeting";
 //#endregion
 
 const METRICS = Object.keys(CATEGORY_MAP);
@@ -28,30 +29,6 @@ function formatValue(unit, total) {
     return `${total} ${total === 1 ? "refeição" : "refeições"}`;
   if (unit === "ml") return `${total.toLocaleString("pt-BR")} ml`;
   return `${total} ${unit}`;
-}
-
-// Saudação por horário. Design v2 usa "Bom dia, Ana." — o nome vem do
-// `displayName` que o usuário definiu em Ajustes; se não houver, cai no
-// primeiro nome do email (localpart até o primeiro `.`, pra que
-// "matheus.mhddn@gmail.com" vire "Matheus" e não "Matheus.mhddn"). Deslogado
-// sem displayName usa só o cumprimento.
-function getGreeting(user, displayName) {
-  const h = new Date().getHours();
-  const g = h < 12 ? "Bom dia" : h < 18 ? "Boa tarde" : "Boa noite";
-  const name = pickName(user, displayName);
-  if (!name) return `${g}.`;
-  return `${g}, ${name}.`;
-}
-
-function pickName(user, displayName) {
-  const stored = String(displayName ?? "").trim();
-  if (stored) return stored;
-  const email = user?.email;
-  if (!email) return "";
-  const localpart = String(email).split("@")[0] || "";
-  const first = localpart.split(".")[0] || "";
-  if (!first) return "";
-  return first.charAt(0).toUpperCase() + first.slice(1).toLowerCase();
 }
 
 // Dias corridos desde o último registro em qualquer métrica. Null se o store
@@ -204,10 +181,18 @@ export default function Home() {
           >
             {formatDateLabel()}
           </Text>
-          <View className="flex-row items-center justify-between">
+          <View className="flex-row items-center justify-between gap-3">
+            {/* `flex-1` dá largura limitada pro Text — sem isso ele não tem
+                onde quebrar e o nome longo vaza. Com a largura definida, a
+                quebra natural cai no espaço depois da vírgula: "Bom dia," na
+                primeira linha, nome na segunda. `numberOfLines={2}` fecha o
+                caso extremo (nome que sozinho não cabe numa linha), cortando
+                com reticências em vez de empurrar o ícone pra fora. */}
             <Text
-              className="text-2xl text-ink dark:text-ink-dark"
+              className="flex-1 text-2xl text-ink dark:text-ink-dark"
               style={{ fontFamily: "Inter_600SemiBold" }}
+              numberOfLines={2}
+              ellipsizeMode="tail"
             >
               {getGreeting(user, displayName)}
             </Text>

--- a/constants/greeting.js
+++ b/constants/greeting.js
@@ -1,0 +1,82 @@
+// Saudação da Home ("Bom dia, Ana.").
+//
+// Vive fora do `app/index.jsx` pelo mesmo motivo do `infra/sync-url.js`:
+// função pura com casos de borda de verdade (acento, separador, fallback do
+// email) merece teste, e importar a tela puxaria a árvore RN inteira pro
+// jest. Aqui roda em Node puro.
+
+/**
+ * Só o PRIMEIRO nome: corta no primeiro caractere não-alfabético.
+ *
+ * `\p{L}` (com flag `u`) é letra Unicode, então acento passa — "João da
+ * Silva" vira "João", não "Jo". Cobre de uma vez os separadores que aparecem
+ * de verdade: espaço ("Matheus Henrique"), ponto do email
+ * ("matheus.mhddn") e dígito.
+ *
+ * Efeito colateral aceito: nomes com apóstrofo ou hífen também cortam
+ * ("D'Angelo" -> "D", "Ana-Maria" -> "Ana"). É a regra literal de "quebrar no
+ * primeiro não-alfabético"; se incomodar, o conserto é permitir `'` e `-` no
+ * meio da classe.
+ */
+const PRIMEIRO_NOME = /^\p{L}+/u;
+
+/**
+ * Extrai o primeiro nome de uma string livre.
+ * @param {unknown} texto
+ * @returns {string} primeiro nome, ou "" se não houver letra no começo
+ */
+export function firstName(texto) {
+  const limpo = String(texto ?? "").trim();
+  return limpo.match(PRIMEIRO_NOME)?.[0] ?? "";
+}
+
+/**
+ * Nome pra saudação. Prefere o `displayName` escolhido em Ajustes; sem ele,
+ * deriva do email.
+ *
+ * @param {{ email?: string } | null | undefined} user
+ * @param {unknown} displayName
+ * @returns {string} "" quando não há nome utilizável
+ */
+export function pickName(user, displayName) {
+  const escolhido = firstName(displayName);
+  if (escolhido) {
+    // Só garante a inicial maiúscula. O resto fica como a pessoa digitou —
+    // ela escolheu esse nome no Ajustes, e forçar lowercase quebraria grafia
+    // legítima tipo "McArthur".
+    return escolhido.charAt(0).toUpperCase() + escolhido.slice(1);
+  }
+
+  const email = user?.email;
+  if (!email) return "";
+  const localpart = String(email).split("@")[0] || "";
+  const derivado = firstName(localpart);
+  if (!derivado) return "";
+  // Aqui o lowercase vale: localpart é derivado, não escolhido — normaliza
+  // "MATHEUS.MHDDN@..." pra "Matheus".
+  return derivado.charAt(0).toUpperCase() + derivado.slice(1).toLowerCase();
+}
+
+/**
+ * Cumprimento por faixa de horário.
+ * @param {number} hora 0-23
+ * @returns {string}
+ */
+export function saudacaoPorHora(hora) {
+  if (hora < 12) return "Bom dia";
+  if (hora < 18) return "Boa tarde";
+  return "Boa noite";
+}
+
+/**
+ * Saudação completa da Home.
+ * @param {{ email?: string } | null | undefined} user
+ * @param {unknown} displayName
+ * @param {number} [hora] injetável pra teste; default é a hora local
+ * @returns {string}
+ */
+export function getGreeting(user, displayName, hora = new Date().getHours()) {
+  const cumprimento = saudacaoPorHora(hora);
+  const nome = pickName(user, displayName);
+  return nome ? `${cumprimento}, ${nome}.` : `${cumprimento}.`;
+}

--- a/tests/greeting.test.js
+++ b/tests/greeting.test.js
@@ -1,0 +1,104 @@
+// @ts-nocheck -- globals do jest não são tipados (ADR-002)
+import {
+  firstName,
+  getGreeting,
+  pickName,
+  saudacaoPorHora,
+} from "@/constants/greeting";
+
+describe("firstName", () => {
+  it("corta no primeiro espaço", () => {
+    expect(firstName("Matheus Henrique Nascimento")).toBe("Matheus");
+  });
+
+  it("preserva acento — a regra é letra Unicode, não [a-z]", () => {
+    expect(firstName("João da Silva")).toBe("João");
+    expect(firstName("Ângela Souza")).toBe("Ângela");
+  });
+
+  it("corta no ponto (caso do localpart de email)", () => {
+    expect(firstName("matheus.mhddn")).toBe("matheus");
+  });
+
+  it("corta em dígito", () => {
+    expect(firstName("José123")).toBe("José");
+  });
+
+  it("ignora espaço em volta", () => {
+    expect(firstName("  Pedro  ")).toBe("Pedro");
+  });
+
+  it("devolve vazio quando não começa com letra", () => {
+    expect(firstName("123")).toBe("");
+    expect(firstName("   ")).toBe("");
+    expect(firstName("")).toBe("");
+    expect(firstName(null)).toBe("");
+    expect(firstName(undefined)).toBe("");
+  });
+
+  // Comportamento consciente, não bug: a regra é "quebrar no primeiro
+  // não-alfabético". Se um dia apóstrofo/hífen tiverem que sobreviver, é
+  // aqui que o teste vai mudar junto.
+  it("corta em apóstrofo e hífen", () => {
+    expect(firstName("D'Angelo")).toBe("D");
+    expect(firstName("Ana-Maria")).toBe("Ana");
+  });
+});
+
+describe("pickName", () => {
+  it("prefere o displayName ao email", () => {
+    expect(pickName({ email: "outro@x.com" }, "Ana")).toBe("Ana");
+  });
+
+  it("aplica primeiro-nome no displayName — era o bug do #268", () => {
+    expect(pickName(null, "Matheus Henrique Nascimento")).toBe("Matheus");
+  });
+
+  it("só força a inicial do displayName, preserva o resto da grafia", () => {
+    expect(pickName(null, "matheus")).toBe("Matheus");
+    expect(pickName(null, "McArthur Silva")).toBe("McArthur");
+  });
+
+  it("cai no email quando displayName está vazio ou é só símbolo", () => {
+    expect(pickName({ email: "matheus.mhddn@gmail.com" }, "")).toBe("Matheus");
+    expect(pickName({ email: "matheus.mhddn@gmail.com" }, "   ")).toBe(
+      "Matheus",
+    );
+    expect(pickName({ email: "matheus@gmail.com" }, "123")).toBe("Matheus");
+  });
+
+  it("normaliza caixa no email, que é derivado e não escolhido", () => {
+    expect(pickName({ email: "MATHEUS.MHDDN@gmail.com" }, null)).toBe(
+      "Matheus",
+    );
+  });
+
+  it("devolve vazio sem user e sem displayName", () => {
+    expect(pickName(null, null)).toBe("");
+    expect(pickName(undefined, "")).toBe("");
+    expect(pickName({}, "")).toBe("");
+  });
+});
+
+describe("saudacaoPorHora", () => {
+  it("vira nas fronteiras 12 e 18", () => {
+    expect(saudacaoPorHora(0)).toBe("Bom dia");
+    expect(saudacaoPorHora(11)).toBe("Bom dia");
+    expect(saudacaoPorHora(12)).toBe("Boa tarde");
+    expect(saudacaoPorHora(17)).toBe("Boa tarde");
+    expect(saudacaoPorHora(18)).toBe("Boa noite");
+    expect(saudacaoPorHora(23)).toBe("Boa noite");
+  });
+});
+
+describe("getGreeting", () => {
+  it("monta cumprimento + primeiro nome", () => {
+    expect(getGreeting(null, "Matheus Henrique", 9)).toBe("Bom dia, Matheus.");
+    expect(getGreeting(null, "Ana", 14)).toBe("Boa tarde, Ana.");
+    expect(getGreeting(null, "Ana", 20)).toBe("Boa noite, Ana.");
+  });
+
+  it("sem nome, fica só o cumprimento", () => {
+    expect(getGreeting(null, null, 9)).toBe("Bom dia.");
+  });
+});


### PR DESCRIPTION
Achado ao validar o #268 no BoT staging: digitei um nome completo em "Como quer ser chamado" e a Home mostrou tudo.

## 1. Nome inteiro em vez do primeiro

`pickName` só extraía o primeiro nome no fallback do **email**. Quando havia `displayName` definido em Ajustes, a string voltava inteira — quem digitasse "Matheus Henrique Nascimento" via tudo na saudação.

Agora **ambos** os caminhos cortam no primeiro caractere não-alfabético, via `/^\p{L}+/u`. A flag `u` com `\p{L}` é letra Unicode, então acento passa:

| entrada | saída |
| --- | --- |
| `Matheus Henrique Nascimento` | `Matheus` |
| `João da Silva` | `João` |
| `Ângela Souza` | `Ângela` |
| `matheus.mhddn` (localpart) | `Matheus` |
| `José123` | `José` |

Uma decisão de caixa que vale revisar: no **displayName** só forço a inicial, o resto fica como você digitou — você escolheu esse nome, e lowercase quebraria grafia legítima tipo "McArthur". No **email** o lowercase vale, porque é derivado e não escolhido (`MATHEUS.MHDDN@…` → `Matheus`).

⚠️ **Efeito colateral consciente:** apóstrofo e hífen também cortam — `D'Angelo` → `D`, `Ana-Maria` → `Ana`. É a regra literal de "quebrar no primeiro não-alfabético" que você pediu. Se preferir preservar esses dois, é uma linha na regex e um teste — me avisa.

## 2. Nome longo não quebrava

O `Text` da saudação estava num `flex-row` com o ícone 1c **sem `flex-1` e sem `numberOfLines`** — mesma classe do #268: sem largura limitada, não existe onde quebrar.

- `flex-1` → a quebra natural cai no espaço depois da vírgula: **"Bom dia,"** na linha 1, **nome** na linha 2.
- `numberOfLines={2}` + `ellipsizeMode="tail"` → fecha o caso extremo (nome que sozinho não cabe numa linha), cortando em vez de empurrar o ícone pra fora da tela.

## Testes

A lógica saiu pra `constants/greeting.js` com **16 testes** — mesmo motivo do `infra/sync-url.js`: função pura com casos de borda reais merece teste, e importar a tela puxaria a árvore RN pro jest. Cobre acento, cada separador, precedência displayName vs email, normalização de caixa e os vazios.

Suíte total: 90 testes (era 74).

## Test plan

- [x] `eslint`, `prettier`, `tsc`, `npm test` (90/90) limpos.
- [ ] BoT staging: definir "Matheus Henrique Nascimento" → Home mostra "Bom dia, Matheus."
- [ ] Definir um nome longo (~15 letras, ex: "Bartholomeuzinho") → confirmar que "Bom dia," desce pra própria linha.
- [ ] Nome absurdo (30+ letras sem espaço) → corta com reticências, ícone 1c continua no lugar.
- [ ] Limpar o campo → volta a derivar do email.