### PR TITLE
feat(sync): banner global e dispensável quando falta login

### DIFF
--- a/components/UpdateBanner.jsx
+++ b/components/UpdateBanner.jsx
@@ -1,8 +1,8 @@
 // @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
 //
-// Banners de atualização (evoluído do #131).
+// Banners do rodapé (evoluído do #131).
 //
-// Três estados, em ordem de prioridade (só um aparece):
+// Quatro estados, em ordem de prioridade (só um aparece):
 //
 //   1. NATIVE_OUTDATED  — versão do APK em execução é MENOR que a última
 //      publicada. Nesses casos o OTA não cobre (`runtimeVersion.policy:
@@ -18,6 +18,16 @@
 //   3. UPDATE_PENDING   — bundle baixado, esperando reload. Toque aplica.
 //      Comportamento original do #131.
 //
+//   4. NEEDS_AUTH       — o sync foi recusado por falta de login (#281). Vem
+//      por último de propósito: os três de cima são transitórios e se
+//      resolvem sozinhos, este persiste até a pessoa entrar. Se disputassem,
+//      o permanente esconderia os passageiros.
+//
+//      É o único **dispensável**, pela mesma razão: um aviso que não passa e
+//      não fecha vira ruído em cima de quem já decidiu não logar. Dispensar
+//      vale só pra sessão (mesmo critério do `RetomadaState` da Home) —
+//      próxima abertura convida de novo, que é o objetivo.
+//
 // Em dev/web/native sem update mecanismo os hooks retornam false — banner
 // não aparece. Fetch da última APK version só tenta em native com rede;
 // falha silenciosa mantém o banner desligado.
@@ -27,8 +37,11 @@ import { Linking, Platform, Pressable, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { ProgressBar } from "react-native-paper";
 import Constants from "expo-constants";
+import { router } from "expo-router";
 import { useUpdates, reloadAsync } from "expo-updates";
 
+import { SYNC_NEEDS_AUTH, useSyncStatus } from "@/infra/sync";
+import { pickBanner } from "@/constants/bannerPriority";
 import { useThemeTokens } from "@/constants/themeTokens";
 
 // Fonte remota da última versão do APK cortada, atualizada manualmente no repo
@@ -60,6 +73,9 @@ export default function UpdateBanner() {
   const { isUpdatePending, isDownloading } = useUpdates();
   const insets = useSafeAreaInsets();
   const t = useThemeTokens();
+  const { status: syncStatus } = useSyncStatus();
+  // Dispensa só a sessão atual — ver a nota de prioridade no topo do arquivo.
+  const [authDismissed, setAuthDismissed] = useState(false);
 
   // Última APK conhecida — carrega em background, sem bloquear render.
   const [latestApk, setLatestApk] = useState(
@@ -87,8 +103,15 @@ export default function UpdateBanner() {
 
   const bottomPad = insets.bottom + 12;
 
-  // Prioridade: native outdated > downloading > pending.
-  if (nativeOutdated) {
+  const qual = pickBanner({
+    nativeOutdated,
+    isDownloading,
+    isUpdatePending,
+    needsAuth: syncStatus === SYNC_NEEDS_AUTH,
+    authDismissed,
+  });
+
+  if (qual === "native-outdated") {
     const url = latestApk.installUrl;
     return (
       <BannerBase
@@ -114,7 +137,7 @@ export default function UpdateBanner() {
     );
   }
 
-  if (isDownloading) {
+  if (qual === "downloading") {
     return (
       <BannerBase color={t.surfaceSubtle} bottomPad={bottomPad}>
         <Text
@@ -130,7 +153,7 @@ export default function UpdateBanner() {
     );
   }
 
-  if (isUpdatePending) {
+  if (qual === "update-pending") {
     return (
       <BannerBase
         color={t.accentToday}
@@ -148,18 +171,50 @@ export default function UpdateBanner() {
     );
   }
 
+  // Falta login (#281). Só chega aqui quando o server recusou por política —
+  // ver `SYNC_NEEDS_AUTH` em infra/sync.js. Copy sem cobrança e sem alarme: o
+  // registro local está intacto, o que falta é a cópia na conta.
+  if (qual === "needs-auth") {
+    return (
+      <BannerBase
+        color={t.surfaceSubtle}
+        bottomPad={bottomPad}
+        onPress={() => router.navigate("/login")}
+        accessibilityLabel="Entrar para sincronizar seus registros"
+        onDismiss={() => setAuthDismissed(true)}
+      >
+        <Text
+          className="text-center text-ink dark:text-ink-dark"
+          style={{ fontFamily: "Inter_600SemiBold", fontSize: 14 }}
+        >
+          Entre para guardar seus registros na sua conta
+        </Text>
+        <Text
+          className="text-center text-body-secondary dark:text-body-secondary-dark"
+          style={{ fontFamily: "Inter_400Regular", fontSize: 12, marginTop: 2 }}
+        >
+          Eles seguem salvos aqui no aparelho. Toque para entrar.
+        </Text>
+      </BannerBase>
+    );
+  }
+
   return null;
 }
 
 /**
- * Wrapper visual + safe-area comum aos 3 banners. Absoluto no rodapé porque
+ * Wrapper visual + safe-area comum aos banners. Absoluto no rodapé porque
  * cada tela já monta o próprio safe-area (MyView safe) e o app é edge-to-edge;
  * absoluto flutua sem mexer no layout de ninguém.
+ *
+ * `onDismiss` é opcional e só o banner de login usa (#281) — os de
+ * atualização não fecham porque somem sozinhos quando a causa passa.
  *
  * @param {{
  *   color: string,
  *   bottomPad: number,
  *   onPress?: () => void,
+ *   onDismiss?: () => void,
  *   accessibilityLabel?: string,
  *   children: any,
  * }} props
@@ -168,6 +223,7 @@ function BannerBase({
   color,
   bottomPad,
   onPress,
+  onDismiss,
   accessibilityLabel,
   children,
 }) {
@@ -185,7 +241,33 @@ function BannerBase({
       className="absolute right-0 bottom-0 left-0 px-4 pt-3"
       style={{ backgroundColor: color, paddingBottom: bottomPad }}
     >
-      {children}
+      {/* Reserva à direita pro botão de fechar não cobrir o fim do texto.
+          Sem isso a última palavra passa por baixo do × em telas estreitas. */}
+      <View style={onDismiss ? { paddingRight: 32 } : undefined}>
+        {children}
+      </View>
+      {onDismiss ? (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Dispensar aviso"
+          onPress={onDismiss}
+          // Área de toque generosa: o alvo visual é um glifo pequeno, e no
+          // rodapé o polegar erra fácil.
+          hitSlop={12}
+          className="absolute right-2 active:opacity-60"
+          style={{ top: 8, padding: 8 }}
+        >
+          {/* `text-center` com largura fixa, não `items-center` no pai: o
+              Text encolhido ao conteúdo deixa a medição do Android decidir a
+              caixa, e ela erra com a Inter cortando o glifo. */}
+          <Text
+            className="text-center text-body-secondary dark:text-body-secondary-dark"
+            style={{ fontFamily: "Inter_500Medium", fontSize: 16, width: 16 }}
+          >
+            ×
+          </Text>
+        </Pressable>
+      ) : null}
     </Wrap>
   );
 }

--- a/components/UpdateBanner.jsx
+++ b/components/UpdateBanner.jsx
@@ -227,25 +227,42 @@ function BannerBase({
   accessibilityLabel,
   children,
 }) {
-  const Wrap = onPress ? Pressable : View;
+  // Área principal e botão de fechar são IRMÃOS, nunca aninhados.
+  //
+  // Aninhar quebra no web: o `accessibilityRole="button"` faz o
+  // react-native-web renderizar um `<button>` de verdade, e `<button>` dentro
+  // de `<button>` é aninhamento inválido — o React DOM recusa e derruba a
+  // árvore. Só apareceu quando o banner de login passou `onPress` e
+  // `onDismiss` juntos; os três de atualização nunca tiveram botão de fechar.
+  //
+  // O padding fica no filho, não neste wrapper, pra toque na borda ainda
+  // contar como toque no banner.
+  const miolo = (
+    // Reserva à direita pro botão de fechar não cobrir o fim do texto.
+    // Sem isso a última palavra passa por baixo do × em telas estreitas.
+    <View style={onDismiss ? { paddingRight: 32 } : undefined}>{children}</View>
+  );
   return (
-    <Wrap
-      {...(onPress
-        ? {
-            onPress,
-            android_ripple: { color: "#00000022" },
-            accessibilityRole: "button",
-            accessibilityLabel,
-          }
-        : {})}
-      className="absolute right-0 bottom-0 left-0 px-4 pt-3"
-      style={{ backgroundColor: color, paddingBottom: bottomPad }}
+    <View
+      className="absolute right-0 bottom-0 left-0"
+      style={{ backgroundColor: color }}
     >
-      {/* Reserva à direita pro botão de fechar não cobrir o fim do texto.
-          Sem isso a última palavra passa por baixo do × em telas estreitas. */}
-      <View style={onDismiss ? { paddingRight: 32 } : undefined}>
-        {children}
-      </View>
+      {onPress ? (
+        <Pressable
+          onPress={onPress}
+          android_ripple={{ color: "#00000022" }}
+          accessibilityRole="button"
+          accessibilityLabel={accessibilityLabel}
+          className="px-4 pt-3"
+          style={{ paddingBottom: bottomPad }}
+        >
+          {miolo}
+        </Pressable>
+      ) : (
+        <View className="px-4 pt-3" style={{ paddingBottom: bottomPad }}>
+          {miolo}
+        </View>
+      )}
       {onDismiss ? (
         <Pressable
           accessibilityRole="button"
@@ -268,6 +285,6 @@ function BannerBase({
           </Text>
         </Pressable>
       ) : null}
-    </Wrap>
+    </View>
   );
 }

--- a/constants/bannerPriority.js
+++ b/constants/bannerPriority.js
@@ -1,0 +1,40 @@
+// @ts-nocheck -- helper puro; tipos vêm quando o componente for tipado (ADR-002)
+
+// Prioridade dos banners do rodapé (#281).
+//
+// Vive fora do componente pelo mesmo motivo do `sync-url.js` e do
+// `sync-retry.js`: importar `UpdateBanner` puxa `infra/sync` → `session` →
+// `supabase` → AsyncStorage, que não roda no jest. Isolado aqui, a decisão
+// que tem risco de bug fica testável sem mock nenhum.
+
+/**
+ * Qual banner mostrar, ou `null` pra nenhum (#281).
+ *
+ * Pura e exportada pra travar a **ordem** por teste. A ordem é a decisão com
+ * risco real aqui: os três de atualização são transitórios e se resolvem
+ * sozinhos; o de login persiste até a pessoa entrar. Se `needs-auth` subisse
+ * na lista, esconderia por tempo indeterminado avisos que importam mais —
+ * inclusive o "reinstale o APK", sem o qual o app nem recebe correção.
+ *
+ * @param {{
+ *   nativeOutdated?: boolean,
+ *   isDownloading?: boolean,
+ *   isUpdatePending?: boolean,
+ *   needsAuth?: boolean,
+ *   authDismissed?: boolean,
+ * }} estado
+ * @returns {"native-outdated"|"downloading"|"update-pending"|"needs-auth"|null}
+ */
+export function pickBanner({
+  nativeOutdated,
+  isDownloading,
+  isUpdatePending,
+  needsAuth,
+  authDismissed,
+}) {
+  if (nativeOutdated) return "native-outdated";
+  if (isDownloading) return "downloading";
+  if (isUpdatePending) return "update-pending";
+  if (needsAuth && !authDismissed) return "needs-auth";
+  return null;
+}

--- a/tests/update-banner.test.js
+++ b/tests/update-banner.test.js
@@ -1,0 +1,76 @@
+// @ts-nocheck -- teste; globals do jest não são tipados (ADR-002)
+import { pickBanner } from "@/constants/bannerPriority";
+
+// A ordem dos banners é a decisão com risco de bug aqui (#281). O de login é
+// o único permanente: enquanto a pessoa não entrar, ele fica. Se subisse na
+// prioridade, esconderia por tempo indeterminado avisos que importam mais.
+
+describe("pickBanner", () => {
+  it("nenhum estado ativo = nenhum banner", () => {
+    expect(pickBanner({})).toBeNull();
+  });
+
+  it("mostra o de login quando só falta entrar", () => {
+    expect(pickBanner({ needsAuth: true })).toBe("needs-auth");
+  });
+
+  it("dispensado esconde o de login", () => {
+    expect(pickBanner({ needsAuth: true, authDismissed: true })).toBeNull();
+  });
+
+  // O caso que importa: dispensar o login não pode engolir os outros.
+  it("dispensar o login não afeta os banners de atualização", () => {
+    expect(
+      pickBanner({
+        isUpdatePending: true,
+        needsAuth: true,
+        authDismissed: true,
+      }),
+    ).toBe("update-pending");
+  });
+
+  // --- prioridade -------------------------------------------------------
+
+  // Sem reinstalar o APK o device nem recebe correção por OTA. É o aviso que
+  // não pode ser escondido por nada.
+  it("APK desatualizado ganha de todo o resto", () => {
+    expect(
+      pickBanner({
+        nativeOutdated: true,
+        isDownloading: true,
+        isUpdatePending: true,
+        needsAuth: true,
+      }),
+    ).toBe("native-outdated");
+  });
+
+  it("download em andamento ganha do pendente e do login", () => {
+    expect(
+      pickBanner({
+        isDownloading: true,
+        isUpdatePending: true,
+        needsAuth: true,
+      }),
+    ).toBe("downloading");
+  });
+
+  it("atualização pronta ganha do login", () => {
+    expect(pickBanner({ isUpdatePending: true, needsAuth: true })).toBe(
+      "update-pending",
+    );
+  });
+
+  // O login é o último da fila, sempre. Este é o teste que quebra se alguém
+  // reordenar achando que "precisa entrar" é mais urgente.
+  it("login é o de menor prioridade contra cada um dos outros", () => {
+    for (const outro of [
+      "nativeOutdated",
+      "isDownloading",
+      "isUpdatePending",
+    ]) {
+      expect(pickBanner({ [outro]: true, needsAuth: true })).not.toBe(
+        "needs-auth",
+      );
+    }
+  });
+});


### PR DESCRIPTION
Fecha #281. Substitui o #282, que o GitHub fechou sozinho quando o merge do
#280 deletou a branch que era o base dele. Mesmo código, rebaseado na `main`
— nenhuma mudança de conteúdo.

**Já validado no BoT Staging** (aparelho real, contra server em
`AUTH_MODE=required`): banner aparece de qualquer tela, toque no corpo leva
pro login, toque no × dispensa sem navegar junto.

## O problema

O #280 deixou o aviso de "precisa entrar" honesto, mas ele vive em
**Ajustes → Sincronização**. Quem nunca logou é justamente quem menos abre
Ajustes.

## O que mudou

Um quarto banner no rodapé, junto dos três de atualização que já existiam.

**Prioridade: último da fila.** Os três de atualização são transitórios e se
resolvem sozinhos; este persiste até a pessoa entrar. Se subisse, esconderia
por tempo indeterminado avisos que importam mais — inclusive o "reinstale o
APK", sem o qual o aparelho nem recebe correção por OTA.

**É o único dispensável**, pela mesma razão: aviso que não passa e não fecha
vira ruído em cima de quem já decidiu não logar. O dispensar vale só pra
sessão — mesmo critério do `RetomadaState` da Home. Próxima abertura convida
de novo, que é o objetivo.

**Ação** leva pro `/login`, igual ao botão de Ajustes.

## Bug encontrado rodando, não em teste

No react-native-web o `accessibilityRole="button"` faz o `Pressable` virar um
`<button>` de verdade. O banner de login é o primeiro a passar `onPress` e
`onDismiss` juntos, e a primeira versão aninhava um dentro do outro:
`<button>` dentro de `<button>` é aninhamento inválido, o React DOM recusa e
derruba a árvore. Os três banners de atualização nunca expuseram isso porque
nenhum tem botão de fechar.

Agora a área principal e o × são **irmãos** dentro de um `View` neutro, com o
padding no filho pra toque na borda continuar contando como toque no banner.

Nenhum teste pegaria: é erro de árvore de DOM, e o jest não renderiza este
componente. Apareceu no navegador.

## Testes

120 → 128. A escolha de prioridade saiu pra `constants/bannerPriority.js`
porque importar o componente no jest não funciona (puxa `infra/sync` →
`session` → `supabase` → AsyncStorage) — mesmo motivo que criou o
`sync-url.js` e o `sync-retry.js`.

Verificado por mutação: subir o login pra primeira prioridade derruba 4
testes.

## Validado

No navegador, contra um server real em `AUTH_MODE=required`:

- banner aparece de qualquer tela quando falta login
- toque no corpo → `/login`
- toque no × → some sem navegar junto
