### PR TITLE
feat(niveis): estado de jornada derivado dos sinais (fatia 1)

### DIFF
--- a/app/ajustes.jsx
+++ b/app/ajustes.jsx
@@ -1,5 +1,5 @@
 // @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   Modal,
   Pressable,
@@ -17,7 +17,13 @@ import { useTable, useValue } from "tinybase/ui-react";
 import { goBack } from "@/constants/navigation";
 import MyView from "@/components/MyView";
 
-import { clearAll, getGoals, setDisplayName, store } from "@/infra/database";
+import {
+  clearAll,
+  getGoals,
+  raiseJourneyPeak,
+  setDisplayName,
+  store,
+} from "@/infra/database";
 import { useSession } from "@/infra/session";
 import { AUTH_ENABLED } from "@/infra/supabase";
 import {
@@ -34,6 +40,13 @@ import { getEnvironmentInfo } from "@/constants/environment";
 import { useThemeTokens } from "@/constants/themeTokens";
 import { JOURNEY_ORDER, formatGoal, goalFor } from "@/constants/goals";
 import { habitSignals } from "@/constants/habitSignals";
+import {
+  BUILDING,
+  GRADUATED,
+  LOCKED,
+  PAUSED,
+  deriveJourney,
+} from "@/constants/journey";
 
 const ENV = getEnvironmentInfo();
 
@@ -62,6 +75,15 @@ const METAS_LABEL = {
   exercise: "Exercício",
   feeding: "Alimentação",
   study: "Estudo",
+};
+
+// Rótulo humano dos status da jornada. Descritivo, nunca elogioso — é
+// diagnóstico, não reforço (docs/11-modelo-de-niveis.md §1.5).
+const STATUS_LABEL = {
+  [BUILDING]: "construindo",
+  [GRADUATED]: "estável",
+  [PAUSED]: "em pausa",
+  [LOCKED]: "—",
 };
 
 // Janela dos sinais de automaticidade. 28 dias é a janela do portão de nível
@@ -528,6 +550,23 @@ function SyncRow() {
  */
 function SignalsBlock({ goals }) {
   const records = useTable("records", store);
+  const peak = useValue("journeyPeakLevel", store);
+
+  const jornada = useMemo(
+    () =>
+      deriveJourney({
+        records: Object.values(records ?? {}),
+        goals,
+        previousLevel: Number(peak) || null,
+      }),
+    [records, goals, peak],
+  );
+
+  // Escrita no store vive em efeito, nunca em render.
+  useEffect(() => {
+    raiseJourneyPeak(jornada.level);
+  }, [jornada.level]);
+
   const linhas = useMemo(() => {
     const lista = Object.values(records ?? {});
     return JOURNEY_ORDER.map((metric) => {
@@ -546,9 +585,15 @@ function SignalsBlock({ goals }) {
         s.resilience.rate == null
           ? "—"
           : `${Math.round(s.resilience.rate * 100)}%`;
-      return { metric, consist, regul, res };
+      return {
+        metric,
+        consist,
+        regul,
+        res,
+        status: STATUS_LABEL[jornada.habits[metric]?.status] ?? "—",
+      };
     });
-  }, [records, goals]);
+  }, [records, goals, jornada]);
 
   return (
     <View className="border-t border-surface-subtle dark:border-surface-subtle-dark px-4 py-3">
@@ -564,6 +609,14 @@ function SignalsBlock({ goals }) {
       >
         Medição em andamento. Ainda não decide nada.
       </Text>
+      <Text
+        className="text-xs text-body-secondary dark:text-body-secondary-dark"
+        style={{ fontFamily: "JetBrainsMono_400Regular", marginTop: 6 }}
+      >
+        nível derivado: {jornada.level}
+        {jornada.focus ? ` · foco: ${METAS_LABEL[jornada.focus]}` : ""}
+        {jornada.regressed ? ` · abaixo do pico (${peak})` : ""}
+      </Text>
 
       <View className="mt-3 flex-row">
         <Text
@@ -572,10 +625,10 @@ function SignalsBlock({ goals }) {
         >
           {" "}
         </Text>
-        {["consist.", "horário", "volta"].map((h) => (
+        {["consist.", "horário", "volta", "estado"].map((h) => (
           <Text
             key={h}
-            className="w-16 text-right text-xs text-label dark:text-label-dark"
+            className="w-14 text-right text-xs text-label dark:text-label-dark"
             style={{ fontFamily: "JetBrainsMono_400Regular" }}
           >
             {h}
@@ -591,10 +644,10 @@ function SignalsBlock({ goals }) {
           >
             {METAS_LABEL[l.metric]}
           </Text>
-          {[l.consist, l.regul, l.res].map((v, i) => (
+          {[l.consist, l.regul, l.res, l.status].map((v, i) => (
             <Text
               key={i}
-              className="w-16 text-right text-sm text-body-secondary dark:text-body-secondary-dark"
+              className="w-14 text-right text-xs text-body-secondary dark:text-body-secondary-dark"
               style={{ fontFamily: "JetBrainsMono_400Regular" }}
             >
               {v}

--- a/constants/journey.js
+++ b/constants/journey.js
@@ -1,0 +1,237 @@
+// @ts-nocheck -- helper puro; tipos vêm quando constants/ for tipado (ADR-002)
+
+// Estado da jornada por níveis (#289, fatia 1).
+//
+// Deriva de `records` + metas: em que nível a pessoa está e qual o status de
+// cada hábito. **Nada aqui muda o uso do app ainda** — o resultado só aparece
+// no bloco de diagnóstico em Ajustes → Avançado.
+//
+// Modelo completo em `docs/11-modelo-de-niveis.md`.
+
+import { GOAL_CADENCE, JOURNEY_ORDER, goalFor } from "./goals";
+import {
+  consistency,
+  dailyVerdicts,
+  regularity,
+  resilience,
+} from "./habitSignals";
+
+/**
+ * ⚠️ LIMIARES PROVISÓRIOS — nenhum destes números tem dado que o sustente.
+ *
+ * A #285 rodou os sinais sobre o histórico real e achou 10 dias de registro:
+ * não fecha nem a janela de 28 dias do portão, muito menos uma curva de
+ * formação. Estes valores são ponto de partida derivado da literatura
+ * (Lally 2010: mediana 66 dias até automaticidade, faixa 18–254), não medida.
+ *
+ * Ficam juntos de propósito: quando houver dado, calibra-se aqui sem tocar em
+ * nenhuma lógica. O mecanismo é testável independente destes valores, e os
+ * testes usam dado sintético justamente pra não depender deles.
+ */
+export const THRESHOLDS = {
+  /** Janela de avaliação, em dias. */
+  window: 28,
+
+  gate: {
+    consistency: 0.8,
+    /**
+     * Piso de amostra pra regularidade significar alguma coisa.
+     *
+     * Achado da #285: estudo marcou R=0,99 sobre **2 registros**. Duas
+     * amostras sempre parecem concentradas — sem piso, o sinal reporta
+     * perfeição espúria e abriria o portão pra quem registrou duas vezes.
+     */
+    regularityMinSamples: 8,
+    /** Desvio circular máximo, em minutos, pra contar como horário estável. */
+    regularityMaxSd: 120,
+  },
+
+  graduation: {
+    consistency: 0.9,
+    regularityMinSamples: 16,
+    regularityMaxSd: 75,
+    /** Recuperou de pelo menos esta fração das falhas isoladas. */
+    resilience: 0.75,
+  },
+};
+
+/** Status possíveis de um hábito na jornada. */
+export const LOCKED = "locked";
+export const BUILDING = "building";
+export const GRADUATED = "graduated";
+export const PAUSED = "paused";
+
+/**
+ * O hábito passou do portão? (perto de automático)
+ *
+ * Regularidade só conta com amostra suficiente — ver `regularityMinSamples`.
+ * Sem amostra o hábito **não** passa: portão aberto por falta de evidência é
+ * pior que portão fechado, porque empilha o próximo hábito em cima de nada.
+ */
+export function passesGate(signals, limiares = THRESHOLDS) {
+  const { gate } = limiares;
+  if (signals.consistency.rate < gate.consistency) return false;
+  if (signals.regularity.n < gate.regularityMinSamples) return false;
+  if (signals.regularity.sdMinutes == null) return false;
+  if (signals.regularity.sdMinutes > gate.regularityMaxSd) return false;
+  // Falta dupla na janela é o sinal de laço quebrado (§6) — não é "perto de
+  // automático" quem ainda desaba dois dias seguidos.
+  if (signals.resilience.doubleMisses > 0) return false;
+  return true;
+}
+
+/**
+ * O hábito graduou? (automático — deixa de poder causar regressão)
+ *
+ * Mesma régua do portão com barra mais alta, nunca "N semanas": prazo fixo
+ * contradiz o argumento do próprio portão (§7).
+ */
+export function passesGraduation(signals, limiares = THRESHOLDS) {
+  const { graduation } = limiares;
+  if (!passesGate(signals, limiares)) return false;
+  if (signals.consistency.rate < graduation.consistency) return false;
+  if (signals.regularity.n < graduation.regularityMinSamples) return false;
+  if (signals.regularity.sdMinutes > graduation.regularityMaxSd) return false;
+  // Quem nunca falhou não tem taxa de recuperação (`null`). Isso NÃO impede
+  // graduação — é ausência de queda, não ausência de resiliência.
+  if (
+    signals.resilience.rate != null &&
+    signals.resilience.rate < graduation.resilience
+  ) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * O hábito quebrou, conforme a cadência dele? (§6 — três regras, não uma)
+ *
+ * - **diário** → duas faltas consecutivas. Perder um dia custa menos de meio
+ *   ponto de automaticidade e recupera rápido (Lally); a segunda falta é onde
+ *   o laço quebra.
+ * - **semanal** → duas semanas seguidas abaixo do alvo. Aplicar a regra
+ *   diária a exercício rebaixaria alguém **por descansar** no fim de semana.
+ *
+ * @param {Array<{hit: boolean}>} verdicts Cronológico.
+ * @param {"daily"|"weekly"} cadence
+ * @param {number} [porSemana] Dias no alvo exigidos por semana (cadência semanal).
+ */
+export function isBroken(verdicts, cadence, porSemana = 3) {
+  const v = verdicts ?? [];
+  if (cadence === "weekly") {
+    // Semana de calendário seria o ideal (§6), mas a janela aqui é relativa a
+    // hoje; blocos de 7 dias a partir do fim preservam a semântica de "duas
+    // semanas seguidas abaixo do alvo" sem depender de onde cai a segunda.
+    const semanas = [];
+    for (let fim = v.length; fim > 0; fim -= 7) {
+      const bloco = v.slice(Math.max(0, fim - 7), fim);
+      if (bloco.length === 7) semanas.push(bloco.filter((d) => d.hit).length);
+    }
+    // `semanas[0]` é a mais recente.
+    return (
+      semanas.length >= 2 && semanas[0] < porSemana && semanas[1] < porSemana
+    );
+  }
+
+  // Diário: duas faltas consecutivas em qualquer ponto da janela recente.
+  for (let i = v.length - 1; i > 0; i--) {
+    if (!v[i].hit && !v[i - 1].hit) return true;
+  }
+  return false;
+}
+
+/**
+ * Estado completo da jornada.
+ *
+ * ## Por que precisa de `previousLevel`
+ *
+ * O nível é **derivado dos sinais**: sobe quando o hábito do topo passa o
+ * portão. Nesse desenho, "quebrar" já é deixar de passar — a queda é
+ * implícita, e olhando só o presente é **impossível distinguir "caiu do lvl 3"
+ * de "nunca passou do lvl 2"**.
+ *
+ * Regressão exige memória. `previousLevel` é o maior nível já alcançado,
+ * persistido no store; é a comparação com ele que transforma uma queda em
+ * evento — o que a tela 4a·2 do design precisa pra dizer "voltamos pra água".
+ *
+ * Sem `previousLevel` a função continua correta, só não afirma regressão —
+ * é o caso do primeiro uso, onde não há passado pra comparar.
+ *
+ * ## ⚠️ Quem pausa é o TOPO, não quem quebrou
+ *
+ * Decisão da #289. Se no lvl 3 a água quebra (mais antiga, não graduada),
+ * pausar a água deixaria a alimentação órfã no topo sem base. Pausando o
+ * topo, larga-se a carga mais nova e o foco volta pro hábito que está
+ * sofrendo — que é a copy do design ("o foco volta pra água por um tempo").
+ *
+ * @param {{records: Array, goals?: object, now?: number, previousLevel?: number|null, thresholds?: object}} args
+ * @returns {{level: number, habits: object, focus: string|null, regressed: boolean}}
+ */
+export function deriveJourney({
+  records,
+  goals,
+  now = Date.now(),
+  previousLevel = null,
+  thresholds = THRESHOLDS,
+}) {
+  const janela = thresholds.window;
+  const lista = records ?? [];
+
+  // 1. Sinais de cada hábito, independentes do nível.
+  const porMetrica = {};
+  for (const metric of JOURNEY_ORDER) {
+    const target = goalFor(goals, metric);
+    const verdicts = dailyVerdicts(lista, metric, target, janela, now);
+    const signals = {
+      consistency: consistency(verdicts),
+      regularity: regularity(lista, metric, janela, now),
+      resilience: resilience(verdicts),
+    };
+    // `broken` é INFORMATIVO — serve pra explicar por que caiu, não pra
+    // derrubar. Quem derruba é o portão. E hábito sem nenhum acerto na janela
+    // não está quebrado: não começou.
+    const comecou = signals.consistency.hits > 0;
+    porMetrica[metric] = {
+      signals,
+      graduated: passesGraduation(signals, thresholds),
+      gated: passesGate(signals, thresholds),
+      broken: comecou && isBroken(verdicts, GOAL_CADENCE[metric]),
+    };
+  }
+
+  // 2. Nível = quantos hábitos, em ordem, passam o portão AGORA. O primeiro
+  //    que não passa interrompe a escada — e é o que está sendo construído.
+  let gateLevel = 0;
+  for (const metric of JOURNEY_ORDER) {
+    if (porMetrica[metric].gated) gateLevel += 1;
+    else break;
+  }
+  // O nível exibido inclui o hábito em construção. Teto na quantidade de
+  // hábitos: passar por todos não abre um sexto.
+  const level = Math.min(gateLevel + 1, JOURNEY_ORDER.length);
+
+  // 3. Regressão só existe contra o passado.
+  const regressed = previousLevel != null && level < previousLevel;
+  const topo = regressed ? previousLevel : level;
+
+  // 4. Status por hábito.
+  const habits = {};
+  JOURNEY_ORDER.forEach((metric, i) => {
+    const info = porMetrica[metric];
+    let status;
+    if (i >= topo) status = LOCKED;
+    // Entre o nível atual e o antigo: são os que a regressão largou.
+    else if (i >= level) status = PAUSED;
+    else if (info.graduated) status = GRADUATED;
+    else status = BUILDING;
+    habits[metric] = { status, ...info };
+  });
+
+  // Foco = o hábito em construção — o card grande da Home (fatia 2).
+  const focus =
+    JOURNEY_ORDER.slice(0, level)
+      .filter((m) => habits[m].status === BUILDING)
+      .pop() ?? null;
+
+  return { level, habits, focus, regressed };
+}

--- a/infra/database.js
+++ b/infra/database.js
@@ -46,6 +46,11 @@ export const store = createMergeableStore()
     // relação à derivação do email — que quando presente cai no primeiro nome
     // (antes do primeiro ponto). Editável em Ajustes.
     displayName: { type: "string", default: "" },
+    // Maior nível já alcançado na jornada (#289). É a MEMÓRIA que torna
+    // regressão detectável: o nível atual é derivado dos sinais, e olhando só
+    // o presente não dá pra distinguir "caiu do lvl 3" de "nunca passou do 2".
+    // Só sobe — cair é justamente o que se quer poder detectar.
+    journeyPeakLevel: { type: "number", default: 0 },
   });
 
 // Espalha `details` (JSON) de volta pro topo. É espalhado por último de
@@ -223,6 +228,17 @@ export function getGoals() {
     if (Number.isFinite(row?.target)) out[metric] = row.target;
   }
   return out;
+}
+
+/**
+ * Eleva o pico de nível, se o atual for maior. Nunca abaixa.
+ *
+ * Chamar de efeito, nunca durante render — é escrita no store.
+ */
+export function raiseJourneyPeak(level) {
+  if (!Number.isFinite(level)) return;
+  const atual = Number(store.getValue("journeyPeakLevel")) || 0;
+  if (level > atual) store.setValue("journeyPeakLevel", level);
 }
 
 // --- Testers (tela de admin, Track A do M3-5) ---

--- a/tests/journey.test.js
+++ b/tests/journey.test.js
@@ -1,0 +1,246 @@
+// @ts-nocheck -- teste; globals do jest não são tipados (ADR-002)
+import {
+  BUILDING,
+  GRADUATED,
+  LOCKED,
+  PAUSED,
+  THRESHOLDS,
+  deriveJourney,
+  isBroken,
+  passesGate,
+  passesGraduation,
+} from "@/constants/journey";
+import { JOURNEY_ORDER } from "@/constants/goals";
+
+// Estado da jornada (#289). Os testes usam dado SINTÉTICO de propósito: os
+// limiares são provisórios e sem calibração, então o que se verifica aqui é o
+// mecanismo — transições, ordem, semântica de pausa — não os valores.
+
+const DIA = 86_400_000;
+// Base fixa: sem isso os testes dependem da hora em que a suíte roda (lição
+// da #285, onde "hoje às 20:00" ficava no futuro antes das 20h).
+const AGORA = new Date(2026, 7, 14, 23, 30, 0, 0).getTime();
+
+/** Registro no dia N atrás, às 9h (horário estável de propósito). */
+function reg(type, diasAtras, quantity, hora = 9) {
+  const d = new Date(AGORA - diasAtras * DIA);
+  d.setHours(hora, 0, 0, 0);
+  return { type, createdAt: d.getTime(), quantity };
+}
+
+/** Série que bate a meta todo dia da janela, sempre no mesmo horário. */
+function serieCheia(type, quantity, dias = 28, hora = 9) {
+  return Array.from({ length: dias }, (_, i) => reg(type, i, quantity, hora));
+}
+
+/** Sinais sintéticos, pra testar os portões sem montar registros. */
+function sinais({ rate = 1, n = 28, sd = 10, doubleMisses = 0, resRate = 1 }) {
+  return {
+    consistency: { rate, hits: Math.round(rate * 28), days: 28 },
+    regularity: { resultant: 0.99, sdMinutes: sd, n },
+    resilience: { rate: resRate, recovered: 1, opportunities: 1, doubleMisses },
+  };
+}
+
+describe("passesGate", () => {
+  it("passa com consistência alta, horário estável e amostra suficiente", () => {
+    expect(passesGate(sinais({}))).toBe(true);
+  });
+
+  it("consistência abaixo do limiar não passa", () => {
+    expect(passesGate(sinais({ rate: 0.5 }))).toBe(false);
+  });
+
+  // O achado da #285 virando trava: estudo marcou R=0,99 sobre 2 registros.
+  // Sem piso de amostra o portão abriria pra quem registrou duas vezes.
+  it("amostra pequena não passa, por mais concentrada que pareça", () => {
+    expect(passesGate(sinais({ n: 2, sd: 1 }))).toBe(false);
+  });
+
+  it("horário disperso não passa", () => {
+    expect(passesGate(sinais({ sd: 400 }))).toBe(false);
+  });
+
+  // Duas faltas seguidas é o laço quebrado (§6) — não é "perto de automático".
+  it("falta dupla na janela não passa", () => {
+    expect(passesGate(sinais({ doubleMisses: 1 }))).toBe(false);
+  });
+
+  it("sem desvio calculável não passa", () => {
+    const s = sinais({});
+    s.regularity.sdMinutes = null;
+    expect(passesGate(s)).toBe(false);
+  });
+});
+
+describe("passesGraduation", () => {
+  it("gradua com barra alta em tudo", () => {
+    expect(passesGraduation(sinais({ rate: 0.95, n: 28, sd: 30 }))).toBe(true);
+  });
+
+  // A diferença entre "perto de automático" e "automático".
+  it("passar o portão não basta pra graduar", () => {
+    const apenasPortao = sinais({ rate: 0.82, n: 10, sd: 100 });
+    expect(passesGate(apenasPortao)).toBe(true);
+    expect(passesGraduation(apenasPortao)).toBe(false);
+  });
+
+  it("amostra insuficiente pra graduação não gradua", () => {
+    expect(passesGraduation(sinais({ rate: 0.95, n: 10, sd: 30 }))).toBe(false);
+  });
+
+  // Nunca ter caído é ausência de queda, não ausência de resiliência.
+  it("quem nunca falhou pode graduar", () => {
+    const s = sinais({ rate: 0.95, n: 28, sd: 30 });
+    s.resilience.rate = null;
+    expect(passesGraduation(s)).toBe(true);
+  });
+
+  it("resiliência baixa impede graduação", () => {
+    expect(
+      passesGraduation(sinais({ rate: 0.95, n: 28, sd: 30, resRate: 0.2 })),
+    ).toBe(false);
+  });
+});
+
+describe("isBroken", () => {
+  const v = (...hits) => hits.map((h) => ({ hit: h }));
+
+  it("diário: duas faltas consecutivas quebram", () => {
+    expect(isBroken(v(true, false, false, true), "daily")).toBe(true);
+  });
+
+  it("diário: faltas isoladas não quebram", () => {
+    expect(isBroken(v(false, true, false, true, false), "daily")).toBe(false);
+  });
+
+  // O caso que a terceira regra existe pra evitar: rebaixar alguém por
+  // descansar sábado e domingo.
+  it("semanal: dois dias seguidos sem registro NÃO quebram", () => {
+    const semana = [true, true, true, false, false, true, true];
+    expect(
+      isBroken(
+        [...semana, ...semana].map((h) => ({ hit: h })),
+        "weekly",
+      ),
+    ).toBe(false);
+  });
+
+  it("semanal: duas semanas seguidas abaixo do alvo quebram", () => {
+    const fraca = [true, false, false, false, false, false, false];
+    expect(
+      isBroken(
+        [...fraca, ...fraca].map((h) => ({ hit: h })),
+        "weekly",
+      ),
+    ).toBe(true);
+  });
+
+  it("semanal: uma semana ruim sozinha não quebra", () => {
+    const boa = [true, true, true, true, false, false, false];
+    const fraca = [true, false, false, false, false, false, false];
+    expect(
+      isBroken(
+        [...boa, ...fraca].map((h) => ({ hit: h })),
+        "weekly",
+      ),
+    ).toBe(false);
+  });
+
+  it("janela curta demais pra duas semanas não quebra", () => {
+    expect(isBroken(v(false, false, false), "weekly")).toBe(false);
+  });
+});
+
+describe("deriveJourney", () => {
+  const base = { goals: {}, now: AGORA, thresholds: THRESHOLDS };
+
+  it("sem registro nenhum, o primeiro hábito está em construção", () => {
+    const j = deriveJourney({ records: [], ...base });
+    expect(j.level).toBe(1);
+    expect(j.habits.sleep.status).toBe(BUILDING);
+    expect(j.habits.water.status).toBe(LOCKED);
+    expect(j.focus).toBe("sleep");
+  });
+
+  // Quem nunca começou não está quebrado. Sem isto, um usuário novo abriria o
+  // app já "regredido" — 28 dias de janela vazia viram 28 faltas.
+  it("hábito sem nenhum acerto não é reportado como quebrado", () => {
+    const j = deriveJourney({ records: [], ...base });
+    expect(j.habits.sleep.broken).toBe(false);
+    expect(j.regressed).toBe(false);
+  });
+
+  // Sono é `presence`: registrar todo dia no mesmo horário basta pra passar.
+  it("sono consistente abre a água", () => {
+    const j = deriveJourney({ records: serieCheia("sleep", 480), ...base });
+    expect(j.level).toBe(2);
+    expect(j.habits.water.status).toBe(BUILDING);
+    expect(j.focus).toBe("water");
+  });
+
+  it("hábitos além do aberto ficam trancados", () => {
+    const j = deriveJourney({ records: serieCheia("sleep", 480), ...base });
+    expect(j.habits.feeding.status).toBe(LOCKED);
+    expect(j.habits.exercise.status).toBe(LOCKED);
+  });
+
+  it("hábito na barra alta aparece como graduado", () => {
+    const j = deriveJourney({ records: serieCheia("sleep", 480), ...base });
+    expect(j.habits.sleep.status).toBe(GRADUATED);
+  });
+
+  // ⚠️ O ponto central da fatia: sem passado, não há regressão. Olhando só o
+  // presente é impossível distinguir "caiu do lvl 3" de "nunca passou do 2".
+  it("sem previousLevel não afirma regressão", () => {
+    const j = deriveJourney({ records: [], ...base });
+    expect(j.regressed).toBe(false);
+  });
+
+  it("nível abaixo do anterior é regressão", () => {
+    const j = deriveJourney({ records: [], previousLevel: 3, ...base });
+    expect(j.regressed).toBe(true);
+    expect(j.level).toBe(1);
+  });
+
+  it("nível igual ou acima do anterior não é regressão", () => {
+    const recs = serieCheia("sleep", 480);
+    expect(
+      deriveJourney({ records: recs, previousLevel: 2, ...base }).regressed,
+    ).toBe(false);
+    expect(
+      deriveJourney({ records: recs, previousLevel: 1, ...base }).regressed,
+    ).toBe(false);
+  });
+
+  // A decisão da #289: quem pausa é o TOPO, não quem quebrou.
+  it("na regressão, pausa o topo — os hábitos entre o nível atual e o antigo", () => {
+    const j = deriveJourney({
+      records: serieCheia("sleep", 480),
+      previousLevel: 4,
+      ...base,
+    });
+    // passou o portão só no sono → level 2, vindo do 4
+    expect(j.level).toBe(2);
+    expect(j.habits.sleep.status).toBe(GRADUATED);
+    expect(j.habits.water.status).toBe(BUILDING);
+    // os dois do topo pausaram, não o sono nem a água
+    expect(j.habits.feeding.status).toBe(PAUSED);
+    expect(j.habits.exercise.status).toBe(PAUSED);
+    expect(j.habits.study.status).toBe(LOCKED);
+  });
+
+  it("nível não passa da quantidade de hábitos", () => {
+    const recs = JOURNEY_ORDER.flatMap((m) =>
+      serieCheia(m, m === "feeding" ? 3 : 2500),
+    );
+    const j = deriveJourney({ records: recs, ...base });
+    expect(j.level).toBeLessThanOrEqual(JOURNEY_ORDER.length);
+  });
+
+  it("devolve os sinais junto, pro diagnóstico mostrar o porquê", () => {
+    const j = deriveJourney({ records: serieCheia("sleep", 480), ...base });
+    expect(j.habits.sleep.signals.consistency.rate).toBe(1);
+    expect(j.habits.sleep.signals.regularity.n).toBe(28);
+  });
+});


### PR DESCRIPTION
Fecha #289. Fatia 1 do modelo de níveis.

**A Home não muda.** O estado derivado aparece só no bloco de diagnóstico em
Ajustes → Avançado, ao lado dos sinais crus da #285.

## O desenho mudou no meio, e os testes são o motivo

A primeira versão derivava tudo dos sinais atuais e usava "quebrou" pra
derrubar o nível. Quatro testes falharam de uma vez, com uma causa em comum:

**Sintoma:** com zero registro, 28 dias de janela vazia viram 28 faltas — um
usuário novo abriria o app **já regredido**.

**Causa real, mais funda:** nesse desenho, quebrar **já é** deixar de passar o
portão. A queda é implícita. E olhando só o presente é impossível distinguir
_"caiu do lvl 3"_ de _"nunca passou do lvl 2"_. **Regressão exige memória** — e
não havia nenhuma.

Daí `journeyPeakLevel` no store: o maior nível já alcançado, que só sobe. É a
comparação com ele que transforma uma queda em **evento**, que é o que a tela
4a·2 do design precisa pra dizer "voltamos pra água". Sem `previousLevel` a
função segue correta, só não afirma regressão — o caso do primeiro uso.

`isBroken` continua, mas **informativo**: explica por que caiu, não derruba.

## Quem pausa é o topo

Decisão tomada na issue. No lvl 3 com a **água** quebrando (mais antiga, não
graduada), pausar a água deixaria a alimentação órfã no topo sem base.
Pausando o topo, larga-se a carga mais nova e o foco volta pro hábito que está
sofrendo — que é exatamente a copy do design.

## Limiares

Num bloco único, marcados como **provisórios**. Nenhum tem dado que o sustente
— a #285 rodou sobre 10 dias de histórico. São ponto de partida da literatura
(Lally 2010), não medida.

Inclui o **piso de amostra da regularidade**, achado da #285: estudo marcou
R=0,99 sobre **2 registros**, e duas amostras sempre parecem concentradas. Sem
piso, o portão abriria pra quem registrou duas vezes.

A separação que torna isso aceitável: **o mecanismo é testável independente
dos valores.** Os testes usam dado sintético de propósito.

## Testes

157 → 185. Mutação:

| mutação | testes que caem |
| --- | --- |
| portão sem piso de amostra | 1 |
| regressão nunca detectada | 2 |
| nada pausa na regressão | 1 |
| quem nunca começou conta como quebrado | 1 |
| semanal quebra com uma semana ruim | 1 |

## Sem bump de versão

JS puro, viaja por OTA no runtime 1.2.0.

## Como validar no BoT Staging

**Ajustes → Avançado** deve mostrar, acima da tabela:

```
nível derivado: 1 · foco: Sono
```

E uma coluna `estado` por métrica (`construindo` / `estável` / `em pausa` / `—`).

Com o histórico atual do dono do app o nível esperado é **1**, foco em Sono —
nenhum hábito passa o portão com 21% de consistência. **Nível maior que 1 é
sinal de limiar frouxo demais**, e é o que mais vale conferir.

O resto do app deve estar idêntico: Home, registro, histórico, Semana.
