### PR TITLE
fix(fonts): block first render until custom fonts load

### DIFF
--- a/app/_layout.jsx
+++ b/app/_layout.jsx
@@ -1,10 +1,12 @@
 // @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
 import "@/global.css";
 
+import { useEffect } from "react";
 import { Stack } from "expo-router";
 import { View } from "react-native";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { useFonts } from "expo-font";
+import * as SplashScreen from "expo-splash-screen";
 import {
   Inter_400Regular,
   Inter_500Medium,
@@ -21,22 +23,48 @@ import { SyncStatusProvider } from "@/infra/sync";
 import { useRestoreThemePreference } from "@/infra/theme";
 import UpdateBanner from "@/components/UpdateBanner";
 
+// Segura o splash nativo até as fontes carregarem. Fora do componente porque
+// precisa rodar UMA vez, antes do primeiro render.
+SplashScreen.preventAutoHideAsync().catch(() => {
+  // Já escondido ou indisponível (web/dev) — seguir sem travar o boot.
+});
+
 export default function RootLayout() {
   useRegistrosPersistencia();
   // Restaura claro/escuro escolhido em Ajustes. Sem isso o toggle só valia
   // até o próximo reload (o NativeWind guarda em memória). Ver infra/theme.js.
   useRestoreThemePreference();
-  // Fontes do design v2 (M5-B fatia 0). Carrega em background; se ainda não
-  // tiver terminado, sistema serve o fallback e a UI re-renderiza quando
-  // ficarem prontas. Não bloqueia boot pra não introduzir splash extra —
-  // fatia 1+ é que começa a usar essas famílias. Ver docs/09-design-v2.md.
-  useFonts({
+
+  // ⚠️ O retorno do useFonts NÃO pode ser descartado.
+  //
+  // Antes ele era, com a justificativa de "não bloquear o boot". O custo
+  // apareceu como bug de renderização recorrente no Android: a UI montava com
+  // a fonte de fallback do sistema, o Android MEDIA o texto com ela, e quando
+  // a Inter terminava de carregar o glifo real vinha mais largo que a caixa já
+  // dimensionada — a última letra cortava ("Depois" virava "Depoi").
+  //
+  // Foi diagnosticado errado três vezes (#239 fontWeight+letterSpacing, #249
+  // underline, #268 flex): cada patch mexia num sintoma diferente da mesma
+  // corrida. A causa é uma só, e é aqui.
+  const [fontsLoaded, fontError] = useFonts({
     Inter_400Regular,
     Inter_500Medium,
     Inter_600SemiBold,
     JetBrainsMono_400Regular,
     JetBrainsMono_500Medium,
   });
+
+  // Erro de fonte não pode deixar o app preso no splash pra sempre — nesse
+  // caso segue com o fallback do sistema, que é degradação aceitável.
+  const pronto = fontsLoaded || !!fontError;
+
+  useEffect(() => {
+    if (pronto) SplashScreen.hideAsync().catch(() => {});
+  }, [pronto]);
+
+  // Nada de árvore antes da fonte existir: é isso que garante que a primeira
+  // medição de texto já use a métrica definitiva.
+  if (!pronto) return null;
 
   return (
     <SafeAreaProvider>

--- a/docs/09-design-v2.md
+++ b/docs/09-design-v2.md
@@ -45,6 +45,8 @@ Duas famílias, ambas via `expo-font` + `@expo-google-fonts/*` (OTA-safe, sem na
 - **Inter** (400/500/600) — corpo e headings
 - **JetBrains Mono** (400/500) — labels em uppercase (section headers, chips)
 
+⚠️ **O boot BLOQUEIA até as fontes carregarem** (`app/_layout.jsx` retorna `null` enquanto `useFonts` não resolve, com o splash nativo segurado pelo `expo-splash-screen`). A fatia 0 tinha feito o contrário — carregava em background pra "não introduzir splash extra" — e isso custou caro: no Android a UI montava com a fonte de fallback, o sistema media o texto com ela, e quando a Inter chegava o glifo real não cabia mais na caixa já dimensionada. A última letra cortava ("Depois" virava "Depoi"). Foi diagnosticado errado três vezes (#239, #249, #268) antes de achar a corrida. Não voltar a descartar o retorno do `useFonts`.
+
 ### Escala (px direto — sem rem, sem `62.5%`)
 
 | Papel         | Size / Weight / Family            | Nota                                       |


### PR DESCRIPTION
Causa raiz do texto cortado no Android. Três PRs anteriores atacaram o sintoma errado — este ataca a corrida que os gerava.

## O que estava acontecendo

O `useFonts` tinha o retorno **descartado**, por decisão consciente da fatia 0 do M5-B ("não bloquear o boot pra não introduzir splash extra"):

```js
useFonts({ Inter_400Regular, /* ... */ });  // ← retorno ignorado
```

O efeito no Android: a árvore montava com a **fonte de fallback do sistema**, o Android **media** o texto com a métrica dela, e quando a Inter terminava de carregar o glifo real vinha mais largo que a caixa já dimensionada. A última letra clipava — `"Depois"` virava `"Depoi"`.

## Por que demorou pra achar

Como o sintoma dependia de **quando** a fonte chegava, ele parecia mudar de lugar a cada rodada. Cada investigação culpou um detalhe diferente do componente onde apareceu naquela vez:

| PR | culpado apontado | veredito |
| --- | --- | --- |
| #239 | `fontWeight` + `letterSpacing` negativo | plausível, não era |
| #249 | `underline` / `textDecorationLine` | plausível, não era |
| #268 | `Text` sem `flex` numa row | plausível, não era |

A prova de que nenhum era a causa: **o "Depois" continuou cortando depois do #249 ter removido o `underline`** — que foi exatamente o que você reportou agora. É corrida de carregamento, não conflito de estilo.

## O fix

`RootLayout` retorna `null` enquanto `useFonts` não resolve, com o splash nativo segurado pelo `expo-splash-screen` (já disponível desde o #246, quando foi adicionado pra corrigir o splash esticado). A **primeira** medição de texto passa a usar a métrica definitiva.

`fontError` também libera o render: erro de fonte não pode prender o app no splash pra sempre — nesse caso segue com o fallback do sistema, degradação aceitável.

## Sobre os PRs anteriores

Não estou revertendo nenhum. As mudanças deles seguem defensáveis por mérito próprio (`flex-1` numa row com conteúdo variável é correto independente disso; o `underline` some sem prejuízo). Só não eram a causa.

O **#268 continua aberto** e vale mergear pelo motivo original — o `Row` de Ajustes realmente precisa do `flex` pra ellipsizar email longo.

## Test plan

- [x] `eslint`, `prettier`, `tsc`, `npm test` (74/74) limpos.
- [ ] BoT staging: abrir o app → splash segura um instante a mais que antes, e a Home entra já com Inter.
- [ ] Tela de retomada → o link deve ler **"Depois"** completo.
- [ ] Varrer as telas atrás de qualquer outra última-letra cortada — a expectativa é que **todas** tenham sumido de uma vez.
- [ ] Confirmar que o splash não fica preso (o app abre normalmente, sem travar).

⚠️ Custo aceito: o boot fica alguns frames mais lento, porque agora espera a fonte de verdade. Era exatamente o que a fatia 0 quis evitar — mas o preço cobrado por evitar foi três rodadas de bug de render.