### PR TITLE
feat(niveis): metas como dado + sinais de automaticidade (fatia 0)

### DIFF
--- a/app/ajustes.jsx
+++ b/app/ajustes.jsx
@@ -1,5 +1,5 @@
 // @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import {
   Modal,
   Pressable,
@@ -12,12 +12,12 @@ import {
 import { router } from "expo-router";
 import { useColorScheme } from "nativewind";
 import Svg, { Path } from "react-native-svg";
-import { useValue } from "tinybase/ui-react";
+import { useTable, useValue } from "tinybase/ui-react";
 
 import { goBack } from "@/constants/navigation";
 import MyView from "@/components/MyView";
 
-import { clearAll, setDisplayName, store } from "@/infra/database";
+import { clearAll, getGoals, setDisplayName, store } from "@/infra/database";
 import { useSession } from "@/infra/session";
 import { AUTH_ENABLED } from "@/infra/supabase";
 import {
@@ -32,6 +32,8 @@ import { saveThemePreference } from "@/infra/theme";
 import { confirmAction } from "@/constants/dialogs";
 import { getEnvironmentInfo } from "@/constants/environment";
 import { useThemeTokens } from "@/constants/themeTokens";
+import { JOURNEY_ORDER, formatGoal, goalFor } from "@/constants/goals";
+import { habitSignals } from "@/constants/habitSignals";
 
 const ENV = getEnvironmentInfo();
 
@@ -51,15 +53,20 @@ const ENV = getEnvironmentInfo();
 //
 // Lembretes da mockup ficaram fora (dependem de expo-notifications, escopo M7).
 
-// Metas hardcoded (mesmos defaults do registry). Cada valor vai ganhar edição
-// quando "metas por-usuário" virar tarefa própria.
-const METAS = [
-  { key: "water", label: "Água", value: "2,0 L" },
-  { key: "sleep", label: "Sono", value: "8h" },
-  { key: "exercise", label: "Exercício", value: "30 min" },
-  { key: "feeding", label: "Alimentação", value: "3 refeições" },
-  { key: "study", label: "Estudo", value: "30 min" },
-];
+// Rótulos das metas. Os VALORES vêm do store desde a #285 — antes eram texto
+// fixo aqui, e o modelo de níveis não fecha sem meta como dado. Edição pelo
+// usuário é fatia própria; por ora o store guarda os mesmos defaults.
+const METAS_LABEL = {
+  water: "Água",
+  sleep: "Sono",
+  exercise: "Exercício",
+  feeding: "Alimentação",
+  study: "Estudo",
+};
+
+// Janela dos sinais de automaticidade. 28 dias é a janela do portão de nível
+// (docs/11-modelo-de-niveis.md §5).
+const JANELA_SINAIS = 28;
 
 export default function Ajustes() {
   const { colorScheme, setColorScheme } = useColorScheme();
@@ -69,6 +76,11 @@ export default function Ajustes() {
 
   const displayName = useValue("displayName", store);
   const [nameModalOpen, setNameModalOpen] = useState(false);
+  // `useTable` assina a tabela: metas semeadas depois do load do persister
+  // chegam sozinhas, sem precisar reabrir a tela.
+  const goalsTable = useTable("goals", store);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const goals = useMemo(() => getGoals(), [goalsTable]);
 
   function handleClear() {
     confirmAction({
@@ -129,11 +141,11 @@ export default function Ajustes() {
 
         {/* Metas do dia (display-only por ora) */}
         <Section title="Metas do dia">
-          {METAS.map((m) => (
+          {JOURNEY_ORDER.map((metric) => (
             <Row
-              key={m.key}
-              label={m.label}
-              value={m.value}
+              key={metric}
+              label={METAS_LABEL[metric]}
+              value={formatGoal(metric, goalFor(goals, metric))}
               valueMono
               disabled
             />
@@ -227,6 +239,7 @@ export default function Ajustes() {
 
         {/* Avançado */}
         <Section title="Avançado">
+          <SignalsBlock goals={goals} />
           <Row
             label="Limpar todos os dados"
             onPress={handleClear}
@@ -497,6 +510,98 @@ function SyncRow() {
           </Text>
         </Pressable>
       ) : null}
+    </View>
+  );
+}
+
+/**
+ * Sinais de automaticidade por métrica (#285, fatia 0).
+ *
+ * Medição silenciosa: nada aqui decide nada. Nenhum limiar, nenhum nível,
+ * nenhum "bom/ruim" — só os números crus, pra calibrar os limiares do modelo
+ * com dado real antes de pendurar consequência neles
+ * (docs/11-modelo-de-niveis.md §12).
+ *
+ * Por isso o tom é deliberadamente frio: sem cor de sucesso, sem barra de
+ * progresso, sem emoji. Se isto parecer placar, vira a gamificação que o
+ * projeto rejeitou.
+ */
+function SignalsBlock({ goals }) {
+  const records = useTable("records", store);
+  const linhas = useMemo(() => {
+    const lista = Object.values(records ?? {});
+    return JOURNEY_ORDER.map((metric) => {
+      const s = habitSignals(
+        lista,
+        metric,
+        goalFor(goals, metric),
+        JANELA_SINAIS,
+      );
+      const consist = `${Math.round(s.consistency.rate * 100)}%`;
+      const sd = s.regularity.sdMinutes;
+      // n<2 não produz desvio: dizer "0 min" seria afirmar regularidade
+      // perfeita sem amostra. "—" é a resposta honesta.
+      const regul = sd == null ? "—" : `±${Math.round(sd)}min`;
+      const res =
+        s.resilience.rate == null
+          ? "—"
+          : `${Math.round(s.resilience.rate * 100)}%`;
+      return { metric, consist, regul, res };
+    });
+  }, [records, goals]);
+
+  return (
+    <View className="border-t border-surface-subtle dark:border-surface-subtle-dark px-4 py-3">
+      <Text
+        className="text-xs uppercase tracking-wider text-label dark:text-label-dark"
+        style={{ fontFamily: "JetBrainsMono_500Medium" }}
+      >
+        Sinais · {JANELA_SINAIS} dias
+      </Text>
+      <Text
+        className="text-xs text-body-secondary dark:text-body-secondary-dark"
+        style={{ fontFamily: "Inter_400Regular", marginTop: 4 }}
+      >
+        Medição em andamento. Ainda não decide nada.
+      </Text>
+
+      <View className="mt-3 flex-row">
+        <Text
+          className="flex-1 text-xs text-label dark:text-label-dark"
+          style={{ fontFamily: "JetBrainsMono_400Regular" }}
+        >
+          {" "}
+        </Text>
+        {["consist.", "horário", "volta"].map((h) => (
+          <Text
+            key={h}
+            className="w-16 text-right text-xs text-label dark:text-label-dark"
+            style={{ fontFamily: "JetBrainsMono_400Regular" }}
+          >
+            {h}
+          </Text>
+        ))}
+      </View>
+
+      {linhas.map((l) => (
+        <View key={l.metric} className="mt-1.5 flex-row">
+          <Text
+            className="flex-1 text-sm text-ink dark:text-ink-dark"
+            style={{ fontFamily: "Inter_400Regular" }}
+          >
+            {METAS_LABEL[l.metric]}
+          </Text>
+          {[l.consist, l.regul, l.res].map((v, i) => (
+            <Text
+              key={i}
+              className="w-16 text-right text-sm text-body-secondary dark:text-body-secondary-dark"
+              style={{ fontFamily: "JetBrainsMono_400Regular" }}
+            >
+              {v}
+            </Text>
+          ))}
+        </View>
+      ))}
     </View>
   );
 }

--- a/constants/goals.js
+++ b/constants/goals.js
@@ -72,3 +72,38 @@ export function goalFor(goals, metric) {
   if (Number.isFinite(custom) && custom > 0) return custom;
   return DEFAULT_GOALS[metric] ?? null;
 }
+
+/**
+ * Meta formatada pra exibição, na unidade que a pessoa lê.
+ *
+ * O alvo é guardado na unidade canônica da métrica (ml, minutos, refeições),
+ * mas ninguém lê "2000 ml" nem "480 min" — lê "2,0 L" e "8h". Este é o
+ * mesmo texto que estava chumbado em `app/ajustes.jsx` antes da #285.
+ *
+ * @param {string} metric
+ * @param {number | null | undefined} target
+ * @returns {string} `"—"` quando não há alvo conhecido.
+ */
+export function formatGoal(metric, target) {
+  if (!Number.isFinite(target) || target <= 0) return "—";
+
+  if (metric === "water") {
+    const litros = target / 1000;
+    return `${litros.toLocaleString("pt-BR", {
+      minimumFractionDigits: 1,
+      maximumFractionDigits: 1,
+    })} L`;
+  }
+
+  if (metric === "sleep") {
+    const h = Math.floor(target / 60);
+    const m = target % 60;
+    return m === 0 ? `${h}h` : `${h}h${String(m).padStart(2, "0")}`;
+  }
+
+  if (metric === "feeding") {
+    return `${target} ${target === 1 ? "refeição" : "refeições"}`;
+  }
+
+  return `${target} min`;
+}

--- a/constants/goals.js
+++ b/constants/goals.js
@@ -1,0 +1,74 @@
+// @ts-nocheck -- helper puro; tipos vêm quando constants/ for tipado (ADR-002)
+
+// Metas por métrica (#285, fatia 0 do modelo de níveis).
+//
+// Antes disto as metas eram texto fixo em `app/ajustes.jsx` — display-only,
+// sem existir como dado. O modelo de níveis não fecha sem elas: o portão de
+// nível compara comportamento contra um alvo, e "8h pra todo mundo" é mentira
+// (tem gente que precisa de 7). Ver `docs/11-modelo-de-niveis.md` §10.
+//
+// Esta fatia só transforma em dado, com os mesmos valores de hoje. Edição
+// pelo usuário é fatia própria — o que importa agora é a forma, pra os sinais
+// de automaticidade terem contra o que medir.
+
+/** Unidades vêm do `CATEGORY_MAP`; aqui só o alvo diário. */
+export const DEFAULT_GOALS = {
+  water: 2000, // ml — "2,0 L" no Ajustes de hoje
+  sleep: 480, // min — 8h
+  exercise: 30, // min
+  feeding: 3, // refeições
+  study: 30, // min
+};
+
+/**
+ * Como o dia é avaliado contra o alvo. Decide qual regra de quebra se aplica
+ * (`docs/11-modelo-de-niveis.md` §6) e, mais pra frente, como o portão lê o
+ * hábito.
+ *
+ * - `sum` — soma do dia contra o alvo (água, exercício, estudo, refeições).
+ * - `presence` — houve registro? (a quantidade não decide nada)
+ *
+ * **Sono é `presence` de propósito.** A §4 do modelo é explícita: o portão é
+ * comportamento, nunca desfecho. Ninguém decide dormir 8h — decide deitar às
+ * 23h30. Somar duração e comparar com 480 min gatearia nível por uma coisa
+ * fora do controle da pessoa. A duração segue registrada e exibida; quem
+ * avalia o hábito é a regularidade do horário (ver `regularity` em
+ * `habitSignals.js`).
+ */
+export const GOAL_KIND = {
+  water: "sum",
+  sleep: "presence",
+  exercise: "sum",
+  feeding: "sum",
+  study: "sum",
+};
+
+/**
+ * Cadência esperada do hábito — define a unidade da regra de quebra (§6).
+ *
+ * Exercício e estudo não são diários (3–5×/semana é o normal). Tratá-los como
+ * diários rebaixaria alguém por descansar no fim de semana.
+ */
+export const GOAL_CADENCE = {
+  water: "daily",
+  sleep: "daily",
+  exercise: "weekly",
+  feeding: "daily",
+  study: "weekly",
+};
+
+/** Métricas que participam da jornada, na ordem sugerida (§8). */
+export const JOURNEY_ORDER = ["sleep", "water", "feeding", "exercise", "study"];
+
+/**
+ * Alvo de uma métrica, com fallback pro default.
+ *
+ * @param {Record<string, number> | null | undefined} goals Metas do store.
+ * @param {string} metric
+ * @returns {number | null} `null` se a métrica não tem alvo conhecido.
+ */
+export function goalFor(goals, metric) {
+  const custom = goals?.[metric];
+  if (Number.isFinite(custom) && custom > 0) return custom;
+  return DEFAULT_GOALS[metric] ?? null;
+}

--- a/constants/habitSignals.js
+++ b/constants/habitSignals.js
@@ -1,0 +1,205 @@
+// @ts-nocheck -- helper puro; tipos vêm quando constants/ for tipado (ADR-002)
+
+// Sinais de automaticidade (#285, fatia 0 do modelo de níveis).
+//
+// Lally et al. mediram automaticidade com questionário (SRHI). Não temos isso
+// e não queremos — questionário é fricção, e o app inteiro é construído em
+// cima de registro rápido. O que temos é registro com timestamp e quantidade.
+//
+// Daqui sai um **proxy comportamental**, não uma medida. Ver
+// `docs/11-modelo-de-niveis.md` §5.
+//
+// ⚠️ Nesta fatia nada consome estes números — nenhum limiar, nenhum nível.
+// São medição silenciosa, pra calibrar os limiares com dado real antes de
+// pendurar consequência neles (§12). O cálculo pode estar errado sem machucar
+// ninguém enquanto isso for verdade.
+
+import { GOAL_KIND } from "./goals";
+
+const MS_DIA = 86_400_000;
+
+/** Chave de dia-calendário local (não UTC — o dia do usuário é o local). */
+function diaLocal(ms) {
+  const d = new Date(ms);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+/** Minutos desde a meia-noite local. */
+function minutoDoDia(ms) {
+  const d = new Date(ms);
+  return d.getHours() * 60 + d.getMinutes();
+}
+
+/**
+ * Veredito por dia-calendário, do mais antigo pro mais recente.
+ *
+ * @param {Array<{type?: string, createdAt?: number, quantity?: number}>} records
+ * @param {string} metric
+ * @param {number} target
+ * @param {number} days Tamanho da janela.
+ * @param {number} [now] Epoch ms; injetável pra teste.
+ * @returns {Array<{dia: string, total: number, hit: boolean}>} Sempre com
+ *   `days` posições — dia sem registro entra como `total: 0, hit: false`.
+ */
+export function dailyVerdicts(records, metric, target, days, now = Date.now()) {
+  const kind = GOAL_KIND[metric] ?? "sum";
+  const porDia = new Map();
+
+  for (const r of records ?? []) {
+    if (r?.type !== metric) continue;
+    const ts = Number(r.createdAt);
+    if (!Number.isFinite(ts)) continue;
+    const k = diaLocal(ts);
+    const q = Number(r.quantity);
+    porDia.set(k, {
+      total: (porDia.get(k)?.total ?? 0) + (Number.isFinite(q) ? q : 0),
+      n: (porDia.get(k)?.n ?? 0) + 1,
+    });
+  }
+
+  const out = [];
+  // Anda do dia mais antigo da janela até hoje, pra a ordem ser cronológica —
+  // `resilience` depende disso pra saber o que é "dia seguinte".
+  for (let i = days - 1; i >= 0; i--) {
+    const k = diaLocal(now - i * MS_DIA);
+    const info = porDia.get(k);
+    const total = info?.total ?? 0;
+    const n = info?.n ?? 0;
+    // `presence`: houve registro basta. A quantidade não decide (§4 — sono é
+    // desfecho, não comportamento).
+    const hit = kind === "presence" ? n > 0 : total >= target;
+    out.push({ dia: k, total, hit });
+  }
+  return out;
+}
+
+/**
+ * Consistência: fração de dias no alvo dentro da janela.
+ *
+ * @returns {{rate: number, hits: number, days: number}}
+ */
+export function consistency(verdicts) {
+  const days = verdicts?.length ?? 0;
+  if (!days) return { rate: 0, hits: 0, days: 0 };
+  const hits = verdicts.filter((v) => v.hit).length;
+  return { rate: hits / days, hits, days };
+}
+
+/**
+ * Regularidade: quão estável é o horário do comportamento.
+ *
+ * Comportamento automático é disparado por contexto e acontece em horário
+ * parecido; a dispersão cai conforme o hábito assenta. É o sinal menos óbvio
+ * dos três e sai de graça — todo registro já tem `createdAt`.
+ *
+ * ⚠️ **Horário é circular, e desvio-padrão comum erra feio nele.** 23h50 e
+ * 00h10 distam 20 minutos, não 23h40. Um `stddev` sobre "minutos desde a
+ * meia-noite" trataria essas duas noites como caos absoluto — e o caso que
+ * mais importa, o horário de deitar, vive exatamente em cima da meia-noite.
+ *
+ * Por isso a estatística é circular: cada horário vira um ângulo no relógio de
+ * 24h, tira-se a média vetorial, e o comprimento do resultante `R` (0 a 1) diz
+ * a concentração. `R` perto de 1 = sempre no mesmo horário. Daí sai um
+ * desvio-padrão circular em minutos, que é o número legível.
+ *
+ * @param {Array<{type?: string, createdAt?: number}>} records
+ * @param {string} metric
+ * @param {number} days
+ * @param {number} [now]
+ * @returns {{resultant: number, sdMinutes: number|null, n: number}}
+ *   `sdMinutes` é `null` quando não há amostra suficiente (n < 2).
+ */
+export function regularity(records, metric, days, now = Date.now()) {
+  const limite = now - days * MS_DIA;
+  const angulos = [];
+
+  for (const r of records ?? []) {
+    if (r?.type !== metric) continue;
+    const ts = Number(r.createdAt);
+    if (!Number.isFinite(ts) || ts < limite || ts > now) continue;
+    angulos.push((2 * Math.PI * minutoDoDia(ts)) / 1440);
+  }
+
+  const n = angulos.length;
+  if (n < 2) return { resultant: n === 1 ? 1 : 0, sdMinutes: null, n };
+
+  let sx = 0;
+  let sy = 0;
+  for (const a of angulos) {
+    sx += Math.cos(a);
+    sy += Math.sin(a);
+  }
+  const resultant = Math.sqrt(sx * sx + sy * sy) / n;
+
+  // R=0 seria dispersão total; o log divergiria. Trava num piso pra devolver
+  // número em vez de Infinity — quem lê quer "muito irregular", não NaN.
+  const R = Math.max(resultant, 1e-6);
+  const sdRad = Math.sqrt(-2 * Math.log(R));
+  const sdMinutes = (sdRad * 1440) / (2 * Math.PI);
+
+  return { resultant, sdMinutes, n };
+}
+
+/**
+ * Resiliência: depois de uma falha isolada, voltou no dia seguinte?
+ *
+ * Hábito automático se recupera sozinho; hábito frágil vira duas faltas — e a
+ * segunda falta consecutiva é onde o laço quebra (§6). Este sinal mede
+ * exatamente a diferença entre um tropeço e o começo de um hábito novo.
+ *
+ * ⚠️ **Oportunidade é só a falha ISOLADA** — a primeira de uma sequência, a
+ * que vem logo depois de um dia no alvo. Contar toda falha faria uma recaída
+ * longa pontuar como recuperação quando enfim acabasse: numa sequência
+ * `alvo, falha, falha, alvo`, o segundo dia de queda "recuperou" no papel. O
+ * que se quer medir é a diferença entre tropeçar e desabar.
+ *
+ * Falha no primeiro dia da janela não conta: sem o dia anterior não dá pra
+ * saber se era isolada ou meio de uma sequência já em curso.
+ *
+ * Só conta oportunidades em que havia dia seguinte dentro da janela.
+ *
+ * `doubleMisses` é medida à parte e conta **todo** par de falhas consecutivas
+ * — é a regra de quebra da §6, não a de recuperação.
+ *
+ * @param {Array<{hit: boolean}>} verdicts Cronológico (saída de `dailyVerdicts`).
+ * @returns {{rate: number|null, recovered: number, opportunities: number, doubleMisses: number}}
+ *   `rate` é `null` quando não houve falha isolada — não dá pra afirmar nada
+ *   sobre recuperação de quem nunca caiu.
+ */
+export function resilience(verdicts) {
+  let recovered = 0;
+  let opportunities = 0;
+  let doubleMisses = 0;
+
+  const v = verdicts ?? [];
+  for (let i = 0; i < v.length - 1; i++) {
+    if (!v[i].hit && !v[i + 1].hit) doubleMisses += 1;
+    // Oportunidade = falha isolada: precedida por dia no alvo.
+    if (v[i].hit || i === 0 || !v[i - 1].hit) continue;
+    opportunities += 1;
+    if (v[i + 1].hit) recovered += 1;
+  }
+
+  return {
+    rate: opportunities ? recovered / opportunities : null,
+    recovered,
+    opportunities,
+    doubleMisses,
+  };
+}
+
+/**
+ * Os três sinais de uma métrica, de uma vez.
+ *
+ * @returns {{metric: string, days: number, consistency: object, regularity: object, resilience: object}}
+ */
+export function habitSignals(records, metric, target, days, now = Date.now()) {
+  const verdicts = dailyVerdicts(records, metric, target, days, now);
+  return {
+    metric,
+    days,
+    consistency: consistency(verdicts),
+    regularity: regularity(records, metric, days, now),
+    resilience: resilience(verdicts),
+  };
+}

--- a/infra/database.js
+++ b/infra/database.js
@@ -1,8 +1,11 @@
 // @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
 import { createMergeableStore } from "tinybase";
 
+import { DEFAULT_GOALS } from "@/constants/goals";
+
 const TABLE = "records";
 const TESTERS = "testers";
+const GOALS = "goals";
 
 // MergeableStore em vez de Store puro: pré-requisito de qualquer sync (M6,
 // ADR-009). Carrega metadata de CRDT pra merge determinístico entre devices.
@@ -25,6 +28,14 @@ export const store = createMergeableStore()
       name: { type: "string" },
       phone: { type: "string" },
       createdAt: { type: "number" },
+    },
+    // Metas por métrica (#285, fatia 0 do modelo de níveis). rowId = a
+    // métrica ("water", "sleep", …). Antes disto as metas eram texto fixo em
+    // Ajustes — não existiam como dado, e o portão de nível não fecha sem
+    // elas. Ver docs/11-modelo-de-niveis.md §10.
+    [GOALS]: {
+      target: { type: "number" },
+      updatedAt: { type: "number" },
     },
   })
   .setValuesSchema({
@@ -183,6 +194,35 @@ export function ensureSyncRoomId() {
     store.setValue("syncRoomId", roomId);
   }
   return roomId;
+}
+
+// --- Metas por métrica (#285) ---
+
+/**
+ * Semeia as metas que ainda não existem, com os defaults.
+ *
+ * Chamada no `then` do persister pelo mesmo motivo do `ensureSyncRoomId`: se
+ * semear ANTES do `startAutoLoad` terminar, o load sobrescreve o que acabou
+ * de ser escrito. Manter como último passo se alguém mexer na ordem.
+ *
+ * Não sobrescreve meta existente — o usuário poderá editar em fatia futura, e
+ * seed não pode desfazer escolha de ninguém.
+ */
+export function ensureGoals() {
+  for (const [metric, target] of Object.entries(DEFAULT_GOALS)) {
+    if (store.getCell(GOALS, metric, "target") == null) {
+      store.setRow(GOALS, metric, { target, updatedAt: Date.now() });
+    }
+  }
+}
+
+/** Metas como objeto simples `{ metric: target }`, pro `goalFor`. */
+export function getGoals() {
+  const out = {};
+  for (const [metric, row] of Object.entries(store.getTable(GOALS) ?? {})) {
+    if (Number.isFinite(row?.target)) out[metric] = row.target;
+  }
+  return out;
 }
 
 // --- Testers (tela de admin, Track A do M3-5) ---

--- a/infra/persistence.js
+++ b/infra/persistence.js
@@ -1,7 +1,7 @@
 import { openDatabaseSync } from "expo-sqlite";
 import { createExpoSqlitePersister } from "tinybase/persisters/persister-expo-sqlite";
 import { useCreatePersister } from "tinybase/ui-react";
-import { ensureSyncRoomId, store } from "./database";
+import { ensureGoals, ensureSyncRoomId, store } from "./database";
 
 const db = openDatabaseSync("back_on_track.db");
 
@@ -31,6 +31,8 @@ export function useRegistrosPersistencia() {
       // Room ID de sync (M6 fatia 3): só gerar/persistir DEPOIS do autoLoad,
       // senão um roomId gerado vira roomId antigo carregado do SQLite.
       ensureSyncRoomId();
+      // Depois do load, mesmo motivo do ensureSyncRoomId acima (#285).
+      ensureGoals();
     },
   );
 }

--- a/infra/persistence.web.js
+++ b/infra/persistence.web.js
@@ -1,6 +1,6 @@
 import { createLocalPersister } from "tinybase/persisters/persister-browser";
 import { useCreatePersister } from "tinybase/ui-react";
-import { ensureSyncRoomId, store } from "./database";
+import { ensureGoals, ensureSyncRoomId, store } from "./database";
 
 /**
  * Versão web de useRegistrosPersistencia.
@@ -24,6 +24,8 @@ export function useRegistrosPersistencia() {
       await persister.startAutoSave();
       // Mesmo motivo da versão native: só gerar syncRoomId depois do autoLoad.
       ensureSyncRoomId();
+      // Depois do load, mesmo motivo do ensureSyncRoomId acima (#285).
+      ensureGoals();
     },
   );
 }

--- a/tests/habit-signals.test.js
+++ b/tests/habit-signals.test.js
@@ -14,9 +14,19 @@ import { DEFAULT_GOALS, goalFor } from "@/constants/goals";
 
 const DIA = 86_400_000;
 
-/** Timestamp de N dias atrás, no horário HH:MM local. */
-function em(diasAtras, hh, mm = 0, base = Date.now()) {
-  const d = new Date(base - diasAtras * DIA);
+// Base de tempo FIXA, passada explicitamente como `now` em toda chamada.
+//
+// Sem isso os testes ficam dependentes da hora em que a suíte roda: `em(0, 20)`
+// é "hoje às 20:00", que às 15h ainda está no FUTURO — e as funções descartam
+// timestamp futuro, então a amostra encolhe e a asserção quebra. Aconteceu de
+// verdade: o mesmo teste passou de manhã e falhou à tarde.
+//
+// 23:30 como hora-base deixa qualquer horário do dia 0 no passado.
+const AGORA = new Date(2026, 7, 14, 23, 30, 0, 0).getTime();
+
+/** Timestamp de N dias atrás, no horário HH:MM local, relativo a `AGORA`. */
+function em(diasAtras, hh, mm = 0) {
+  const d = new Date(AGORA - diasAtras * DIA);
   d.setHours(hh, mm, 0, 0);
   return d.getTime();
 }
@@ -52,32 +62,38 @@ describe("dailyVerdicts", () => {
       reg("water", em(0, 14), 700),
       reg("water", em(0, 20), 900),
     ];
-    const v = dailyVerdicts(recs, "water", 2000, 1);
+    const v = dailyVerdicts(recs, "water", 2000, 1, AGORA);
     expect(v).toHaveLength(1);
     expect(v[0].total).toBe(2100);
     expect(v[0].hit).toBe(true);
   });
 
   it("dia abaixo do alvo não conta como hit", () => {
-    const v = dailyVerdicts([reg("water", em(0, 9), 500)], "water", 2000, 1);
+    const v = dailyVerdicts(
+      [reg("water", em(0, 9), 500)],
+      "water",
+      2000,
+      1,
+      AGORA,
+    );
     expect(v[0].hit).toBe(false);
   });
 
   it("dia sem registro entra na janela como falha", () => {
-    const v = dailyVerdicts([], "water", 2000, 3);
+    const v = dailyVerdicts([], "water", 2000, 3, AGORA);
     expect(v).toHaveLength(3);
     expect(v.every((d) => d.hit === false && d.total === 0)).toBe(true);
   });
 
   it("ignora registros de outras métricas", () => {
     const recs = [reg("sleep", em(0, 23), 480), reg("water", em(0, 9), 2500)];
-    expect(dailyVerdicts(recs, "water", 2000, 1)[0].total).toBe(2500);
+    expect(dailyVerdicts(recs, "water", 2000, 1, AGORA)[0].total).toBe(2500);
   });
 
   // A ordem cronológica não é cosmética: `resilience` depende dela pra saber
   // o que é "dia seguinte". Invertida, ela mede recuperação ao contrário.
   it("devolve do mais antigo pro mais recente", () => {
-    const v = dailyVerdicts([], "water", 2000, 3);
+    const v = dailyVerdicts([], "water", 2000, 3, AGORA);
     expect(v[0].dia < v[1].dia).toBe(true);
     expect(v[1].dia < v[2].dia).toBe(true);
   });
@@ -85,12 +101,18 @@ describe("dailyVerdicts", () => {
   // Sono é `presence`: o portão é comportamento, não desfecho (§4). Dormir
   // pouco não pode contar como falha de hábito — registrar é o hábito.
   it("sono conta presença, não quantidade", () => {
-    const v = dailyVerdicts([reg("sleep", em(0, 23), 60)], "sleep", 480, 1);
+    const v = dailyVerdicts(
+      [reg("sleep", em(0, 23), 60)],
+      "sleep",
+      480,
+      1,
+      AGORA,
+    );
     expect(v[0].hit).toBe(true);
   });
 
   it("sono sem registro nenhum é falha", () => {
-    expect(dailyVerdicts([], "sleep", 480, 1)[0].hit).toBe(false);
+    expect(dailyVerdicts([], "sleep", 480, 1, AGORA)[0].hit).toBe(false);
   });
 });
 
@@ -129,7 +151,7 @@ describe("regularity", () => {
       reg("sleep", em(1, 23, 55)),
       reg("sleep", em(0, 0, 5)),
     ];
-    const r = regularity(recs, "sleep", 7);
+    const r = regularity(recs, "sleep", 7, AGORA);
     expect(r.n).toBe(4);
     expect(r.resultant).toBeGreaterThan(0.99);
     expect(r.sdMinutes).toBeLessThan(20);
@@ -137,7 +159,7 @@ describe("regularity", () => {
 
   it("horário sempre igual = concentração máxima", () => {
     const recs = [0, 1, 2, 3].map((d) => reg("water", em(d, 9, 0)));
-    const r = regularity(recs, "water", 7);
+    const r = regularity(recs, "water", 7, AGORA);
     expect(r.resultant).toBeCloseTo(1, 5);
     expect(r.sdMinutes).toBeLessThan(1);
   });
@@ -150,7 +172,7 @@ describe("regularity", () => {
       reg("water", em(1, 14)),
       reg("water", em(0, 20)),
     ];
-    const r = regularity(recs, "water", 7);
+    const r = regularity(recs, "water", 7, AGORA);
     expect(r.resultant).toBeLessThan(0.1);
     expect(r.sdMinutes).toBeGreaterThan(200);
   });
@@ -158,23 +180,23 @@ describe("regularity", () => {
   it("dispersão maior produz sdMinutes maior", () => {
     const apertado = [reg("water", em(1, 9, 0)), reg("water", em(0, 9, 10))];
     const largo = [reg("water", em(1, 7, 0)), reg("water", em(0, 13, 0))];
-    expect(regularity(apertado, "water", 7).sdMinutes).toBeLessThan(
-      regularity(largo, "water", 7).sdMinutes,
+    expect(regularity(apertado, "water", 7, AGORA).sdMinutes).toBeLessThan(
+      regularity(largo, "water", 7, AGORA).sdMinutes,
     );
   });
 
   // Sem amostra não se afirma nada — null é resposta, 0 seria mentira
   // ("perfeitamente regular").
   it("menos de 2 registros não produz desvio", () => {
-    expect(regularity([], "water", 7).sdMinutes).toBeNull();
+    expect(regularity([], "water", 7, AGORA).sdMinutes).toBeNull();
     expect(
-      regularity([reg("water", em(0, 9))], "water", 7).sdMinutes,
+      regularity([reg("water", em(0, 9))], "water", 7, AGORA).sdMinutes,
     ).toBeNull();
   });
 
   it("ignora registros fora da janela", () => {
     const recs = [reg("water", em(30, 9)), reg("water", em(0, 9))];
-    expect(regularity(recs, "water", 7).n).toBe(1);
+    expect(regularity(recs, "water", 7, AGORA).n).toBe(1);
   });
 });
 
@@ -242,7 +264,7 @@ describe("resilience", () => {
 describe("habitSignals", () => {
   it("junta os três sinais numa chamada", () => {
     const recs = [reg("water", em(1, 9), 2500), reg("water", em(0, 9), 2500)];
-    const s = habitSignals(recs, "water", 2000, 7);
+    const s = habitSignals(recs, "water", 2000, 7, AGORA);
     expect(s.metric).toBe("water");
     expect(s.days).toBe(7);
     expect(s.consistency.hits).toBe(2);

--- a/tests/habit-signals.test.js
+++ b/tests/habit-signals.test.js
@@ -1,0 +1,252 @@
+// @ts-nocheck -- teste; globals do jest não são tipados (ADR-002)
+import {
+  consistency,
+  dailyVerdicts,
+  habitSignals,
+  regularity,
+  resilience,
+} from "@/constants/habitSignals";
+import { DEFAULT_GOALS, goalFor } from "@/constants/goals";
+
+// Sinais de automaticidade (#285). Nesta fatia nada consome estes números —
+// são medição silenciosa pra calibrar limiares depois. Justamente por isso os
+// testes são a única rede: um erro aqui não aparece na tela.
+
+const DIA = 86_400_000;
+
+/** Timestamp de N dias atrás, no horário HH:MM local. */
+function em(diasAtras, hh, mm = 0, base = Date.now()) {
+  const d = new Date(base - diasAtras * DIA);
+  d.setHours(hh, mm, 0, 0);
+  return d.getTime();
+}
+
+const reg = (type, createdAt, quantity = 0) => ({ type, createdAt, quantity });
+
+describe("goalFor", () => {
+  it("usa a meta do store quando existe", () => {
+    expect(goalFor({ water: 3000 }, "water")).toBe(3000);
+  });
+
+  it("cai no default quando não há meta salva", () => {
+    expect(goalFor({}, "water")).toBe(DEFAULT_GOALS.water);
+    expect(goalFor(null, "sleep")).toBe(DEFAULT_GOALS.sleep);
+  });
+
+  // Meta zero ou negativa é dado corrompido, não escolha — cair no default é
+  // mais seguro que dizer que todo dia bateu a meta.
+  it("ignora meta inválida", () => {
+    expect(goalFor({ water: 0 }, "water")).toBe(DEFAULT_GOALS.water);
+    expect(goalFor({ water: -5 }, "water")).toBe(DEFAULT_GOALS.water);
+  });
+
+  it("devolve null pra métrica desconhecida", () => {
+    expect(goalFor({}, "abacaxi")).toBeNull();
+  });
+});
+
+describe("dailyVerdicts", () => {
+  it("soma o dia e compara com o alvo", () => {
+    const recs = [
+      reg("water", em(0, 9), 500),
+      reg("water", em(0, 14), 700),
+      reg("water", em(0, 20), 900),
+    ];
+    const v = dailyVerdicts(recs, "water", 2000, 1);
+    expect(v).toHaveLength(1);
+    expect(v[0].total).toBe(2100);
+    expect(v[0].hit).toBe(true);
+  });
+
+  it("dia abaixo do alvo não conta como hit", () => {
+    const v = dailyVerdicts([reg("water", em(0, 9), 500)], "water", 2000, 1);
+    expect(v[0].hit).toBe(false);
+  });
+
+  it("dia sem registro entra na janela como falha", () => {
+    const v = dailyVerdicts([], "water", 2000, 3);
+    expect(v).toHaveLength(3);
+    expect(v.every((d) => d.hit === false && d.total === 0)).toBe(true);
+  });
+
+  it("ignora registros de outras métricas", () => {
+    const recs = [reg("sleep", em(0, 23), 480), reg("water", em(0, 9), 2500)];
+    expect(dailyVerdicts(recs, "water", 2000, 1)[0].total).toBe(2500);
+  });
+
+  // A ordem cronológica não é cosmética: `resilience` depende dela pra saber
+  // o que é "dia seguinte". Invertida, ela mede recuperação ao contrário.
+  it("devolve do mais antigo pro mais recente", () => {
+    const v = dailyVerdicts([], "water", 2000, 3);
+    expect(v[0].dia < v[1].dia).toBe(true);
+    expect(v[1].dia < v[2].dia).toBe(true);
+  });
+
+  // Sono é `presence`: o portão é comportamento, não desfecho (§4). Dormir
+  // pouco não pode contar como falha de hábito — registrar é o hábito.
+  it("sono conta presença, não quantidade", () => {
+    const v = dailyVerdicts([reg("sleep", em(0, 23), 60)], "sleep", 480, 1);
+    expect(v[0].hit).toBe(true);
+  });
+
+  it("sono sem registro nenhum é falha", () => {
+    expect(dailyVerdicts([], "sleep", 480, 1)[0].hit).toBe(false);
+  });
+});
+
+describe("consistency", () => {
+  const v = (...hits) => hits.map((h) => ({ hit: h }));
+
+  it("todos os dias no alvo = 1", () => {
+    expect(consistency(v(true, true, true)).rate).toBe(1);
+  });
+
+  it("nenhum dia no alvo = 0", () => {
+    expect(consistency(v(false, false)).rate).toBe(0);
+  });
+
+  it("conta a fração certa", () => {
+    const r = consistency(v(true, false, true, true));
+    expect(r.rate).toBe(0.75);
+    expect(r.hits).toBe(3);
+    expect(r.days).toBe(4);
+  });
+
+  it("janela vazia não explode", () => {
+    expect(consistency([])).toEqual({ rate: 0, hits: 0, days: 0 });
+  });
+});
+
+describe("regularity", () => {
+  // ESTE é o teste que justifica a estatística circular. 23h50 e 00h10 distam
+  // 20 minutos. Um desvio-padrão sobre "minutos desde a meia-noite" daria
+  // ~700 minutos e diria que a pessoa é caótica — quando ela é quase perfeita.
+  // E é exatamente o caso do horário de deitar, o hábito do lvl 1.
+  it("horários em volta da meia-noite são regulares, não caóticos", () => {
+    const recs = [
+      reg("sleep", em(3, 23, 50)),
+      reg("sleep", em(2, 0, 10)),
+      reg("sleep", em(1, 23, 55)),
+      reg("sleep", em(0, 0, 5)),
+    ];
+    const r = regularity(recs, "sleep", 7);
+    expect(r.n).toBe(4);
+    expect(r.resultant).toBeGreaterThan(0.99);
+    expect(r.sdMinutes).toBeLessThan(20);
+  });
+
+  it("horário sempre igual = concentração máxima", () => {
+    const recs = [0, 1, 2, 3].map((d) => reg("water", em(d, 9, 0)));
+    const r = regularity(recs, "water", 7);
+    expect(r.resultant).toBeCloseTo(1, 5);
+    expect(r.sdMinutes).toBeLessThan(1);
+  });
+
+  // Espalhado pelas 24h: o vetor médio quase se cancela.
+  it("horários espalhados dão dispersão alta", () => {
+    const recs = [
+      reg("water", em(3, 2)),
+      reg("water", em(2, 8)),
+      reg("water", em(1, 14)),
+      reg("water", em(0, 20)),
+    ];
+    const r = regularity(recs, "water", 7);
+    expect(r.resultant).toBeLessThan(0.1);
+    expect(r.sdMinutes).toBeGreaterThan(200);
+  });
+
+  it("dispersão maior produz sdMinutes maior", () => {
+    const apertado = [reg("water", em(1, 9, 0)), reg("water", em(0, 9, 10))];
+    const largo = [reg("water", em(1, 7, 0)), reg("water", em(0, 13, 0))];
+    expect(regularity(apertado, "water", 7).sdMinutes).toBeLessThan(
+      regularity(largo, "water", 7).sdMinutes,
+    );
+  });
+
+  // Sem amostra não se afirma nada — null é resposta, 0 seria mentira
+  // ("perfeitamente regular").
+  it("menos de 2 registros não produz desvio", () => {
+    expect(regularity([], "water", 7).sdMinutes).toBeNull();
+    expect(
+      regularity([reg("water", em(0, 9))], "water", 7).sdMinutes,
+    ).toBeNull();
+  });
+
+  it("ignora registros fora da janela", () => {
+    const recs = [reg("water", em(30, 9)), reg("water", em(0, 9))];
+    expect(regularity(recs, "water", 7).n).toBe(1);
+  });
+});
+
+describe("resilience", () => {
+  const v = (...hits) => hits.map((h) => ({ hit: h }));
+
+  // A diferença entre um tropeço e o começo de um hábito novo (§6).
+  it("falhou e voltou no dia seguinte = recuperou", () => {
+    const r = resilience(v(true, false, true, true));
+    expect(r.recovered).toBe(1);
+    expect(r.opportunities).toBe(1);
+    expect(r.rate).toBe(1);
+    expect(r.doubleMisses).toBe(0);
+  });
+
+  it("duas faltas seguidas contam como não-recuperação", () => {
+    const r = resilience(v(true, false, false, true));
+    expect(r.doubleMisses).toBe(1);
+    expect(r.rate).toBe(0);
+  });
+
+  // Quem nunca caiu não tem taxa de recuperação. 1 seria afirmar resiliência
+  // sem evidência; 0 seria puni-la por nunca ter falhado.
+  it("sem nenhuma falha, a taxa é null", () => {
+    expect(resilience(v(true, true, true)).rate).toBeNull();
+  });
+
+  it("falha no último dia da janela não vira oportunidade", () => {
+    const r = resilience(v(true, true, false));
+    expect(r.opportunities).toBe(0);
+    expect(r.rate).toBeNull();
+  });
+
+  // Só a falha ISOLADA conta como oportunidade. Nesta sequência:
+  //   idx 0 falha — primeira da janela, sem dia anterior: não conta
+  //   idx 2 falha após alvo — oportunidade, e o dia seguinte falha: não recuperou
+  //   idx 3 falha após falha — não é isolada: não conta
+  //   idx 5 falha após alvo — oportunidade, e o dia seguinte acerta: recuperou
+  it("mistura de recuperações e recaídas", () => {
+    const r = resilience(v(false, true, false, false, true, false, true));
+    expect(r.opportunities).toBe(2);
+    expect(r.recovered).toBe(1);
+    expect(r.doubleMisses).toBe(1);
+  });
+
+  // Sem esta distinção, uma recaída longa pontuaria como recuperação assim
+  // que acabasse — que é o oposto do que o sinal deve dizer.
+  it("recaída longa não vira recuperação quando enfim acaba", () => {
+    const r = resilience(v(true, false, false, false, true));
+    expect(r.opportunities).toBe(1);
+    expect(r.recovered).toBe(0);
+    expect(r.rate).toBe(0);
+    expect(r.doubleMisses).toBe(2);
+  });
+
+  // Falha logo no início da janela: não dá pra saber se era isolada ou meio
+  // de uma sequência que começou antes.
+  it("falha no primeiro dia da janela não conta como oportunidade", () => {
+    const r = resilience(v(false, true, true));
+    expect(r.opportunities).toBe(0);
+    expect(r.rate).toBeNull();
+  });
+});
+
+describe("habitSignals", () => {
+  it("junta os três sinais numa chamada", () => {
+    const recs = [reg("water", em(1, 9), 2500), reg("water", em(0, 9), 2500)];
+    const s = habitSignals(recs, "water", 2000, 7);
+    expect(s.metric).toBe("water");
+    expect(s.days).toBe(7);
+    expect(s.consistency.hits).toBe(2);
+    expect(s.regularity.n).toBe(2);
+    expect(s.resilience).toHaveProperty("doubleMisses");
+  });
+});


### PR DESCRIPTION
Fecha #285. Fatia 0 do modelo de níveis — ver `docs/11-modelo-de-niveis.md` §12.

**Nenhum nível, nenhum limiar, nenhuma regressão.** É a instrumentação que
permite calibrar com dado real antes de pendurar consequência.

## Por que esta fatia vem primeiro

Os limiares do modelo (§5 e §7) não tinham dado que os sustentasse: o
levantamento do histórico real achou 35 registros em 10 dias — não fecha nem a
janela de 28 dias do portão.

A decisão foi **instrumentar antes de gamificar**. E a primeira leitura já
justificou isso: **água deu 0% de consistência com 23 registros** — o alvo
default de 2 L nunca foi atingido num dia. Se tivéssemos ido direto pros
níveis, o dono do app ficaria preso no lvl 0 indefinidamente, e o app pareceria
quebrado em vez de exigente.

## O que entra

**Metas viram dado.** Tabela `goals` no store, semeada no `then` do persister
— mesmo motivo do `ensureSyncRoomId`: semear antes do `startAutoLoad` faz o
load sobrescrever. Não sobrescreve meta existente. Ajustes lê do store em vez
do `const METAS` chumbado; os valores exibidos são os mesmos.

**Três sinais puros** em `constants/habitSignals.js`:

| sinal | o que mede |
| --- | --- |
| consistência | fração de dias no alvo na janela |
| regularidade | dispersão do horário (proxy de disparo por contexto) |
| resiliência | após falha **isolada**, voltou no dia seguinte? |

**Bloco em Ajustes → Avançado** com os números crus, janela de 28 dias. Tom
deliberadamente frio — sem cor de sucesso, sem barra, sem emoji, e a linha
"Medição em andamento. Ainda não decide nada." É superfície de diagnóstico, não
de reforço (ver §1.5 do modelo). `—` quando não há amostra, nunca `0`.

## Duas decisões que valem destaque na revisão

**Regularidade usa estatística circular, não desvio-padrão comum.** 23h50 e
00h10 distam 20 minutos, não 23h40. Um `stddev` sobre "minutos desde a
meia-noite" diria que a pessoa é caótica justamente no caso que mais importa —
o horário de deitar, que é o hábito do lvl 1. Há teste cobrindo exatamente
esse cenário.

**Sono é avaliado por presença, não por quantidade.** O portão é comportamento,
nunca desfecho (§4): ninguém decide dormir 8h. Somar duração e comparar com
480 min gatearia nível por algo fora do controle da pessoa.

## Bug pego por teste durante a fatia

`resilience` contava **toda** falha como oportunidade de recuperação, inclusive
a segunda e terceira de uma sequência — uma recaída longa pontuaria como
"recuperou" assim que acabasse. Agora só a falha isolada conta, e falha no
primeiro dia da janela não conta porque não dá pra saber se era isolada.

Também corrigi um teste instável que eu mesmo introduzi: o helper montava
"hoje às 20:00", que antes das 20h está no futuro e é descartado pelo filtro de
janela. Passou de manhã e falhou à tarde. Agora há base de tempo fixa e nenhum
teste consulta o relógio real.

## Testes

128 → 157. Verificado por mutação:

| mutação | testes que caem |
| --- | --- |
| regularidade sempre perfeita | 2 |
| horário linear em vez de circular | 3 |
| sono gateado por duração | 1 |
| toda falha vira oportunidade | 4 |

## Sem bump de versão

`runtimeVersion.policy` é `appVersion`, então qualquer bump cria runtime novo e
custa 6 reinstalações. Isto é JS puro e viaja por OTA no 1.2.0.

## Como validar no BoT Staging

1. **Ajustes → Metas do dia** — mesmos valores de sempre (2,0 L / 8h / 30 min /
   3 refeições / 30 min), agora vindos do store. **Metas em branco = o seeding
   falhou**, que é o ponto mais frágil da fatia.
2. **Ajustes → Avançado → Sinais · 28 dias** — tabela com consistência, horário
   e volta por métrica.

Os números dependem do que está **no aparelho**, não no servidor — podem
diferir do levantamento feito sobre o JSON sincronizado.
