### PR TITLE
fix(sync): diz que falta login em vez de fingir queda de rede

### DIFF
--- a/app/ajustes.jsx
+++ b/app/ajustes.jsx
@@ -22,6 +22,7 @@ import { useSession } from "@/infra/session";
 import { AUTH_ENABLED } from "@/infra/supabase";
 import {
   SYNC_CONNECTING,
+  SYNC_NEEDS_AUTH,
   SYNC_OFF,
   SYNC_OFFLINE,
   SYNC_ONLINE,
@@ -419,14 +420,25 @@ const SYNC_UI = {
     text: "desligado",
     hint: null,
   },
+  // Recusado por falta de login (#278). Antes isto caía em `offline`, e as
+  // três coisas ficavam falsas ao mesmo tempo: não era falta de conexão, nada
+  // ia "subir quando voltar", e o "Tentar de novo" nunca funcionaria. Copy
+  // sem cobrança, como o resto — o registro local segue intacto.
+  [SYNC_NEEDS_AUTH]: {
+    dot: "bg-border-strong dark:bg-border-strong-dark",
+    text: "precisa entrar",
+    hint: "Seus registros estão salvos aqui. Entre para guardá-los também na sua conta.",
+  },
 };
 
 function SyncRow() {
   const { status, reconnect } = useSyncStatus();
   const ui = SYNC_UI[status] ?? SYNC_UI[SYNC_OFF];
   // Só oferece "tentar de novo" quando há o que retentar. Em `off` não há
-  // servidor configurado; em `connecting`/`online` já está acontecendo.
+  // servidor configurado; em `connecting`/`online` já está acontecendo; em
+  // `needs-auth` retentar é justamente o que não resolve — a ação é entrar.
   const canRetry = status === SYNC_OFFLINE;
+  const precisaEntrar = status === SYNC_NEEDS_AUTH;
 
   return (
     <View className="gap-1 border-t border-surface-subtle dark:border-surface-subtle-dark px-4 py-3">
@@ -467,6 +479,21 @@ function SyncRow() {
             style={{ fontFamily: "Inter_500Medium" }}
           >
             Tentar de novo
+          </Text>
+        </Pressable>
+      ) : null}
+      {precisaEntrar ? (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Entrar para sincronizar"
+          onPress={() => router.navigate("/login")}
+          className="mt-1 self-start rounded-xl bg-surface-subtle dark:bg-surface-subtle-dark px-3 py-1.5 active:opacity-70"
+        >
+          <Text
+            className="text-xs text-primary dark:text-primary-dark"
+            style={{ fontFamily: "Inter_500Medium" }}
+          >
+            Entrar
           </Text>
         </Pressable>
       ) : null}

--- a/infra/sync-session.js
+++ b/infra/sync-session.js
@@ -68,3 +68,25 @@ export function isTokenExpired(session, now = Date.now(), skewMs = 5_000) {
   if (!Number.isFinite(exp) || exp <= 0) return false;
   return exp * 1000 - skewMs <= now;
 }
+
+/**
+ * A conexão caiu porque falta login — e não porque a rede caiu? (#278)
+ *
+ * Só é verdade quando as duas coisas valem: o client não tem token **e** o
+ * server declarou `authMode: "required"` no `/healthz`. Nesse par a recusa é
+ * determinística: anônimo nunca vai entrar, por mais que tente.
+ *
+ * Fora disso, `false` — inclusive quando o modo é desconhecido (o `/healthz`
+ * não respondeu). Server inalcançável **é** problema de rede, então cair no
+ * caminho de "sem conexão" está certo ali.
+ *
+ * Importa não errar pra cá: dizer "precisa entrar" pra quem só está sem sinal
+ * manda a pessoa fazer login à toa e esconde a causa real.
+ *
+ * @param {boolean} hasToken O client mandou `?token=`?
+ * @param {string | null | undefined} authMode O que o `/healthz` devolveu.
+ * @returns {boolean}
+ */
+export function needsLogin(hasToken, authMode) {
+  return !hasToken && authMode === "required";
+}

--- a/infra/sync-url.js
+++ b/infra/sync-url.js
@@ -19,3 +19,29 @@ export function buildSyncUrl(baseUrl, roomId, token) {
   const base = `${baseUrl}/${encodeURIComponent(String(roomId))}`;
   return token ? `${base}?token=${encodeURIComponent(token)}` : base;
 }
+
+/**
+ * URL do `/healthz`, derivada da mesma base do sync (#278).
+ *
+ * O server anuncia ali o `authMode`. O client precisa disso porque o 401 do
+ * handshake **não atravessa** o WebSocket: browser e React Native não expõem
+ * o status HTTP de um upgrade recusado, então uma rejeição por falta de login
+ * é indistinguível de queda de rede.
+ *
+ * Consultar isto resolve as duas coisas de uma vez: se o `/healthz` responde,
+ * a rede está de pé e a recusa foi política; se nem ele responde, é rede
+ * mesmo. Não precisa de heurística.
+ *
+ * `wss://` vira `https://` e `ws://` vira `http://` — mesmo host, mesma porta.
+ *
+ * @param {string} baseUrl Mesma base do `buildSyncUrl` (ex.: `wss://host`).
+ * @returns {string | null} `null` se a base estiver vazia (sync desligado).
+ */
+export function buildHealthzUrl(baseUrl) {
+  if (!baseUrl) return null;
+  const semBarra = String(baseUrl).replace(/\/+$/, "");
+  const http = semBarra
+    .replace(/^wss:\/\//i, "https://")
+    .replace(/^ws:\/\//i, "http://");
+  return `${http}/healthz`;
+}

--- a/infra/sync.js
+++ b/infra/sync.js
@@ -14,9 +14,9 @@ import { useCreateSynchronizer, useValue } from "tinybase/ui-react";
 import { SYNC_URL } from "@/constants/sync";
 import { store } from "./database";
 import { useSession } from "./session";
-import { buildSyncUrl } from "./sync-url";
+import { buildHealthzUrl, buildSyncUrl } from "./sync-url";
 import { retryDelay } from "./sync-retry";
-import { isTokenExpired, resolveRoomId } from "./sync-session";
+import { isTokenExpired, needsLogin, resolveRoomId } from "./sync-session";
 
 // Re-exporta pra manter API estável (callers antigos podem importar de sync.js).
 // A implementação vive em infra/sync-url.js pra ficar testável isolado
@@ -28,6 +28,41 @@ export const SYNC_OFF = "off";
 export const SYNC_CONNECTING = "connecting";
 export const SYNC_ONLINE = "online";
 export const SYNC_OFFLINE = "offline";
+/** Recusado por falta de login, não por rede (#278). Não adianta retentar. */
+export const SYNC_NEEDS_AUTH = "needs-auth";
+
+/**
+ * Pergunta ao server em que `AUTH_MODE` ele está.
+ *
+ * Serve a dois propósitos de uma vez: se responde, a rede está de pé e a
+ * recusa do WS foi política; se não responde, é rede mesmo. Por isso o
+ * `catch` devolve `null` em vez de propagar — "não sei" é uma resposta útil
+ * aqui, e o caller trata como offline.
+ *
+ * @param {string | null} healthzUrl
+ * @param {number} [timeoutMs]
+ * @returns {Promise<string | null>} `"optional"`, `"required"` ou `null`.
+ */
+async function fetchAuthMode(healthzUrl, timeoutMs = 4000) {
+  if (!healthzUrl) return null;
+  // AbortController existe em RN e no web; o timeout evita ficar pendurado
+  // num server que aceita a conexão TCP e não responde.
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    const res = await fetch(healthzUrl, {
+      signal: ctrl.signal,
+      cache: "no-store",
+    });
+    if (!res.ok) return null;
+    const corpo = await res.json();
+    return corpo?.authMode ?? null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(t);
+  }
+}
 
 /**
  * Conecta o MergeableStore ao server WS de sync, com reconexão automática.
@@ -168,11 +203,33 @@ export function useRegistrosSync() {
       const ws = new WebSocket(url);
       currentWsRef.current = ws;
 
-      const onDown = () => {
+      const onDown = async () => {
         // Conexão obsoleta (já trocamos de socket) ou hook desmontado:
         // não mexer em estado nem agendar nada.
         if (currentWsRef.current !== ws || !mountedRef.current) return;
         if (retryTimerRef.current) return; // retry já agendado
+
+        // Caiu sem token: pode não ser rede. Sob `AUTH_MODE=required` o
+        // server recusa anônimo por política, e o 401 do handshake não chega
+        // até aqui — a API WebSocket não expõe status de upgrade recusado.
+        // Perguntar o modo é o que separa "preciso entrar" de "estou sem
+        // sinal"; sem isso o app diz "sem conexão" e oferece um "Tentar de
+        // novo" que nunca vai funcionar (#278).
+        if (!token) {
+          const modo = await fetchAuthMode(buildHealthzUrl(SYNC_URL));
+          // Reconferir depois do await: o socket pode ter sido trocado ou o
+          // hook desmontado enquanto a sondagem estava no ar.
+          if (currentWsRef.current !== ws || !mountedRef.current) return;
+          if (retryTimerRef.current) return;
+          if (needsLogin(false, modo)) {
+            // Sem retry de propósito: anônimo não entra por mais que insista.
+            // Ficar no backoff só gastaria bateria e encheria o log do server
+            // de rejeição que nós mesmos causamos.
+            setStatus(SYNC_NEEDS_AUTH);
+            return;
+          }
+        }
+
         setStatus(SYNC_OFFLINE);
         const delay = retryDelay(retryExpRef.current);
         retryExpRef.current += 1;

--- a/server/README.md
+++ b/server/README.md
@@ -134,6 +134,7 @@ Confere no log do boot qual verificador subiu:
 
 | Requisição                             | `AUTH_MODE=optional` | `AUTH_MODE=required` |
 | -------------------------------------- | -------------------- | -------------------- |
+| `GET /healthz`                         | 200 + `authMode`     | 200 + `authMode`     |
 | Sem `?token=`                          | ✅ aceita anônimo    | ❌ 401               |
 | `?token=` válido + `sub === pathId`    | ✅ aceita            | ✅ aceita            |
 | `?token=` válido + `sub !== pathId`    | ❌ 403               | ❌ 403               |
@@ -142,12 +143,42 @@ Confere no log do boot qual verificador subiu:
 | `?token=` ES256 com `kid` fora do JWKS | ❌ 401               | ❌ 401               |
 | `?token=` alg não suportado (RS256…)   | ❌ 401               | ❌ 401               |
 
+### `GET /healthz` — anúncio do modo (#278)
+
+```
+$ curl https://backontrack-sync.mhdn.com.br/healthz
+{"ok":true,"authMode":"required"}
+```
+
+Existe por um motivo específico: **o 401 do handshake não chega ao app.** A API
+WebSocket de browser e React Native não expõe o status HTTP de um upgrade
+recusado — o cliente vê só um `close` genérico, indistinguível de queda de
+rede. Sem isto, o tester sem login veria "sem conexão" e um "Tentar de novo"
+que nunca funciona.
+
+O client consulta este endpoint **só quando** uma conexão sem token falha.
+A resposta resolve as duas perguntas de uma vez:
+
+| `/healthz` respondeu? | `authMode` | conclusão do client                                      |
+| --------------------- | ---------- | -------------------------------------------------------- |
+| sim                   | `required` | é política — mostra "precisa entrar", **para o backoff** |
+| sim                   | `optional` | é rede — mostra "sem conexão", segue tentando            |
+| não                   | —          | server inalcançável, é rede — mostra "sem conexão"       |
+
+Alternativas descartadas: inferir no client sem perguntar (mente em
+`optional`, onde a mesma falha é rede de verdade) e aceitar o upgrade pra
+fechar com close code 4001 (o `createWsServer` registraria a conexão e criaria
+o arquivo de sala — um por conexão rejeitada, o lixo da #277 automatizado).
+
+Qualquer outra rota HTTP segue respondendo `426 Upgrade Required`.
+
 ### Rollout
 
 1. Deploy com `AUTH_MODE=optional`. Clientes anônimos (compat) continuam sincronizando.
 2. Merge da fatia C (cliente passa a mandar JWT + migração dos dados anônimos → sala do userId). OTA chega nos testers.
 3. Aviso via WhatsApp (Evolution API) pros testers logarem — [[evolution-api-testers-stack]].
-4. Dias depois, PR separado: flip `AUTH_MODE=required` no server. Anônimo passa a ser rejeitado.
+4. **Deploy do server com `/healthz`** (#278) — precisa vir ANTES do flip. Enquanto não estiver no ar, o client sonda, não recebe resposta, e cai no caminho de "sem conexão": mesma coisa que hoje, sem regressão. Mas se o flip acontecer antes deste deploy, o tester sem login volta a ver a mensagem errada.
+5. Dias depois, PR separado: flip `AUTH_MODE=required` no server. Anônimo passa a ser rejeitado.
 
 Cloudflare Tunnel na frente já garante TLS válido; o server em si só fala WS plano em `127.0.0.1:8787` do host (loopback, não LAN — só o cloudflared do systemd alcança).
 

--- a/server/server.js
+++ b/server/server.js
@@ -34,6 +34,7 @@ import {
   verify,
 } from "node:crypto";
 import { mkdirSync } from "node:fs";
+import { createServer } from "node:http";
 import { join, resolve } from "node:path";
 
 import { createMergeableStore } from "tinybase";
@@ -169,8 +170,46 @@ async function verifyJwt(token) {
   return payload;
 }
 
+// Servidor HTTP na frente do WS, por um motivo só: anunciar o AUTH_MODE (#278).
+//
+// Quando o server recusa uma conexão sem token, ele responde 401 no handshake
+// — mas o 401 **não atravessa** até o cliente. A API WebSocket de browser e
+// React Native não expõe o status HTTP de um handshake que falhou; o app vê
+// só um `close` genérico, indistinguível de queda de rede. Sem isto, o tester
+// sem login veria "sem conexão" e um "Tentar de novo" que nunca funciona.
+//
+// Alternativas descartadas:
+//   - **Inferir no client** ("falhou e não tenho sessão ⇒ preciso entrar"):
+//     mente em `AUTH_MODE=optional`, onde a mesma falha é rede de verdade.
+//   - **Aceitar o upgrade e fechar com close code 4001** (esse o cliente lê):
+//     aceitar faz o `createWsServer` registrar a conexão e criar o persister,
+//     ou seja um arquivo de sala por conexão rejeitada. É o lixo da #277 de
+//     volta, agora automatizado.
+//
+// Então: a recusa continua no `verifyClient` (nada é alocado pra quem não
+// passa) e o cliente pergunta o modo aqui, só quando falha sem token.
+const httpServer = createServer((req, res) => {
+  const rota = (req.url ?? "").split("?")[0].replace(/\/+$/, "") || "/";
+  if (req.method === "GET" && rota === "/healthz") {
+    const corpo = JSON.stringify({ ok: true, authMode: AUTH_MODE });
+    res.writeHead(200, {
+      "content-type": "application/json",
+      "content-length": Buffer.byteLength(corpo),
+      // O app é servido de outra origem (e no native não há origem). Só
+      // devolve o modo de auth — nada aqui é segredo.
+      "access-control-allow-origin": "*",
+      "cache-control": "no-store",
+    });
+    res.end(corpo);
+    return;
+  }
+  // Qualquer outra coisa segue como antes: este endpoint é de WebSocket.
+  res.writeHead(426, { "content-type": "text/plain" });
+  res.end("Upgrade Required");
+});
+
 const wss = new WebSocketServer({
-  port: PORT,
+  server: httpServer,
   verifyClient: ({ req }, callback) => {
     const url = new URL(req.url, "http://internal");
     const pathId = url.pathname.replace(/^\/+/, "").replace(/\/+$/, "");
@@ -228,6 +267,11 @@ const verifiers = [
   .filter(Boolean)
   .join(" + ");
 
-console.log(
-  `[sync] listening on ws://0.0.0.0:${PORT} — data dir: ${DATA_DIR} — auth: ${AUTH_MODE}${verifiers ? ` (${verifiers})` : ""}`,
-);
+// O log sai DENTRO do callback do listen: os testes usam essa linha como
+// sinal de "já bindou" pra começar a conectar. Emitir antes abriria uma
+// corrida em que o teste conecta num socket que ainda não existe.
+httpServer.listen(PORT, () => {
+  console.log(
+    `[sync] listening on ws://0.0.0.0:${PORT} — data dir: ${DATA_DIR} — auth: ${AUTH_MODE}${verifiers ? ` (${verifiers})` : ""}`,
+  );
+});

--- a/tests/sync-server-auth.test.js
+++ b/tests/sync-server-auth.test.js
@@ -12,7 +12,7 @@ import {
   sign as cryptoSign,
 } from "node:crypto";
 import { mkdtempSync, rmSync } from "node:fs";
-import { createServer } from "node:http";
+import { createServer, request as httpRequest } from "node:http";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
@@ -187,6 +187,99 @@ function tryConnect(port, room, token, timeoutMs = 3000) {
     });
   });
 }
+
+// --- /healthz: anúncio do modo (#278) ------------------------------------
+
+// O 401 do handshake não chega ao app (browser/RN não expõem status HTTP de
+// upgrade que falhou), então o client pergunta o modo aqui pra saber se a
+// falha foi política ou rede. Se este endpoint mentir, o app volta a dizer
+// "sem conexão" pra quem na verdade precisa entrar.
+
+// `fetch` global aqui é o do ambiente jest-expo (React Native), não o do
+// Node — `res.status` vem undefined. Usa http.request direto, como o resto
+// deste arquivo já faz com o cliente `ws`.
+function httpGet(port, path) {
+  return new Promise((resolveGet, rejectGet) => {
+    const req = httpRequest(
+      { host: "127.0.0.1", port, path, method: "GET" },
+      (res) => {
+        let corpo = "";
+        res.on("data", (c) => (corpo += c));
+        res.on("end", () => resolveGet({ status: res.statusCode, corpo }));
+      },
+    );
+    req.on("error", rejectGet);
+    req.end();
+  });
+}
+
+async function getHealthz(port) {
+  const { status, corpo } = await httpGet(port, "/healthz");
+  return { status, body: JSON.parse(corpo) };
+}
+
+describe("GET /healthz", () => {
+  test("anuncia authMode=optional quando o server está em optional", async () => {
+    const server = await startServer({
+      AUTH_MODE: "optional",
+      SUPABASE_JWT_SECRET: JWT_SECRET,
+    });
+    try {
+      const { status, body } = await getHealthz(server.port);
+      expect(status).toBe(200);
+      expect(body).toEqual({ ok: true, authMode: "optional" });
+    } finally {
+      await stopServer(server);
+    }
+  }, 15000);
+
+  test("anuncia authMode=required quando o server está em required", async () => {
+    const server = await startServer({
+      AUTH_MODE: "required",
+      SUPABASE_JWT_SECRET: JWT_SECRET,
+    });
+    try {
+      const { status, body } = await getHealthz(server.port);
+      expect(status).toBe(200);
+      expect(body.authMode).toBe("required");
+    } finally {
+      await stopServer(server);
+    }
+  }, 15000);
+
+  // Regressão: o WS precisa continuar funcionando com o http.createServer na
+  // frente. Trocar `port:` por `server:` no WebSocketServer faz ele parar de
+  // bindar sozinho — sem o listen explícito, nada escuta.
+  test("o WebSocket continua de pé com o HTTP na frente", async () => {
+    const server = await startServer({
+      AUTH_MODE: "optional",
+      SUPABASE_JWT_SECRET: JWT_SECRET,
+    });
+    try {
+      const res = await tryConnect(
+        server.port,
+        "sala-com-http-na-frente",
+        null,
+      );
+      expect(res).toEqual({ open: true });
+    } finally {
+      await stopServer(server);
+    }
+  }, 15000);
+
+  test("rota desconhecida segue respondendo 426 Upgrade Required", async () => {
+    const server = await startServer({
+      AUTH_MODE: "optional",
+      SUPABASE_JWT_SECRET: JWT_SECRET,
+    });
+    try {
+      const res = await httpGet(server.port, "/qualquer-coisa");
+      expect(res.status).toBe(426);
+    } finally {
+      await stopServer(server);
+    }
+  }, 15000);
+});
 
 // --- AUTH_MODE=optional --------------------------------------------------
 

--- a/tests/sync-session.test.js
+++ b/tests/sync-session.test.js
@@ -1,5 +1,9 @@
 // @ts-nocheck -- teste; globals do jest não são tipados (ADR-002)
-import { isTokenExpired, resolveRoomId } from "@/infra/sync-session";
+import {
+  isTokenExpired,
+  needsLogin,
+  resolveRoomId,
+} from "@/infra/sync-session";
 
 // Cobre os dois defeitos da #275. Os dois eram "tratar 'ainda não sei' como se
 // fosse resposta" — os testes abaixo travam justamente esse instante.
@@ -102,5 +106,34 @@ describe("isTokenExpired", () => {
     const daquiUmaHora = sessao(AGORA + 3_600_000);
     expect(daquiUmaHora.expires_at).toBeLessThan(AGORA); // é segundos mesmo
     expect(isTokenExpired(daquiUmaHora, AGORA)).toBe(false);
+  });
+});
+
+describe("needsLogin", () => {
+  // O caso que a #278 existe pra resolver.
+  it("sem token + server em required = precisa entrar", () => {
+    expect(needsLogin(false, "required")).toBe(true);
+  });
+
+  // Hoje o server roda optional. Dizer "precisa entrar" aqui seria trocar uma
+  // mentira por outra: a falha é rede de verdade.
+  it("sem token + server em optional = não é problema de login", () => {
+    expect(needsLogin(false, "optional")).toBe(false);
+  });
+
+  // Server inalcançável: o /healthz não respondeu, então o modo é null. Isso
+  // É problema de rede — cair em "sem conexão" está certo.
+  it("modo desconhecido nunca vira 'precisa entrar'", () => {
+    expect(needsLogin(false, null)).toBe(false);
+    expect(needsLogin(false, undefined)).toBe(false);
+    expect(needsLogin(false, "")).toBe(false);
+  });
+
+  // Quem TEM token e falhou tem outro problema (token vencido, sub errado,
+  // rede). Mandar essa pessoa "entrar" esconderia a causa real.
+  it("com token nunca é 'precisa entrar', em nenhum modo", () => {
+    expect(needsLogin(true, "required")).toBe(false);
+    expect(needsLogin(true, "optional")).toBe(false);
+    expect(needsLogin(true, null)).toBe(false);
   });
 });

--- a/tests/sync-url.test.js
+++ b/tests/sync-url.test.js
@@ -3,7 +3,7 @@
 // infra/sync.js — a lógica de montagem/encoding da URL onde bug moraria
 // (roomId com espaço, JWT com `+`/`=`, mistura de logado/deslogado).
 
-import { buildSyncUrl } from "../infra/sync-url";
+import { buildHealthzUrl, buildSyncUrl } from "../infra/sync-url";
 
 describe("buildSyncUrl", () => {
   const BASE = "wss://backontrack-sync.mhdn.com.br";
@@ -54,5 +54,56 @@ describe("buildSyncUrl", () => {
     // useValue pode retornar tipos diferentes conforme a store — proteja o
     // template string de virar `[object Object]` ou `undefined`.
     expect(buildSyncUrl(BASE, 42, null)).toBe(`${BASE}/42`);
+  });
+});
+
+// --- buildHealthzUrl (#278) ----------------------------------------------
+
+// O client consulta o /healthz pra saber se a recusa do WS foi política
+// (AUTH_MODE=required) ou rede. Errar o esquema aqui faz a sondagem falhar
+// sempre, e falha de sondagem é lida como "offline" — ou seja, o app voltaria
+// silenciosamente a mentir pro tester sem login.
+describe("buildHealthzUrl", () => {
+  it("converte wss:// em https://", () => {
+    expect(buildHealthzUrl("wss://backontrack-sync.mhdn.com.br")).toBe(
+      "https://backontrack-sync.mhdn.com.br/healthz",
+    );
+  });
+
+  it("converte ws:// em http:// (dev local)", () => {
+    expect(buildHealthzUrl("ws://localhost:8787")).toBe(
+      "http://localhost:8787/healthz",
+    );
+  });
+
+  it("preserva a porta", () => {
+    expect(buildHealthzUrl("ws://192.168.1.25:8787")).toBe(
+      "http://192.168.1.25:8787/healthz",
+    );
+  });
+
+  it("tolera barra no fim sem duplicar", () => {
+    expect(buildHealthzUrl("wss://host/")).toBe("https://host/healthz");
+    expect(buildHealthzUrl("wss://host///")).toBe("https://host/healthz");
+  });
+
+  it("aceita esquema em maiúsculas", () => {
+    expect(buildHealthzUrl("WSS://host")).toBe("https://host/healthz");
+  });
+
+  // Sync desligado (EXPO_PUBLIC_SYNC_URL="") não deve produzir URL nenhuma —
+  // o caller usa null pra não sondar.
+  it("devolve null quando a base está vazia", () => {
+    expect(buildHealthzUrl("")).toBeNull();
+    expect(buildHealthzUrl(null)).toBeNull();
+    expect(buildHealthzUrl(undefined)).toBeNull();
+  });
+
+  // Só o PREFIXO vira http. Um host que contenha "ws" no meio não pode ser
+  // reescrito por engano.
+  it("não reescreve 'ws' fora do esquema", () => {
+    expect(buildHealthzUrl("wss://ws-sync.example.com")).toBe(
+      "https://ws-sync.example.com/healthz",
+    );
   });
 });


### PR DESCRIPTION
Fecha #278. Pré-requisito do flip pra `AUTH_MODE=required`.

## O problema

Toda recusa do server vira `SYNC_OFFLINE` hoje. Depois do flip, o tester sem
login veria em Ajustes:

> ● sem conexão
> _Seus registros ficam salvos aqui e sobem quando voltar._
> [Tentar de novo]

As três coisas falsas ao mesmo tempo: não é falta de conexão, nada vai subir
quando voltar, e retentar nunca resolve. E o backoff ficaria reconectando pra
sempre — bateria do tester e log do server cheio de rejeição que nós mesmos
causamos.

**Por que não dava pra distinguir:** o 401 acontece no `verifyClient`, antes
do upgrade HTTP. A API WebSocket de browser e React Native não expõe o status
de um handshake recusado — o app vê só um `close` genérico, igualzinho a
queda de rede.

## A solução

**Server:** `GET /healthz` → `{"ok":true,"authMode":"optional|required"}`.
A recusa continua no `verifyClient` (nada é alocado pra quem não passa, e os
8 testes de auth seguem intactos).

**Client:** quando uma conexão **sem token** cai, sonda o `/healthz`. A
resposta resolve as duas perguntas de uma vez:

| `/healthz` respondeu? | `authMode` | conclusão |
| --- | --- | --- |
| sim | `required` | política → "precisa entrar", **backoff para** |
| sim | `optional` | rede → "sem conexão", segue tentando |
| não | — | server inalcançável → rede → "sem conexão" |

Repare que o caso "server fora do ar" se resolve sozinho: se nem o `/healthz`
responde, é rede. Não precisa de heurística.

**UI:** estado `needs-auth` com copy honesta e ação **Entrar** em vez de
"Tentar de novo".

## Alternativas descartadas

- **Inferir no client** ("falhou e não tenho sessão ⇒ preciso entrar"): mente
  em `AUTH_MODE=optional`, que é o modo de hoje, onde a mesma falha é rede de
  verdade. Trocaria uma mensagem errada por outra.
- **Close code 4001** (aceitar o upgrade e fechar com código próprio, que o
  cliente _consegue_ ler, ao contrário do 401): aceitar faz o `createWsServer`
  registrar a conexão e criar o persister — **um arquivo de sala por conexão
  rejeitada**. É o lixo que a #277 acabou de limpar, agora automatizado.

## ⚠️ Ordem de deploy

O server precisa ter o `/healthz` no ar **antes** do flip. Enquanto não tiver,
a sondagem não recebe resposta e o client cai em "sem conexão" — igual a hoje,
sem regressão. Mas flipar antes de deployar traz a mensagem errada de volta.
Documentado no README como passo 4 do rollout.

## Testes

109 → 120. Verificado por mutação que caem contra o comportamento errado:

| mutação | testes que caem |
| --- | --- |
| `needsLogin` trata modo desconhecido como `required` | 1 |
| `needsLogin` ignora o token | 1 |
| `buildHealthzUrl` esquece de trocar o esquema | 4 |

Também subi o server na mão em `required` e confirmei as respostas reais:
`/healthz` correto, `426` em rota desconhecida, `401` no upgrade anônimo.

## Como validar no staging

Não dá pra exercitar o caminho novo sem um server em `required`, e o de
produção está em `optional`. O que dá pra conferir:

1. Sync continua funcionando normalmente (logado e deslogado) — o WS agora
   passa por um `http.createServer`, então vale confirmar que nada regrediu.
2. `curl https://backontrack-sync.mhdn.com.br/healthz` **depois** do deploy do
   server deve devolver `{"ok":true,"authMode":"optional"}`.

O estado `needs-auth` em si só aparece quando o flip acontecer.
