### PR TITLE
feat(release): publish every PR to staging without a label

### DIFF
--- a/.github/workflows/test-pr-on-staging.yaml
+++ b/.github/workflows/test-pr-on-staging.yaml
@@ -1,25 +1,25 @@
 name: Test PR on Staging
 
-# Publica o código de um PR **ainda não mergeado** na branch `staging` — é o
-# que o BoT staging consome. Serve pra validar no aparelho ANTES do merge.
+# TODO PR publica na branch `staging` — é o que o BoT staging consome. Serve
+# pra validar no aparelho ANTES do merge.
 #
-# ## Por que isto existe
+# ## Por que sem label
 #
-# O gate do #266 só publicava a main em staging, ou seja: a validação no
-# aparelho acontecia DEPOIS do merge. Protegia os testers, mas deixava a main
-# carregando o bug até sair um segundo PR de correção — foi exatamente o
-# padrão do #239 seguido do #249. Os bugs que motivaram o gate (quebra de
-# fonte no Android) só aparecem no APK: nem CI nem preview da Vercel pegam.
-# Então o lugar certo de validar é antes de mergear.
+# O #269 exigia a label `staging` no PR. Como a regra virou "toda feature
+# branch vai pro staging", a label passaria a estar em todo PR — e uma marca
+# que está em tudo não marca nada. Pior: dava a impressão de escolher qual PR
+# está carregado, o que ela nunca fez. Existe UM canal `staging` e UM app no
+# aparelho, então é sempre um PR por vez: **o staging mostra o push mais
+# recente**, seja de qual PR for. Automatizar a label só tornaria a colisão
+# silenciosa. Melhor tirar a cerimônia e deixar a regra explícita aqui.
 #
-# ## Como usar
+# ## Quem NÃO publica
 #
-# Coloque a label `staging` no PR. A partir daí, todo push nele republica em
-# staging automaticamente — dá pra iterar (corrige, empurra, confere no
-# aparelho) sem voltar aqui. Tirar a label para de publicar.
-#
-# **Uma label por vez.** Dois PRs com a label brigariam pela mesma branch e o
-# último push venceria. O resumo da run sempre diz o que ficou carregado.
+# - **Draft** — trabalho em andamento não precisa ocupar a bancada.
+# - **Label `skip-staging`** — escape hatch manual.
+# - **PR de fork** — não recebe `EXPO_TOKEN`, falharia com erro confuso.
+# - **Mudança só de docs/workflow** — `paths-ignore` abaixo; não altera o
+#   bundle, publicar seria gasto de update à toa.
 #
 # ## O que garante que isto não vaze pros testers
 #
@@ -29,21 +29,25 @@ name: Test PR on Staging
 
 on:
   pull_request:
-    types: [labeled, synchronize]
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+      - ".github/**"
   workflow_dispatch:
     inputs:
       pr:
-        description: "Número do PR a carregar no BoT staging"
+        description: "Número do PR a carregar no BoT staging (força, ignora os filtros)"
         required: true
 
 jobs:
   publish:
     name: PR -> branch staging
-    # No `synchronize` o evento dispara a cada push, com ou sem label — daí a
-    # checagem explícita. O dispatch manual não depende de label.
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      contains(github.event.pull_request.labels.*.name, 'staging')
+      (github.event.pull_request.draft == false &&
+       github.event.pull_request.head.repo.full_name == github.repository &&
+       !contains(github.event.pull_request.labels.*.name, 'skip-staging'))
     runs-on: ubuntu-latest
     steps:
       - name: Resolve o PR alvo
@@ -88,7 +92,7 @@ jobs:
             echo ""
             echo "Abra o **BoT staging** no aparelho pra validar (pode precisar fechar e reabrir)."
             echo ""
-            echo "Enquanto a label \`staging\` estiver no PR, todo push republica aqui automaticamente."
+            echo "Se você tinha outro PR carregado, ele foi substituído — a bancada é um slot só, sempre com o push mais recente."
             echo ""
-            echo "Isto **não** chega nos testers — a promoção sai da branch \`release\`, que só a main alimenta."
+            echo "Isto **não** chega nos testers: a promoção sai da branch \`release\`, que só a main alimenta."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/10-canais-e-promocao.md
+++ b/docs/10-canais-e-promocao.md
@@ -17,7 +17,7 @@ O ponto comum: nada disso é pegável por lint, teste ou preview web. Precisa ro
 ## Como funciona agora
 
 ```
-PR com label `staging`  ──┐
+todo PR (a cada push)  ───┐
 (ainda não mergeado)      │
                           ├──> branch staging ──> canal staging ──> BoT staging
 merge na main  ───────────┘                                         (seu aparelho)
@@ -31,11 +31,11 @@ merge na main  ───────────┘                             
 
 Três branches, dois canais, dois apps no seu aparelho:
 
-| branch    | quem alimenta        | pra quê                            |
-| --------- | -------------------- | ---------------------------------- |
-| `staging` | PRs com label + main | bancada de validação (BoT staging) |
-| `release` | só main              | única fonte da promoção            |
-| `preview` | só promoção manual   | os 6 testers                       |
+| branch    | quem alimenta      | pra quê                            |
+| --------- | ------------------ | ---------------------------------- |
+| `staging` | todo PR + main     | bancada de validação (BoT staging) |
+| `release` | só main            | única fonte da promoção            |
+| `preview` | só promoção manual | os 6 testers                       |
 
 Duas coisas fazem isso funcionar sem ninguém reinstalar nada:
 
@@ -50,11 +50,13 @@ Mas isso torna `staging` uma fonte insegura pra promoção: se ela recebe PRs n�
 
 ## O fluxo do dia a dia
 
-**1. Validar um PR antes de mergear** → colocar a label `staging` no PR. A partir daí todo push nele republica em `staging` automaticamente; abra o **BoT staging** no aparelho e confira. Iterar (corrige → empurra → confere) não exige voltar no GitHub.
+**1. Validar um PR antes de mergear** → não precisa fazer nada. **Todo PR publica em `staging` a cada push**; abra o **BoT staging** no aparelho e confira. Iterar (corrige → empurra → confere) não exige tocar no GitHub.
 
-⚠️ **Uma label por vez.** Dois PRs com a label brigariam pela mesma branch e o último push venceria.
+⚠️ **A bancada é um slot só.** Existe um canal `staging` e um app no aparelho, então o BoT staging mostra sempre **o push mais recente**, seja de qual PR for — e um merge na main também sobrescreve. Não dá pra ter dois PRs carregados ao mesmo tempo; o resumo de cada run diz o que ficou.
 
-Alternativa sem label: workflow **Test PR on Staging** no `workflow_dispatch`, passando o número do PR.
+**Quem não publica:** PR em draft, PR com a label `skip-staging`, PR de fork (não recebe o `EXPO_TOKEN`) e mudança que só toca `docs/**`, `**/*.md` ou `.github/**` (não altera o bundle).
+
+Pra forçar qualquer PR ignorando esses filtros: workflow **Test PR on Staging** no `workflow_dispatch`, passando o número.
 
 **2. Merge na main** → `publish-update.yaml` publica em `release` (fonte da promoção) e em `staging` (o BoT staging volta a refletir a main). Testers não recebem nada.
 


### PR DESCRIPTION
Implementa a regra "toda feature branch vai pro staging" — mas **removendo** a label em vez de automatizar a colagem dela.

## Por que sem label, e não auto-label

A leitura literal do pedido seria um workflow que cola a label `staging` em todo PR aberto. Não fiz isso por dois motivos:

1. **Uma marca que está em todo PR não marca nada.** Vira ruído visual no PR list sem informar.
2. **Ela sugeria um controle que nunca existiu.** A label parecia escolher *qual* PR está carregado no aparelho. Nunca escolheu: existe **um** canal `staging` e **um** app instalado, então é sempre um PR por vez. Auto-colar em todos só tornaria a colisão silenciosa em vez de resolvida.

O que a regra realmente quer é "todo PR fica testável sem eu lembrar de marcar" — e isso se resolve tirando a cerimônia, deixando a regra explícita no gatilho.

## Comportamento

**Todo push em PR aberto publica em `staging`.** O BoT staging mostra sempre o push mais recente, seja de qual PR for (um merge na main também sobrescreve). O resumo de cada run diz o que ficou carregado.

**Não publica:**

| caso | motivo |
| --- | --- |
| PR em **draft** | trabalho em andamento não precisa ocupar a bancada |
| label **`skip-staging`** | escape hatch manual |
| PR de **fork** | não recebe `EXPO_TOKEN`, falharia com erro confuso |
| só `docs/**`, `**/*.md`, `.github/**` | não altera o bundle; publicar gastaria update à toa |

`workflow_dispatch` segue disponível pra forçar qualquer PR ignorando os filtros.

## Labels

- **`staging`** deletada (perdeu função) e removida do #268.
- **`skip-staging`** criada como opt-out.

## Test plan

- [x] YAML valida; `prettier` limpo.
- [ ] Após merge: abrir/atualizar um PR com mudança de app e conferir que publicou sem label nenhuma.
- [ ] Conferir que um PR só-docs **não** dispara a workflow.
- [ ] Marcar um PR como draft e conferir que não publica.

⚠️ Os PRs já abertos (#267, #270) precisam da main mesclada na branch pra ganhar o workflow — em eventos `pull_request` o GitHub usa o arquivo da branch do PR, e elas nasceram antes. Mesma armadilha do rollout do #269.