### PR TITLE
fix(retomada): let layout size the "Depois" link, not text measurement

### DIFF
--- a/components/RetomadaState.jsx
+++ b/components/RetomadaState.jsx
@@ -94,25 +94,26 @@ export default function RetomadaState({ daysSinceLast, onDismiss }) {
         </View>
       </View>
 
-      {/* Link "Depois" — sem `underline` porque no Android + custom font o
-          decoration bugava o advance width e clipava a última letra
-          ("Depoi"). Cor label + peso regular já hierarquiza como link
-          secundário; visualmente basta. */}
-      <View className="items-center">
-        <Pressable
-          accessibilityRole="button"
-          accessibilityLabel="Depois"
-          onPress={onDismiss}
-          className="p-4 active:opacity-70"
+      {/* Link "Depois".
+          O texto centraliza por `text-center`, NÃO por `items-center` no
+          container. Parece a mesma coisa e não é: `alignItems: center` faz o
+          filho encolher pra própria largura, e aí quem decide o tamanho da
+          caixa é a medição de texto do Android — que erra com a Inter e come
+          a última letra ("Depoi"). Com o Text ocupando a largura do pai, a
+          caixa vem do layout e a medição não decide nada. */}
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Depois"
+        onPress={onDismiss}
+        className="p-4 active:opacity-70"
+      >
+        <Text
+          className="text-center text-sm text-label dark:text-label-dark"
+          style={{ fontFamily: "Inter_400Regular" }}
         >
-          <Text
-            className="text-sm text-label dark:text-label-dark"
-            style={{ fontFamily: "Inter_400Regular" }}
-          >
-            Depois
-          </Text>
-        </Pressable>
-      </View>
+          Depois
+        </Text>
+      </Pressable>
     </View>
   );
 }


### PR DESCRIPTION
Quinta tentativa no corte do "Depois" — a primeira com um discriminador de verdade.

## O que finalmente separou as hipóteses

O print da Home mostrou a saudação renderizando **"Boa tarde, Matheus Henrique Dias do Nascimento."** inteira, com ponto final, quebrando em 3 linhas. Mesma fonte, mesma tela, mesmo Android — **sem corte nenhum**.

Ao lado disso, o "Depois" continuava perdendo o "s".

A diferença entre os dois não é fonte, peso, decoration nem espaçamento. É **de onde vem a largura**:

| | como a largura é decidida | resultado |
| --- | --- | --- |
| saudação | `flex-1` → vem do layout | inteiro ✅ |
| "Depois" | encolhe ao conteúdo → vem da medição do Android | corta ❌ |

O link estava dentro de `<View className="items-center">`, que faz o `Pressable` encolher pra largura do conteúdo, que faz o `Text` encolher junto. Nesse arranjo quem dimensiona a caixa é o `measureText` do Android, que erra com a Inter.

## O fix

Centralizar **pelo texto** (`text-center`) em vez de **pela caixa** (`items-center`). Visualmente idêntico; a diferença é que o `Text` passa a ocupar a largura do pai e a medição não decide mais nada.

Isso substitui a explicação do #249, que atribuiu o mesmo sintoma ao `underline`. O decoration foi removido lá e o corte continuou — a hipótese estava errada.

## Escopo: por que só este

O app tem ~20 botões centralizados com forma parecida. **Não mexi neles**, por dois motivos:

1. Eles encolhem **uma vez só** (o `Pressable` já é full-width), enquanto o "Depois" encolhia duas.
2. Nenhum foi reportado com corte.

Cheguei a converter 6 deles e reverti. Depois de quatro diagnósticos errados neste mesmo bug, mudar 20 arquivos por semelhança estrutural sem evidência é exatamente o padrão que quero parar de repetir. Se aparecer corte num botão, o fix é o mesmo e aplico na hora.

## Test plan

- [x] `eslint`, `prettier`, `tsc`, `npm test` (74/74) limpos.
- [ ] BoT staging → tela de retomada → o link deve ler **"Depois"** completo, centralizado como antes.
- [ ] Conferir que o toque ainda funciona (a área clicável mudou de largura-do-texto pra largura-do-container, o que é melhor pra acessibilidade).