### PR TITLE
feat(niveis): momentos de subir de nível e de regressão (fatia 3a)

### DIFF
--- a/app/ajustes.jsx
+++ b/app/ajustes.jsx
@@ -22,6 +22,7 @@ import {
   getGoals,
   acknowledgeJourneyLevel,
   raiseJourneyPeak,
+  setJourneyDemoLevel,
   setDisplayName,
   store,
 } from "@/infra/database";
@@ -552,6 +553,8 @@ function SyncRow() {
 function SignalsBlock({ goals }) {
   const records = useTable("records", store);
   const peak = useValue("journeyPeakLevel", store);
+  const demo = Number(useValue("journeyDemoLevel", store) ?? -1);
+  const emDemo = demo >= 0;
 
   const jornada = useMemo(
     () =>
@@ -635,6 +638,53 @@ function SignalsBlock({ goals }) {
             {h}
           </Text>
         ))}
+      </View>
+
+      {/* Previsualização de nível: força o nível pra ver as telas que o
+          histórico curto não alcança. Afrouxar limiar não resolveria — com
+          21% de consistência o portão teria que cair tão fundo que deixaria
+          de ser o mesmo portão. Isto testa a TELA; o modelo continua coberto
+          por tests/journey.test.js com dado sintético. */}
+      <View className="mt-3 flex-row items-center gap-2">
+        <Text
+          className="flex-1 text-xs text-label dark:text-label-dark"
+          style={{ fontFamily: "JetBrainsMono_400Regular" }}
+        >
+          {emDemo ? `demo: lvl ${demo}` : "previsualizar nível"}
+        </Text>
+        {[2, 3].map((n) => (
+          <Pressable
+            key={n}
+            accessibilityRole="button"
+            accessibilityLabel={`Previsualizar nível ${n}`}
+            onPress={() => {
+              setJourneyDemoLevel(n, jornada.level);
+              // ack um abaixo → a Home dispara o sheet de subida.
+              acknowledgeJourneyLevel(n - 1);
+            }}
+            className="rounded-lg border border-border-subtle dark:border-border-subtle-dark px-3 py-1.5 active:opacity-70"
+          >
+            <Text
+              className="text-xs text-body-secondary dark:text-body-secondary-dark"
+              style={{ fontFamily: "JetBrainsMono_400Regular" }}
+            >
+              lvl {n}
+            </Text>
+          </Pressable>
+        ))}
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Sair da previsualização"
+          onPress={() => setJourneyDemoLevel(-1, jornada.level)}
+          className="rounded-lg border border-border-subtle dark:border-border-subtle-dark px-3 py-1.5 active:opacity-70"
+        >
+          <Text
+            className="text-xs text-body-secondary dark:text-body-secondary-dark"
+            style={{ fontFamily: "JetBrainsMono_400Regular" }}
+          >
+            sair
+          </Text>
+        </Pressable>
       </View>
 
       {/* Controles de simulação (#293).

--- a/app/ajustes.jsx
+++ b/app/ajustes.jsx
@@ -38,7 +38,7 @@ import {
 } from "@/infra/sync";
 import { saveThemePreference } from "@/infra/theme";
 import { confirmAction } from "@/constants/dialogs";
-import { getEnvironmentInfo } from "@/constants/environment";
+import { getEnvironmentInfo, isDevSurface } from "@/constants/environment";
 import { useThemeTokens } from "@/constants/themeTokens";
 import { JOURNEY_ORDER, formatGoal, goalFor } from "@/constants/goals";
 import { habitSignals } from "@/constants/habitSignals";
@@ -51,6 +51,8 @@ import {
 } from "@/constants/journey";
 
 const ENV = getEnvironmentInfo();
+// Ferramenta de dev não vai pro app dos testers. Ver isDevSurface.
+const DEV_SURFACE = isDevSurface();
 
 // Tela Ajustes (M5-B fatia 4, mockup 2a·8).
 //
@@ -640,88 +642,94 @@ function SignalsBlock({ goals }) {
         ))}
       </View>
 
-      {/* Previsualização de nível: força o nível pra ver as telas que o
+      {/* Controles de desenvolvimento — NÃO aparecem no app dos testers.
+          Ver `isDevSurface`: só em dev e no canal `staging`. */}
+      {DEV_SURFACE ? (
+        <>
+          {/* Previsualização de nível: força o nível pra ver as telas que o
           histórico curto não alcança. Afrouxar limiar não resolveria — com
           21% de consistência o portão teria que cair tão fundo que deixaria
           de ser o mesmo portão. Isto testa a TELA; o modelo continua coberto
           por tests/journey.test.js com dado sintético. */}
-      <View className="mt-3 flex-row items-center gap-2">
-        <Text
-          className="flex-1 text-xs text-label dark:text-label-dark"
-          style={{ fontFamily: "JetBrainsMono_400Regular" }}
-        >
-          {emDemo ? `demo: lvl ${demo}` : "previsualizar nível"}
-        </Text>
-        {[2, 3].map((n) => (
-          <Pressable
-            key={n}
-            accessibilityRole="button"
-            accessibilityLabel={`Previsualizar nível ${n}`}
-            onPress={() => {
-              setJourneyDemoLevel(n, jornada.level);
-              // ack um abaixo → a Home dispara o sheet de subida.
-              acknowledgeJourneyLevel(n - 1);
-            }}
-            className="rounded-lg border border-border-subtle dark:border-border-subtle-dark px-3 py-1.5 active:opacity-70"
-          >
+          <View className="mt-3 flex-row items-center gap-2">
             <Text
-              className="text-xs text-body-secondary dark:text-body-secondary-dark"
+              className="flex-1 text-xs text-label dark:text-label-dark"
               style={{ fontFamily: "JetBrainsMono_400Regular" }}
             >
-              lvl {n}
+              {emDemo ? `demo: lvl ${demo}` : "previsualizar nível"}
             </Text>
-          </Pressable>
-        ))}
-        <Pressable
-          accessibilityRole="button"
-          accessibilityLabel="Sair da previsualização"
-          onPress={() => setJourneyDemoLevel(-1, jornada.level)}
-          className="rounded-lg border border-border-subtle dark:border-border-subtle-dark px-3 py-1.5 active:opacity-70"
-        >
-          <Text
-            className="text-xs text-body-secondary dark:text-body-secondary-dark"
-            style={{ fontFamily: "JetBrainsMono_400Regular" }}
-          >
-            sair
-          </Text>
-        </Pressable>
-      </View>
+            {[2, 3].map((n) => (
+              <Pressable
+                key={n}
+                accessibilityRole="button"
+                accessibilityLabel={`Previsualizar nível ${n}`}
+                onPress={() => {
+                  setJourneyDemoLevel(n, jornada.level);
+                  // ack um abaixo → a Home dispara o sheet de subida.
+                  acknowledgeJourneyLevel(n - 1);
+                }}
+                className="rounded-lg border border-border-subtle dark:border-border-subtle-dark px-3 py-1.5 active:opacity-70"
+              >
+                <Text
+                  className="text-xs text-body-secondary dark:text-body-secondary-dark"
+                  style={{ fontFamily: "JetBrainsMono_400Regular" }}
+                >
+                  lvl {n}
+                </Text>
+              </Pressable>
+            ))}
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Sair da previsualização"
+              onPress={() => setJourneyDemoLevel(-1, jornada.level)}
+              className="rounded-lg border border-border-subtle dark:border-border-subtle-dark px-3 py-1.5 active:opacity-70"
+            >
+              <Text
+                className="text-xs text-body-secondary dark:text-body-secondary-dark"
+                style={{ fontFamily: "JetBrainsMono_400Regular" }}
+              >
+                sair
+              </Text>
+            </Pressable>
+          </View>
 
-      {/* Controles de simulação (#293).
+          {/* Controles de simulação (#293).
           Os dois momentos são inobserváveis com histórico curto: nada sobe,
           nada cai. Estes botões só mexem no `journeyAckLevel` — o nível que a
           pessoa "já viu" — pra forçar a comparação a dar subida ou queda.
           Nenhum registro é tocado, e dispensar o momento devolve o ack ao
           nível real. É o equivalente ao server em `required` que usamos pra
           ver o estado de "precisa entrar". */}
-      <View className="mt-3 flex-row gap-2">
-        <Pressable
-          accessibilityRole="button"
-          accessibilityLabel="Simular subida de nível"
-          onPress={() => acknowledgeJourneyLevel(jornada.level - 1)}
-          className="flex-1 rounded-xl border border-border-subtle dark:border-border-subtle-dark py-2 active:opacity-70"
-        >
-          <Text
-            className="text-center text-xs text-body-secondary dark:text-body-secondary-dark"
-            style={{ fontFamily: "JetBrainsMono_400Regular" }}
-          >
-            simular subida
-          </Text>
-        </Pressable>
-        <Pressable
-          accessibilityRole="button"
-          accessibilityLabel="Simular regressão"
-          onPress={() => acknowledgeJourneyLevel(jornada.level + 2)}
-          className="flex-1 rounded-xl border border-border-subtle dark:border-border-subtle-dark py-2 active:opacity-70"
-        >
-          <Text
-            className="text-center text-xs text-body-secondary dark:text-body-secondary-dark"
-            style={{ fontFamily: "JetBrainsMono_400Regular" }}
-          >
-            simular regressão
-          </Text>
-        </Pressable>
-      </View>
+          <View className="mt-3 flex-row gap-2">
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Simular subida de nível"
+              onPress={() => acknowledgeJourneyLevel(jornada.level - 1)}
+              className="flex-1 rounded-xl border border-border-subtle dark:border-border-subtle-dark py-2 active:opacity-70"
+            >
+              <Text
+                className="text-center text-xs text-body-secondary dark:text-body-secondary-dark"
+                style={{ fontFamily: "JetBrainsMono_400Regular" }}
+              >
+                simular subida
+              </Text>
+            </Pressable>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Simular regressão"
+              onPress={() => acknowledgeJourneyLevel(jornada.level + 2)}
+              className="flex-1 rounded-xl border border-border-subtle dark:border-border-subtle-dark py-2 active:opacity-70"
+            >
+              <Text
+                className="text-center text-xs text-body-secondary dark:text-body-secondary-dark"
+                style={{ fontFamily: "JetBrainsMono_400Regular" }}
+              >
+                simular regressão
+              </Text>
+            </Pressable>
+          </View>
+        </>
+      ) : null}
 
       {linhas.map((l) => (
         <View key={l.metric} className="mt-1.5 flex-row">

--- a/app/ajustes.jsx
+++ b/app/ajustes.jsx
@@ -20,6 +20,7 @@ import MyView from "@/components/MyView";
 import {
   clearAll,
   getGoals,
+  acknowledgeJourneyLevel,
   raiseJourneyPeak,
   setDisplayName,
   store,
@@ -634,6 +635,42 @@ function SignalsBlock({ goals }) {
             {h}
           </Text>
         ))}
+      </View>
+
+      {/* Controles de simulação (#293).
+          Os dois momentos são inobserváveis com histórico curto: nada sobe,
+          nada cai. Estes botões só mexem no `journeyAckLevel` — o nível que a
+          pessoa "já viu" — pra forçar a comparação a dar subida ou queda.
+          Nenhum registro é tocado, e dispensar o momento devolve o ack ao
+          nível real. É o equivalente ao server em `required` que usamos pra
+          ver o estado de "precisa entrar". */}
+      <View className="mt-3 flex-row gap-2">
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Simular subida de nível"
+          onPress={() => acknowledgeJourneyLevel(jornada.level - 1)}
+          className="flex-1 rounded-xl border border-border-subtle dark:border-border-subtle-dark py-2 active:opacity-70"
+        >
+          <Text
+            className="text-center text-xs text-body-secondary dark:text-body-secondary-dark"
+            style={{ fontFamily: "JetBrainsMono_400Regular" }}
+          >
+            simular subida
+          </Text>
+        </Pressable>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Simular regressão"
+          onPress={() => acknowledgeJourneyLevel(jornada.level + 2)}
+          className="flex-1 rounded-xl border border-border-subtle dark:border-border-subtle-dark py-2 active:opacity-70"
+        >
+          <Text
+            className="text-center text-xs text-body-secondary dark:text-body-secondary-dark"
+            style={{ fontFamily: "JetBrainsMono_400Regular" }}
+          >
+            simular regressão
+          </Text>
+        </Pressable>
       </View>
 
       {linhas.map((l) => (

--- a/app/index.jsx
+++ b/app/index.jsx
@@ -126,7 +126,7 @@ export default function Home() {
   const peak = useValue("journeyPeakLevel", store);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const goals = useMemo(() => getGoals(), [records]);
-  const journey = useMemo(
+  const journeyReal = useMemo(
     () =>
       deriveJourney({
         records: Object.values(records ?? {}),
@@ -135,10 +135,23 @@ export default function Home() {
       }),
     [records, goals, peak],
   );
-  // Escrita no store fica em efeito, nunca em render.
+  // Previsualização de nível (#293). Substitui só o nível e o foco — o resto
+  // do estado segue real. Testa a TELA, não o modelo.
+  const demoLevel = useValue("journeyDemoLevel", store);
+  const emDemo = Number(demoLevel ?? -1) >= 0;
+  const journey = emDemo
+    ? {
+        ...journeyReal,
+        level: Number(demoLevel),
+        focus: JOURNEY_ORDER[Number(demoLevel) - 1] ?? null,
+      }
+    : journeyReal;
+
+  // Escrita no store fica em efeito, nunca em render. Em demo o peak NÃO sobe:
+  // senão sair do demo deixaria o app permanentemente "regredido".
   useEffect(() => {
-    raiseJourneyPeak(journey.level);
-  }, [journey.level]);
+    if (!emDemo) raiseJourneyPeak(journey.level);
+  }, [journey.level, emDemo]);
 
   const { focus, rest } = splitZones(journey);
   const copy = headerCopy(journey);

--- a/app/index.jsx
+++ b/app/index.jsx
@@ -10,9 +10,12 @@ import InstallApp from "@/components/InstallApp";
 import Icon1c from "@/components/Icon1c";
 import RetomadaState from "@/components/RetomadaState";
 import FocusCard from "@/components/journey/FocusCard";
+import RegressionNotice from "@/components/journey/RegressionNotice";
+import LevelUpSheet from "@/components/journey/LevelUpSheet";
 import CompactRow from "@/components/journey/CompactRow";
 
 import {
+  acknowledgeJourneyLevel,
   add,
   getGoals,
   getToday,
@@ -31,6 +34,15 @@ import {
   restBadge,
   splitZones,
 } from "@/constants/journeyHome";
+import {
+  MOMENT_LEVEL_UP,
+  MOMENT_REGRESSION,
+  levelUpCopy,
+  pendingMoment,
+  regressionCopy,
+} from "@/constants/journeyMoments";
+import { JOURNEY_ORDER } from "@/constants/goals";
+import { PAUSED } from "@/constants/journey";
 //#endregion
 
 const METRICS = Object.keys(CATEGORY_MAP);
@@ -129,6 +141,18 @@ export default function Home() {
 
   const { focus, rest } = splitZones(journey);
   const copy = headerCopy(journey);
+
+  // Momento pendente (#293). O ack é o que garante "uma vez e some": sem ele
+  // o aviso de regressão voltaria em toda abertura.
+  const ackLevel = useValue("journeyAckLevel", store);
+  const moment = pendingMoment(journey.level, Number(ackLevel ?? -1));
+  const pausados = JOURNEY_ORDER.filter(
+    (m) => journey.habits[m]?.status === PAUSED,
+  );
+
+  function dispensarMomento() {
+    acknowledgeJourneyLevel(journey.level);
+  }
 
   // Retomada aparece quando: (a) nunca registrou, ou (b) 3+ dias corridos sem
   // registro em nenhuma métrica. Dismissal in-memory desliga só nesta sessão.
@@ -280,6 +304,16 @@ export default function Home() {
           </Text>
         </View>
 
+        {/* Aviso de regressão: no topo, acima de tudo. Não é modal de
+            propósito — não bloqueia, e a pessoa pode ignorar e registrar. */}
+        {moment === MOMENT_REGRESSION ? (
+          <RegressionNotice
+            copy={regressionCopy({ focus: focus ?? "sleep", paused: pausados })}
+            onHistory={() => router.navigate("/history")}
+            onDismiss={dispensarMomento}
+          />
+        ) : null}
+
         {/* Zona de foco: o hábito do nível, com número grande e ação rápida.
             É o único com essa altura — a hierarquia mora aqui. */}
         {focus ? (
@@ -335,6 +369,27 @@ export default function Home() {
             o auto-load da sessão, o gate `!user` piscava o botão logo depois
             de logar. Concentrar em Ajustes elimina o flicker e centraliza. */}
       </ScrollView>
+
+      {/* Subir de nível: bottom sheet, fora do ScrollView. Fullscreen trataria
+          a subida como interrupção solene; sheet trata como recado. */}
+      {moment === MOMENT_LEVEL_UP && focus ? (
+        <LevelUpSheet
+          visible
+          copy={levelUpCopy({
+            from: Number(ackLevel ?? 0),
+            to: journey.level,
+            achieved: JOURNEY_ORDER[Math.max(0, journey.level - 2)],
+            next: focus,
+          })}
+          achieved={JOURNEY_ORDER[Math.max(0, journey.level - 2)]}
+          next={focus}
+          onDismiss={dispensarMomento}
+          onConfirm={() => {
+            dispensarMomento();
+            router.navigate(`/(metrics)/${focus}`);
+          }}
+        />
+      ) : null}
     </MyView>
   );
 }

--- a/app/index.jsx
+++ b/app/index.jsx
@@ -37,6 +37,7 @@ import {
 import {
   MOMENT_LEVEL_UP,
   MOMENT_REGRESSION,
+  achievedHabit,
   levelUpCopy,
   pendingMoment,
   regressionCopy,
@@ -149,6 +150,11 @@ export default function Home() {
   const pausados = JOURNEY_ORDER.filter(
     (m) => journey.habits[m]?.status === PAUSED,
   );
+
+  // `null` no lvl 1: nada foi conquistado ainda, o primeiro hábito está sendo
+  // construído. Sem isso o sheet diria "Sono virou seu" com Sono também como
+  // próximo foco.
+  const conquistado = achievedHabit(journey.level, JOURNEY_ORDER);
 
   function dispensarMomento() {
     acknowledgeJourneyLevel(journey.level);
@@ -372,16 +378,16 @@ export default function Home() {
 
       {/* Subir de nível: bottom sheet, fora do ScrollView. Fullscreen trataria
           a subida como interrupção solene; sheet trata como recado. */}
-      {moment === MOMENT_LEVEL_UP && focus ? (
+      {moment === MOMENT_LEVEL_UP && conquistado ? (
         <LevelUpSheet
           visible
           copy={levelUpCopy({
             from: Number(ackLevel ?? 0),
             to: journey.level,
-            achieved: JOURNEY_ORDER[Math.max(0, journey.level - 2)],
+            achieved: conquistado,
             next: focus,
           })}
-          achieved={JOURNEY_ORDER[Math.max(0, journey.level - 2)]}
+          achieved={conquistado}
           next={focus}
           onDismiss={dispensarMomento}
           onConfirm={() => {

--- a/components/journey/LevelUpSheet.jsx
+++ b/components/journey/LevelUpSheet.jsx
@@ -1,0 +1,161 @@
+// @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar
+import { Modal, Pressable, Text, View } from "react-native";
+
+import MetricIcon from "@/components/MetricIcon";
+import { useThemeTokens } from "@/constants/themeTokens";
+import { METRIC_TINT } from "@/constants/journeyHome";
+
+// Momento de subir de nível (#293, tela 4a·4 do Turno 4).
+//
+// **Bottom sheet, não fullscreen.** A diferença importa: fullscreen trataria
+// a subida como interrupção solene; sheet trata como recado. É reconhecimento,
+// não cerimônia.
+//
+// Sem confete, sem verde de vitória, sem "🎉" — reforço sóbrio
+// (docs/11-modelo-de-niveis.md §1.5). O reconhecimento vem em prosa: "Sono
+// virou seu".
+//
+// A peça mais importante é a última: `reassurance` antecipa a queda ("sem
+// drama") antes que ela aconteça. Reconhecimento que não antecipa a queda
+// vira dívida — a pessoa passa a ter algo a perder.
+
+/**
+ * @param {{
+ *   visible: boolean,
+ *   copy: object,
+ *   achieved: string,
+ *   next: string|null,
+ *   onDismiss: () => void,
+ *   onConfirm: () => void,
+ * }} props
+ */
+export default function LevelUpSheet({
+  visible,
+  copy,
+  achieved,
+  next,
+  onDismiss,
+  onConfirm,
+}) {
+  const t = useThemeTokens();
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="slide"
+      onRequestClose={onDismiss}
+    >
+      {/* Fundo escurecido: toque fora fecha, como qualquer sheet. */}
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Fechar"
+        onPress={onDismiss}
+        className="flex-1"
+        style={{ backgroundColor: "#0F141988" }}
+      />
+      <View className="rounded-t-3xl bg-white dark:bg-card-dark px-5 pt-5 pb-8">
+        <Text
+          className="text-xs uppercase tracking-wider text-label dark:text-label-dark"
+          style={{ fontFamily: "JetBrainsMono_500Medium" }}
+        >
+          {copy.steps}
+        </Text>
+
+        <View className="mt-2 flex-row items-center gap-3">
+          <View
+            className={`items-center justify-center rounded-xl ${METRIC_TINT[achieved] ?? ""}`}
+            style={{ width: 40, height: 40 }}
+          >
+            <MetricIcon metric={achieved} size={22} color={t.primary} />
+          </View>
+          <Text
+            className="flex-1 text-xl text-ink dark:text-ink-dark"
+            style={{ fontFamily: "Inter_600SemiBold" }}
+          >
+            {copy.title}
+          </Text>
+        </View>
+
+        <Text
+          className="mt-2.5 text-sm text-body-secondary dark:text-body-secondary-dark"
+          style={{ fontFamily: "Inter_400Regular", lineHeight: 21 }}
+        >
+          {copy.body}
+        </Text>
+
+        {copy.nextName ? (
+          <View className="mt-4 rounded-2xl border border-border-subtle dark:border-border-subtle-dark p-3.5">
+            <Text
+              className="text-xs uppercase tracking-wider text-label dark:text-label-dark"
+              style={{ fontFamily: "JetBrainsMono_500Medium" }}
+            >
+              {copy.nextLabel}
+            </Text>
+            <View className="mt-2 flex-row items-center gap-3">
+              <View
+                className={`items-center justify-center rounded-lg ${METRIC_TINT[next] ?? ""}`}
+                style={{ width: 32, height: 32 }}
+              >
+                <MetricIcon metric={next} size={18} color={t.primary} />
+              </View>
+              <View className="flex-1">
+                <Text
+                  className="text-base text-ink dark:text-ink-dark"
+                  style={{ fontFamily: "Inter_500Medium" }}
+                >
+                  {copy.nextName}
+                </Text>
+                {copy.nextHint ? (
+                  <Text
+                    className="text-xs text-body-secondary dark:text-body-secondary-dark"
+                    style={{ fontFamily: "Inter_400Regular" }}
+                  >
+                    {copy.nextHint}
+                  </Text>
+                ) : null}
+              </View>
+            </View>
+          </View>
+        ) : null}
+
+        {/* Antecipa a queda. Tira peso do futuro antes que ele chegue. */}
+        <Text
+          className="mt-3.5 text-xs text-label dark:text-label-dark"
+          style={{ fontFamily: "Inter_400Regular", lineHeight: 18 }}
+        >
+          {copy.reassurance}
+        </Text>
+
+        <View className="mt-4 flex-row gap-2">
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={copy.dismiss}
+            onPress={onDismiss}
+            className="flex-1 rounded-xl border border-border-strong dark:border-border-strong-dark py-3 active:opacity-70"
+          >
+            <Text
+              className="text-center text-sm text-ink dark:text-ink-dark"
+              style={{ fontFamily: "Inter_500Medium" }}
+            >
+              {copy.dismiss}
+            </Text>
+          </Pressable>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={copy.confirm}
+            onPress={onConfirm}
+            className="flex-1 rounded-xl bg-primary dark:bg-primary-dark py-3 active:opacity-70"
+          >
+            <Text
+              className="text-center text-sm text-white dark:text-on-primary-dark"
+              style={{ fontFamily: "Inter_600SemiBold" }}
+            >
+              {copy.confirm}
+            </Text>
+          </Pressable>
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/components/journey/RegressionNotice.jsx
+++ b/components/journey/RegressionNotice.jsx
@@ -1,0 +1,81 @@
+// @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar
+import { Pressable, Text, View } from "react-native";
+
+// Aviso de regressão (#293, tela 4a·2 do Turno 4).
+//
+// **A tela mais difícil do modelo.** Se ela der vontade de fechar o app, o
+// resto desmorona — foi assim que o briefing a descreveu, e o designer a
+// tratou como prioridade.
+//
+// Três escolhas que sustentam isso:
+//
+// 1. **Aviso no topo, não modal.** Não bloqueia. A pessoa pode ignorar e
+//    registrar — o app não sequestra a tela pra falar de queda.
+// 2. **Zero vermelho.** Fundo neutro (`surface-subtle`). O `danger` segue
+//    reservado pro destrutivo, como manda o design v2.
+// 3. **"Ver histórico" ao lado de "Entendi"** — a promessa de que nada sumiu
+//    vem com um caminho pra conferir. Provar, não afirmar.
+
+/**
+ * @param {{
+ *   copy: {title: string, body: string, preserved: string, history: string, dismiss: string},
+ *   onHistory: () => void,
+ *   onDismiss: () => void,
+ * }} props
+ */
+export default function RegressionNotice({ copy, onHistory, onDismiss }) {
+  return (
+    <View className="gap-2 rounded-2xl border border-border-subtle dark:border-border-subtle-dark bg-surface-subtle dark:bg-surface-subtle-dark p-4">
+      <Text
+        className="text-sm uppercase tracking-wider text-label dark:text-label-dark"
+        style={{ fontFamily: "JetBrainsMono_500Medium" }}
+      >
+        {copy.title}
+      </Text>
+
+      <Text
+        className="text-sm text-ink dark:text-ink-dark"
+        style={{ fontFamily: "Inter_400Regular", lineHeight: 20 }}
+      >
+        {copy.body}
+      </Text>
+
+      {/* A dúvida que a regressão levanta, respondida antes de ser feita. */}
+      <Text
+        className="text-xs text-body-secondary dark:text-body-secondary-dark"
+        style={{ fontFamily: "Inter_400Regular", lineHeight: 18 }}
+      >
+        {copy.preserved}
+      </Text>
+
+      <View className="mt-1 flex-row gap-2">
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={copy.history}
+          onPress={onHistory}
+          className="flex-1 rounded-xl border border-border-strong dark:border-border-strong-dark py-2.5 active:opacity-70"
+        >
+          <Text
+            className="text-center text-xs text-ink dark:text-ink-dark"
+            style={{ fontFamily: "Inter_500Medium" }}
+          >
+            {copy.history}
+          </Text>
+        </Pressable>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={copy.dismiss}
+          onPress={onDismiss}
+          className="flex-1 rounded-xl bg-primary dark:bg-primary-dark py-2.5 active:opacity-70"
+        >
+          <Text
+            className="text-center text-xs text-white dark:text-on-primary-dark"
+            style={{ fontFamily: "Inter_600SemiBold" }}
+          >
+            {copy.dismiss}
+          </Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}

--- a/constants/environment.js
+++ b/constants/environment.js
@@ -39,6 +39,33 @@ function describeBundle() {
 }
 
 /**
+ * Estamos numa superfície de desenvolvimento? (#293)
+ *
+ * Serve pra manter ferramenta de dev fora do app dos testers sem perder a
+ * capacidade de validar no BoT Staging.
+ *
+ * ⚠️ **`__DEV__` sozinho não serve.** O BoT Staging é build de produção
+ * (`--environment preview`), então `__DEV__` é `false` lá — e apagaria os
+ * controles justamente no lugar onde a validação acontece, que é a regra do
+ * projeto.
+ *
+ * `Updates.channel` é o canal do **build**, não do update: sobrevive a OTA e
+ * distingue os dois APKs de verdade. BoT Staging é `staging`; o dos testers é
+ * `preview`. Em dev e Expo Go vem `null`, daí o `__DEV__` como complemento.
+ *
+ * @returns {boolean}
+ */
+export function isDevSurface() {
+  try {
+    // eslint-disable-next-line no-undef
+    if (typeof __DEV__ !== "undefined" && __DEV__) return true;
+    return Updates.channel === "staging";
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Tudo que o app sabe sobre o próprio ambiente, sem o tester digitar nada.
  * @returns {{ environment: string, userAgent: string, appVersion: string, bundle: string }}
  */

--- a/constants/journeyMoments.js
+++ b/constants/journeyMoments.js
@@ -1,0 +1,99 @@
+// @ts-nocheck -- helper puro; tipos vêm quando constants/ for tipado (ADR-002)
+
+// Momentos da jornada (#293, fatia 3a) — telas 4a·2 e 4a·4 do Turno 4.
+//
+// Um momento aparece UMA VEZ e some. Quem garante isso é o `journeyAckLevel`
+// no store: o nível que a pessoa já viu. Sem ele o aviso de regressão
+// reapareceria em toda abertura do app.
+//
+// Tom: reforço sóbrio (docs/11-modelo-de-niveis.md §1.5). Subir de nível é
+// reconhecimento em prosa, não celebração — sem confete, sem verde de vitória,
+// sem "🎉". E a regressão não tem vermelho nem palavra de culpa.
+
+import { CATEGORY_MAP } from "@/components/categoryUtils";
+
+export const MOMENT_LEVEL_UP = "level-up";
+export const MOMENT_REGRESSION = "regression";
+
+/**
+ * Que momento está pendente, se algum.
+ *
+ * @param {number} level Nível derivado agora.
+ * @param {number} ackLevel Último nível reconhecido. `-1` = nunca reconheceu.
+ * @returns {"level-up"|"regression"|null}
+ */
+export function pendingMoment(level, ackLevel) {
+  if (!Number.isFinite(level)) return null;
+  const ack = Number.isFinite(ackLevel) ? ackLevel : -1;
+  // Primeira abertura: não há passado, então não há momento. Mostrar "subiu de
+  // nível" pra quem acabou de instalar o app seria comemorar o nada.
+  if (ack < 0) return null;
+  if (level > ack) return MOMENT_LEVEL_UP;
+  if (level < ack) return MOMENT_REGRESSION;
+  return null;
+}
+
+const nomeDe = (metric) => CATEGORY_MAP[metric]?.displayName ?? metric;
+const capitalizar = (s) => `${s.charAt(0).toUpperCase()}${s.slice(1)}`;
+
+/**
+ * Copy do sheet de subir de nível (4a·4).
+ *
+ * Três movimentos, nessa ordem:
+ * 1. **nomeia o que virou seu** — "Sono virou seu" é reconhecimento em prosa;
+ * 2. **explica o que muda** — para de cobrar atenção;
+ * 3. **antecipa a queda** — "sem drama". Tirar peso do futuro antes que ele
+ *    chegue é o que impede o reconhecimento de virar dívida.
+ *
+ * @param {{from: number, to: number, achieved: string, next: string|null}} args
+ */
+export function levelUpCopy({ from, to, achieved, next }) {
+  const conquistado = capitalizar(nomeDe(achieved));
+  const proximo = next ? nomeDe(next) : null;
+
+  return {
+    steps: `lvl ${from} → lvl ${to}`,
+    title: `${conquistado} virou seu.`,
+    body: "Últimas semanas com regularidade. A partir de agora ele fica no ar sem cobrar atenção.",
+    nextLabel: proximo ? "próximo foco" : null,
+    nextName: proximo ? capitalizar(proximo) : null,
+    nextHint: proximo ? (CATEGORY_MAP[next]?.subtitle ?? null) : null,
+    // O ponto mais importante da tela: a queda já vem anunciada, e sem peso.
+    reassurance: `${conquistado} continua na tela. Se ficar instável por uns dias, o foco volta pra ele — sem drama.`,
+    dismiss: "Depois",
+    confirm: proximo ? `Começar com ${proximo}` : "Continuar",
+  };
+}
+
+/**
+ * Copy do aviso de regressão (4a·2).
+ *
+ * ⚠️ **"voltamos", primeira pessoa do plural.** O app voltou junto — não é a
+ * pessoa que falhou sozinha. E o hábito fica **"em pausa"**, nunca "perdido".
+ *
+ * A promessa de que nada sumiu vem acompanhada de um botão pro histórico:
+ * provar em vez de afirmar.
+ *
+ * @param {{focus: string, paused: string[]}} args
+ */
+export function regressionCopy({ focus, paused }) {
+  const foco = nomeDe(focus);
+  const pausados = (paused ?? []).map(nomeDe);
+  const quem =
+    pausados.length === 0
+      ? "Um hábito"
+      : pausados.length === 1
+        ? capitalizar(pausados[0])
+        : `${capitalizar(pausados.slice(0, -1).join(", "))} e ${pausados.at(-1)}`;
+  const verbo = pausados.length > 1 ? "ficaram" : "ficou";
+
+  return {
+    title: `voltamos pra ${foco}`,
+    body: `${quem} ${verbo} uns dias em branco. O foco volta pra ${foco} por um tempo — quando ela estiver de novo estável, o resto retoma.`,
+    // Dito em voz alta porque é a dúvida que a regressão levanta.
+    preserved:
+      "Nada do que você já registrou foi perdido. Você continua podendo registrar tudo.",
+    history: "Ver histórico",
+    dismiss: "Entendi",
+  };
+}

--- a/constants/journeyMoments.js
+++ b/constants/journeyMoments.js
@@ -33,6 +33,23 @@ export function pendingMoment(level, ackLevel) {
   return null;
 }
 
+/**
+ * Qual hábito foi conquistado ao chegar neste nível.
+ *
+ * ⚠️ **`null` abaixo do lvl 2, e isso não é detalhe.** No lvl 1 o primeiro
+ * hábito está sendo CONSTRUÍDO, não conquistado — nada virou seu ainda.
+ * Sem esta guarda o sheet diria "Sono virou seu" tendo "Sono" também como
+ * próximo foco: o mesmo hábito nos dois papéis, na primeira subida que a
+ * pessoa veria.
+ *
+ * @param {number} level
+ * @param {string[]} order Ordem da jornada.
+ */
+export function achievedHabit(level, order) {
+  if (!Number.isFinite(level) || level < 2) return null;
+  return (order ?? [])[level - 2] ?? null;
+}
+
 const nomeDe = (metric) => CATEGORY_MAP[metric]?.displayName ?? metric;
 const capitalizar = (s) => `${s.charAt(0).toUpperCase()}${s.slice(1)}`;
 

--- a/infra/database.js
+++ b/infra/database.js
@@ -51,6 +51,13 @@ export const store = createMergeableStore()
     // o presente não dá pra distinguir "caiu do lvl 3" de "nunca passou do 2".
     // Só sobe — cair é justamente o que se quer poder detectar.
     journeyPeakLevel: { type: "number", default: 0 },
+    // Nível que o usuário já VIU e reconheceu (#293). Diferente do peak:
+    // o peak dirige o estado (o que aparece "em pausa" na Home, de forma
+    // persistente), o ack dirige o momento (aparece uma vez e some). Se o ack
+    // governasse o estado, hábito pausado viraria trancado no instante em que
+    // a pessoa tocasse "Entendi" — e o design mostra "em pausa" DEPOIS disso.
+    // -1 = nunca reconheceu nada, pra distinguir de "reconheceu o lvl 0".
+    journeyAckLevel: { type: "number", default: -1 },
   });
 
 // Espalha `details` (JSON) de volta pro topo. É espalhado por último de
@@ -239,6 +246,12 @@ export function raiseJourneyPeak(level) {
   if (!Number.isFinite(level)) return;
   const atual = Number(store.getValue("journeyPeakLevel")) || 0;
   if (level > atual) store.setValue("journeyPeakLevel", level);
+}
+
+/** Marca o nível como visto. Chamar ao dispensar um momento. */
+export function acknowledgeJourneyLevel(level) {
+  if (!Number.isFinite(level)) return;
+  store.setValue("journeyAckLevel", level);
 }
 
 // --- Testers (tela de admin, Track A do M3-5) ---

--- a/infra/database.js
+++ b/infra/database.js
@@ -58,6 +58,17 @@ export const store = createMergeableStore()
     // a pessoa tocasse "Entendi" — e o design mostra "em pausa" DEPOIS disso.
     // -1 = nunca reconheceu nada, pra distinguir de "reconheceu o lvl 0".
     journeyAckLevel: { type: "number", default: -1 },
+    // Nível forçado pra PREVISUALIZAR telas (#293). -1 = desligado.
+    //
+    // Existe porque os momentos são inobserváveis com histórico curto, e
+    // afrouxar os limiares não resolveria: com 21% de consistência e ±207min
+    // de dispersão, o portão teria que cair tão fundo que deixaria de ser o
+    // mesmo portão. Forçar o nível testa a TELA; o modelo continua sendo
+    // testado por `tests/journey.test.js`, com dado sintético.
+    //
+    // Enquanto ligado, o peak NÃO sobe — senão sair do demo deixaria o app
+    // permanentemente "regredido".
+    journeyDemoLevel: { type: "number", default: -1 },
   });
 
 // Espalha `details` (JSON) de volta pro topo. É espalhado por último de
@@ -246,6 +257,21 @@ export function raiseJourneyPeak(level) {
   if (!Number.isFinite(level)) return;
   const atual = Number(store.getValue("journeyPeakLevel")) || 0;
   if (level > atual) store.setValue("journeyPeakLevel", level);
+}
+
+/**
+ * Liga/desliga a previsualização de nível. `-1` desliga.
+ *
+ * Ao sair do demo, devolve peak e ack ao nível real pra não deixar resíduo —
+ * sem isso o app mostraria um aviso de regressão que nunca aconteceu.
+ */
+export function setJourneyDemoLevel(level, realLevel) {
+  const alvo = Number.isFinite(level) ? level : -1;
+  store.setValue("journeyDemoLevel", alvo);
+  if (alvo < 0 && Number.isFinite(realLevel)) {
+    store.setValue("journeyPeakLevel", realLevel);
+    store.setValue("journeyAckLevel", realLevel);
+  }
 }
 
 /** Marca o nível como visto. Chamar ao dispensar um momento. */

--- a/tests/dev-surface.test.js
+++ b/tests/dev-surface.test.js
@@ -1,0 +1,41 @@
+// @ts-nocheck -- teste; globals do jest não são tipados (ADR-002)
+
+// `isDevSurface` decide se ferramenta de dev aparece (#293). Errar pro lado
+// permissivo entrega controles de simulação aos 6 testers; errar pro lado
+// restritivo apaga os controles no BoT Staging, que é onde a validação
+// acontece pela regra do projeto. Os dois lados custam, então tem teste.
+
+describe("isDevSurface", () => {
+  const original = global.__DEV__;
+
+  afterEach(() => {
+    global.__DEV__ = original;
+    jest.resetModules();
+  });
+
+  function comCanal(channel, dev = false) {
+    jest.resetModules();
+    jest.doMock("expo-updates", () => ({ channel, updateId: null }));
+    global.__DEV__ = dev;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    return require("@/constants/environment").isDevSurface();
+  }
+
+  it("aparece em dev", () => {
+    expect(comCanal(null, true)).toBe(true);
+  });
+
+  it("aparece no canal staging (o BoT Staging)", () => {
+    expect(comCanal("staging")).toBe(true);
+  });
+
+  // O caso que motivou o gate: os 6 testers rodam no canal preview.
+  it("NÃO aparece no canal preview (app dos testers)", () => {
+    expect(comCanal("preview")).toBe(false);
+  });
+
+  it("não aparece em canal desconhecido", () => {
+    expect(comCanal("release")).toBe(false);
+    expect(comCanal(null)).toBe(false);
+  });
+});

--- a/tests/dev-surface.test.js
+++ b/tests/dev-surface.test.js
@@ -17,7 +17,6 @@ describe("isDevSurface", () => {
     jest.resetModules();
     jest.doMock("expo-updates", () => ({ channel, updateId: null }));
     global.__DEV__ = dev;
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
     return require("@/constants/environment").isDevSurface();
   }
 

--- a/tests/journey-moments.test.js
+++ b/tests/journey-moments.test.js
@@ -4,6 +4,7 @@ import {
   MOMENT_REGRESSION,
   levelUpCopy,
   pendingMoment,
+  achievedHabit,
   regressionCopy,
 } from "@/constants/journeyMoments";
 
@@ -44,6 +45,29 @@ describe("pendingMoment", () => {
   // default é -1 e não 0.
   it("reconhecer o lvl 0 e subir dispara momento", () => {
     expect(pendingMoment(1, 0)).toBe(MOMENT_LEVEL_UP);
+  });
+});
+
+describe("achievedHabit", () => {
+  const ordem = ["sleep", "water", "feeding"];
+
+  // No lvl 1 o primeiro hábito está sendo CONSTRUÍDO, não conquistado. Sem
+  // esta guarda o sheet diria "Sono virou seu" tendo Sono como próximo foco.
+  it("abaixo do lvl 2 nada foi conquistado", () => {
+    expect(achievedHabit(0, ordem)).toBeNull();
+    expect(achievedHabit(1, ordem)).toBeNull();
+  });
+
+  it("no lvl 2 o primeiro hábito virou seu", () => {
+    expect(achievedHabit(2, ordem)).toBe("sleep");
+  });
+
+  it("no lvl 3 é o segundo", () => {
+    expect(achievedHabit(3, ordem)).toBe("water");
+  });
+
+  it("além da ordem não inventa hábito", () => {
+    expect(achievedHabit(99, ordem)).toBeNull();
   });
 });
 

--- a/tests/journey-moments.test.js
+++ b/tests/journey-moments.test.js
@@ -1,0 +1,137 @@
+// @ts-nocheck -- teste; globals do jest não são tipados (ADR-002)
+import {
+  MOMENT_LEVEL_UP,
+  MOMENT_REGRESSION,
+  levelUpCopy,
+  pendingMoment,
+  regressionCopy,
+} from "@/constants/journeyMoments";
+
+// Momentos da jornada (#293). Duas coisas com risco de bug aqui: um momento
+// aparecer mais de uma vez (ou nunca), e a copy escorregar pro vocabulário
+// que o projeto rejeita — culpa na regressão, jogo na subida.
+
+describe("pendingMoment", () => {
+  it("nível acima do reconhecido = subiu", () => {
+    expect(pendingMoment(2, 1)).toBe(MOMENT_LEVEL_UP);
+  });
+
+  it("nível abaixo do reconhecido = regrediu", () => {
+    expect(pendingMoment(1, 3)).toBe(MOMENT_REGRESSION);
+  });
+
+  // O que faz o momento aparecer UMA vez: reconhecer iguala os dois.
+  it("nível igual ao reconhecido = nada pendente", () => {
+    expect(pendingMoment(2, 2)).toBeNull();
+  });
+
+  // Comemorar a instalação seria comemorar o nada.
+  it("primeira abertura não dispara momento", () => {
+    expect(pendingMoment(1, -1)).toBeNull();
+    expect(pendingMoment(3, -1)).toBeNull();
+  });
+
+  it("ack ausente é tratado como primeira abertura", () => {
+    expect(pendingMoment(2, undefined)).toBeNull();
+    expect(pendingMoment(2, null)).toBeNull();
+  });
+
+  it("nível inválido não dispara nada", () => {
+    expect(pendingMoment(undefined, 1)).toBeNull();
+  });
+
+  // Reconhecer o lvl 0 é diferente de nunca ter reconhecido nada — por isso o
+  // default é -1 e não 0.
+  it("reconhecer o lvl 0 e subir dispara momento", () => {
+    expect(pendingMoment(1, 0)).toBe(MOMENT_LEVEL_UP);
+  });
+});
+
+describe("levelUpCopy", () => {
+  const c = levelUpCopy({ from: 1, to: 2, achieved: "sleep", next: "water" });
+
+  it("mostra a transição de nível", () => {
+    expect(c.steps).toBe("lvl 1 → lvl 2");
+  });
+
+  // Reconhecimento em prosa, não celebração.
+  it("nomeia o que virou seu", () => {
+    expect(c.title).toBe("Sono virou seu.");
+  });
+
+  it("aponta o próximo foco", () => {
+    expect(c.nextName).toBe("Água");
+    expect(c.confirm).toBe("Começar com água");
+  });
+
+  // O movimento mais importante da tela: a queda já vem anunciada, e leve.
+  it("antecipa a queda sem peso", () => {
+    expect(c.reassurance).toMatch(/sem drama/);
+    expect(c.reassurance).toMatch(/continua na tela/);
+  });
+
+  it("sem próximo hábito, não inventa um", () => {
+    const fim = levelUpCopy({ from: 4, to: 5, achieved: "study", next: null });
+    expect(fim.nextName).toBeNull();
+    expect(fim.confirm).toBe("Continuar");
+  });
+
+  // A trava do tom: nada de vocabulário de jogo (§1.5 e o "o que ficou fora"
+  // escrito pelo próprio designer).
+  it("não usa vocabulário de jogo nem celebração", () => {
+    const tudo = Object.values(c).filter(Boolean).join(" ");
+    expect(tudo).not.toMatch(
+      /parab|desbloque|conquist|missão|troféu|medalha|🎉|🏆|XP|pontos/i,
+    );
+  });
+});
+
+describe("regressionCopy", () => {
+  const c = regressionCopy({ focus: "water", paused: ["feeding"] });
+
+  // Primeira pessoa do plural: o app voltou junto, não é a pessoa que falhou.
+  it("o título é coletivo", () => {
+    expect(c.title).toBe("voltamos pra água");
+  });
+
+  it("nomeia o que ficou em branco e promete o retorno", () => {
+    expect(c.body).toMatch(/alimentação/i);
+    expect(c.body).toMatch(/retoma/);
+  });
+
+  // A dúvida que a regressão levanta, respondida em voz alta — e com um botão
+  // pro histórico, pra provar em vez de afirmar.
+  it("diz que nada foi perdido e oferece o histórico", () => {
+    expect(c.preserved).toMatch(/nada.*foi perdido/i);
+    expect(c.history).toBe("Ver histórico");
+  });
+
+  // A trava mais importante do projeto: zero culpa.
+  it("não usa nenhuma palavra de culpa ou falha", () => {
+    const tudo = Object.values(c).join(" ");
+    expect(tudo).not.toMatch(
+      /falh|perdeu|errou|quebrou|fracass|desistiu|preguiç|culpa/i,
+    );
+  });
+
+  // "em pausa", nunca "perdido" — e o texto não pode contradizer o badge.
+  it("não chama o hábito de perdido", () => {
+    expect(c.body).not.toMatch(/perdid/i);
+  });
+
+  it("lista mais de um hábito pausado", () => {
+    const dois = regressionCopy({
+      focus: "sleep",
+      paused: ["water", "feeding"],
+    });
+    expect(dois.body).toMatch(/água/i);
+    expect(dois.body).toMatch(/alimentação/i);
+    expect(dois.body).toMatch(/ficaram/);
+  });
+
+  it("sem pausados nomeados, não quebra", () => {
+    const vazio = regressionCopy({ focus: "water", paused: [] });
+    expect(vazio.title).toBe("voltamos pra água");
+    expect(vazio.body).toMatch(/ficou/);
+  });
+});


### PR DESCRIPTION
Fecha #293. Fatia 3a — telas **4a·2** (regressão) e **4a·4** (subir de nível) do Turno 4.

## O mecanismo novo: reconhecimento

Um momento precisa aparecer **uma vez** e sumir. O app já sabia o nível atual e o pico, mas **não sabia o que já tinha sido mostrado** — sem isso o aviso de regressão voltaria em toda abertura.

Entra `journeyAckLevel`: o nível que a pessoa já viu.

| comparação | momento |
| --- | --- |
| `ack < level` | subiu |
| `ack > level` | regrediu |
| `ack == level` | nada |

**Peak e ack são diferentes e ambos ficam.** O peak dirige o *estado* (o que aparece "em pausa", persistente); o ack dirige o *momento* (uma vez). Se o ack governasse os dois, hábito pausado viraria trancado no instante em que a pessoa tocasse "Entendi" — e o design mostra "em pausa" **depois** disso.

**Default do ack é `-1`, não `0`.** Reconhecer o lvl 0 é diferente de nunca ter reconhecido nada; sem a distinção, quem acabou de instalar veria um "subiu de nível" comemorando o nada.

## Bug pego ao montar a simulação

No lvl 1 o primeiro hábito está sendo **construído**, não conquistado. Sem guarda, o sheet diria _"Sono virou seu"_ tendo **Sono** também como próximo foco — o mesmo hábito nos dois papéis, **na primeira subida que qualquer pessoa veria**.

`achievedHabit` devolve `null` abaixo do lvl 2, e a Home só monta o sheet quando há algo conquistado.

## As duas telas

**Regressão** — aviso no topo, **não modal**: não bloqueia, e a pessoa pode ignorar e registrar. Zero vermelho. _"voltamos pra água"_ na primeira pessoa do plural — o app voltou junto, não é a pessoa que falhou sozinha. "Ver histórico" ao lado de "Entendi", pra **provar** que nada sumiu em vez de só afirmar.

**Subir de nível** — bottom sheet, **não fullscreen**: fullscreen trataria a subida como interrupção solene, sheet trata como recado. A peça mais importante é a última linha, que **antecipa a queda**: _"se ficar instável por uns dias, o foco volta pra ele — sem drama"_. Reconhecimento que não antecipa a queda vira dívida.

## Previsualização de nível

Os momentos são inobserváveis com histórico curto. Afrouxar limiar não resolveria: com 21% de consistência e ±207min de dispersão, o portão teria que cair tão fundo que deixaria de ser o mesmo portão — e a tela seria vista sob um modelo que não é o nosso.

Então a previsualização força o **nível**, e assume o que é: **teste da tela, não do modelo**. O modelo segue coberto por `tests/journey.test.js` com dado sintético.

Enquanto ligada o peak não sobe, e sair devolve peak e ack ao nível real — sem resíduo.

## Testes

227 → 231, com duas travas de tom:

- subida: sem `parabéns|desbloqueou|conquista|missão|troféu|medalha|🎉|XP|pontos`
- regressão: sem `falhou|perdeu|errou|quebrou|fracassou|desistiu|culpa`

Mutação: comemorar na primeira abertura derruba 2, regressão nunca disparar derruba 1, momento nunca sumir derruba 1, título que culpa derruba 3.

## Sem bump de versão

JS puro, OTA no runtime 1.2.0.

## Como validar no BoT Staging

Ajustes → Avançado, bloco de sinais:

1. **`simular regressão`** → Home mostra o aviso "voltamos pra sono". Tocar "Entendi" some, e **não deve voltar** ao reabrir a tela.
2. **`lvl 2`** → Home mostra o sheet "Sono virou seu" com Água como próximo foco.
3. **`lvl 3`** → mesma tela com outro par (Água conquistada, Alimentação a seguir).
4. **`sair`** → volta ao real, sem aviso de regressão residual.

**O que mais vale julgar:** o sheet de subida parece _reconhecimento_ ou _celebração_? É a linha que a fatia inteira tenta não cruzar.
