### PR TITLE
fix(release): keep staging exclusive to PRs

### DIFF
--- a/.github/workflows/publish-update.yaml
+++ b/.github/workflows/publish-update.yaml
@@ -1,23 +1,24 @@
 name: Publish Update
 
-# Todo merge na main publica OTA em DUAS branches:
+# Todo merge na main publica OTA na branch `release` — e SÓ nela.
 #
 #   release  — linhagem só-main. Única fonte da promoção pros testers.
-#   staging  — bancada de validação, o que o BoT staging consome.
+#   staging  — bancada de validação, alimentada SÓ por PR. Não é tocada aqui.
 #
-# ## Por que duas
+# ## Por que a main não publica mais em staging
 #
-# A branch `staging` também recebe PRs não-mergeados (`test-pr-on-staging.yaml`),
-# porque validar no aparelho só vale se acontecer ANTES do merge — os bugs que
-# motivaram o gate (quebra de fonte no Android, #239/#249) não aparecem no CI
-# nem no preview da Vercel, só no APK.
+# Publicava, com a ideia de manter o BoT staging refletindo a main quando não
+# havia PR em teste. O efeito prático foi outro: como `staging` é um slot só,
+# todo merge SOBRESCREVIA em silêncio o PR que estava sendo validado no
+# aparelho. Aconteceu três vezes seguidas — o #268 e o #270 foram reportados
+# como "não funciona" quando o código deles nem estava no aparelho.
 #
-# Isso torna `staging` uma fonte insegura pra promoção: promover de lá poderia
-# mandar código não-mergeado pros 6 testers. Daí a `release`, que só a main
-# alimenta — é barreira estrutural, não disciplina.
+# Agora a bancada é exclusiva de PR: um merge nunca rouba o teste em curso.
+# Pra ver a main no aparelho, é só rodar `Test PR on Staging` sem PR aberto
+# ou esperar o próximo PR — o custo é bem menor que o da confusão.
 #
-# Publicar main nas duas mantém o BoT staging refletindo a main quando você não
-# está testando um PR específico, e dá o teste de integração da main mesclada.
+# A `release` segue sendo a única fonte da promoção, o que impede código
+# não-mergeado de chegar nos 6 testers. Barreira estrutural, não disciplina.
 #
 # `--environment preview` é o conjunto de env vars do EAS (Supabase etc.), não
 # o canal — todos os ambientes compartilham o mesmo backend de propósito.
@@ -30,7 +31,7 @@ on:
 
 jobs:
   publish:
-    name: main -> release + staging
+    name: main -> release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -51,19 +52,14 @@ jobs:
           MSG: ${{ github.event.head_commit.message }}
         run: eas update --branch release --environment preview --message "$MSG" --non-interactive
 
-      - name: Publica em staging (bancada)
-        env:
-          MSG: ${{ github.event.head_commit.message }}
-        run: eas update --branch staging --environment preview --message "$MSG" --non-interactive
-
       - name: Lembrete de promoção
         run: |
           {
-            echo "## OTA publicada em \`release\` e \`staging\`"
+            echo "## OTA publicada em \`release\`"
             echo ""
             echo "Os testers **não** recebem ainda — a branch \`preview\` só muda por promoção manual."
             echo ""
-            echo "O **BoT staging** já reflete esta main (se você estava testando um PR, ele foi sobrescrito)."
+            echo "O **BoT staging** não foi tocado: a bancada é exclusiva de PR, pra um merge nunca sobrescrever o que você está testando."
             echo ""
             echo "Pra liberar pros testers: rode a workflow **Promote Update**."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/10-canais-e-promocao.md
+++ b/docs/10-canais-e-promocao.md
@@ -17,23 +17,21 @@ O ponto comum: nada disso é pegável por lint, teste ou preview web. Precisa ro
 ## Como funciona agora
 
 ```
-todo PR (a cada push)  ───┐
-(ainda não mergeado)      │
-                          ├──> branch staging ──> canal staging ──> BoT staging
-merge na main  ───────────┘                                         (seu aparelho)
-     │
-     └────────────────────────> branch release
-                                     │
-                                     │  [workflow "Promote Update", manual]
-                                     ▼
-                               branch preview ──> canal preview ──> 6 testers
+todo PR (a cada push) ──────> branch staging ──> canal staging ──> BoT staging
+(ainda não mergeado)                                               (seu aparelho)
+
+merge na main ──────────────> branch release
+                                   │
+                                   │  [workflow "Promote Update", manual]
+                                   ▼
+                             branch preview ──> canal preview ──> 6 testers
 ```
 
 Três branches, dois canais, dois apps no seu aparelho:
 
 | branch    | quem alimenta      | pra quê                            |
 | --------- | ------------------ | ---------------------------------- |
-| `staging` | todo PR + main     | bancada de validação (BoT staging) |
+| `staging` | **só PR**          | bancada de validação (BoT staging) |
 | `release` | só main            | única fonte da promoção            |
 | `preview` | só promoção manual | os 6 testers                       |
 
@@ -52,13 +50,15 @@ Mas isso torna `staging` uma fonte insegura pra promoção: se ela recebe PRs n�
 
 **1. Validar um PR antes de mergear** → não precisa fazer nada. **Todo PR publica em `staging` a cada push**; abra o **BoT staging** no aparelho e confira. Iterar (corrige → empurra → confere) não exige tocar no GitHub.
 
-⚠️ **A bancada é um slot só.** Existe um canal `staging` e um app no aparelho, então o BoT staging mostra sempre **o push mais recente**, seja de qual PR for — e um merge na main também sobrescreve. Não dá pra ter dois PRs carregados ao mesmo tempo; o resumo de cada run diz o que ficou.
+⚠️ **A bancada é um slot só.** Existe um canal `staging` e um app no aparelho, então o BoT staging mostra sempre **o push mais recente**, seja de qual PR for. Não dá pra ter dois PRs carregados ao mesmo tempo; o resumo de cada run diz o que ficou.
+
+**Merge na main NÃO toca a bancada.** Publicava antes, e o efeito era o merge sobrescrever em silêncio o PR que estava sendo validado — aconteceu três vezes, com PRs sendo reportados como "não funciona" quando o código deles nem estava no aparelho. Hoje a bancada é exclusiva de PR.
 
 **Quem não publica:** PR em draft, PR com a label `skip-staging`, PR de fork (não recebe o `EXPO_TOKEN`) e mudança que só toca `docs/**`, `**/*.md` ou `.github/**` (não altera o bundle).
 
 Pra forçar qualquer PR ignorando esses filtros: workflow **Test PR on Staging** no `workflow_dispatch`, passando o número.
 
-**2. Merge na main** → `publish-update.yaml` publica em `release` (fonte da promoção) e em `staging` (o BoT staging volta a refletir a main). Testers não recebem nada.
+**2. Merge na main** → `publish-update.yaml` publica só em `release` (fonte da promoção). Testers não recebem nada, e o BoT staging continua com o que você estava testando.
 
 **3. Promover** → rodar a workflow **Promote Update** (aba Actions). Ela pega o último grupo de `release` e republica em `preview`. Os testers recebem na próxima abertura do app.
 


### PR DESCRIPTION
Remove o passo que publicava a main em `staging`. A bancada passa a ser alimentada **só por PR**.

## O problema

`publish-update.yaml` publicava em `release` **e** `staging`, com a ideia de manter o BoT staging refletindo a main quando não houvesse PR em teste.

O efeito prático foi outro: como `staging` é **um slot só**, todo merge sobrescrevia em silêncio o PR que estava sendo validado no aparelho.

Isso aconteceu **três vezes seguidas** nesta sessão:

- **#268** reportado como "não está funcional" — o código não estava no aparelho, o merge do #267 tinha sobrescrito.
- **#270** reportado como "ainda usa nome completo" — idem, o merge do #272 tinha sobrescrito.

Cada uma dessas rodadas custou uma investigação inteira atrás de um bug de código que não existia. O custo da confusão superou de longe o benefício de ver a main na bancada.

## Depois

```
todo PR (a cada push) ──────> branch staging ──> canal staging ──> BoT staging
(ainda não mergeado)

merge na main ──────────────> branch release ──[promoção manual]──> preview ──> testers
```

| branch | quem alimenta |
| --- | --- |
| `staging` | **só PR** |
| `release` | só main |
| `preview` | só promoção manual |

Pra ver a main no aparelho: rodar `Test PR on Staging` num PR qualquer, ou esperar o próximo. Custo bem menor que o de perder o teste em curso sem aviso.

A `release` segue como única fonte da promoção — a garantia de que código não-mergeado não chega nos 6 testers continua estrutural, não muda nada aqui.

## Test plan

- [x] YAML valida, `prettier` e `npm test` (74/74) limpos.
- [ ] Após merge: conferir que a run publicou **só** em `release` (`eas update:list --branch staging` deve seguir com o PR #270 no topo, intocado).