### PR TITLE
feat(niveis): pular nível com conferência do histórico (fatia 3b)

### DIFF
--- a/app/ajustes.jsx
+++ b/app/ajustes.jsx
@@ -16,11 +16,14 @@ import { useTable, useValue } from "tinybase/ui-react";
 
 import { goBack } from "@/constants/navigation";
 import MyView from "@/components/MyView";
+import SkipLevelSheet from "@/components/journey/SkipLevelSheet";
 
 import {
   clearAll,
   getGoals,
   acknowledgeJourneyLevel,
+  getGrantedHabits,
+  grantHabit,
   raiseJourneyPeak,
   setJourneyDemoLevel,
   setDisplayName,
@@ -42,6 +45,7 @@ import { getEnvironmentInfo, isDevSurface } from "@/constants/environment";
 import { useThemeTokens } from "@/constants/themeTokens";
 import { JOURNEY_ORDER, formatGoal, goalFor } from "@/constants/goals";
 import { habitSignals } from "@/constants/habitSignals";
+import { skipCopy, skipEvidence, skipQualifies } from "@/constants/journeySkip";
 import {
   BUILDING,
   GRADUATED,
@@ -107,6 +111,39 @@ export default function Ajustes() {
   const goalsTable = useTable("goals", store);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const goals = useMemo(() => getGoals(), [goalsTable]);
+
+  // Pular nível (#295): a pessoa declara que já tem o hábito, o app confere o
+  // histórico com o MESMO critério do portão e concede — ou diz que observa.
+  const [skipMetric, setSkipMetric] = useState(null);
+  const recordsTable = useTable("records", store);
+  const grantedValue = useValue("journeyGranted", store);
+  const skipInfo = useMemo(() => {
+    if (!skipMetric) return null;
+    const lista = Object.values(recordsTable ?? {});
+    const signals = habitSignals(
+      lista,
+      skipMetric,
+      goalFor(goals, skipMetric),
+      JANELA_SINAIS,
+    );
+    const qualifies = skipQualifies(signals);
+    const jornadaAtual = deriveJourney({
+      records: lista,
+      goals,
+      granted: getGrantedHabits(),
+    });
+    return {
+      signals,
+      qualifies,
+      evidence: skipEvidence(signals, JANELA_SINAIS),
+      copy: skipCopy({
+        metric: skipMetric,
+        qualifies,
+        nextLevel: jornadaAtual.level + 1,
+      }),
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [skipMetric, recordsTable, goals, grantedValue]);
 
   function handleClear() {
     confirmAction({
@@ -263,6 +300,26 @@ export default function Ajustes() {
           </Section>
         )}
 
+        {/* Já tenho esse hábito — pular nível com conferência (#295). */}
+        <Section title="Já tenho esse hábito">
+          {JOURNEY_ORDER.map((metric) => (
+            <Row
+              key={metric}
+              label={METAS_LABEL[metric]}
+              value={
+                getGrantedHabits().includes(metric) ? "estável" : "conferir"
+              }
+              valueChevron={!getGrantedHabits().includes(metric)}
+              disabled={getGrantedHabits().includes(metric)}
+              onPress={
+                getGrantedHabits().includes(metric)
+                  ? undefined
+                  : () => setSkipMetric(metric)
+              }
+            />
+          ))}
+        </Section>
+
         {/* Avançado */}
         <Section title="Avançado">
           <SignalsBlock goals={goals} />
@@ -291,6 +348,21 @@ export default function Ajustes() {
           </Text>
         ) : null}
       </ScrollView>
+
+      {skipInfo ? (
+        <SkipLevelSheet
+          visible
+          metric={skipMetric}
+          copy={skipInfo.copy}
+          evidence={skipInfo.evidence}
+          qualifies={skipInfo.qualifies}
+          onDismiss={() => setSkipMetric(null)}
+          onConfirm={() => {
+            grantHabit(skipMetric);
+            setSkipMetric(null);
+          }}
+        />
+      ) : null}
 
       {nameModalOpen && (
         <NameEditModal

--- a/components/journey/SkipLevelSheet.jsx
+++ b/components/journey/SkipLevelSheet.jsx
@@ -1,0 +1,156 @@
+// @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar
+import { Modal, Pressable, Text, View } from "react-native";
+
+import MetricIcon from "@/components/MetricIcon";
+import { useThemeTokens } from "@/constants/themeTokens";
+import { METRIC_TINT } from "@/constants/journeyHome";
+
+// Pular nível com conferência do histórico (#295, tela 4a·6 do Turno 4).
+//
+// A tela tem um risco de tom específico: virar interrogatório. O design
+// resolve com dois movimentos, e os dois estão aqui:
+//
+// 1. **Números concretos, não veredito.** O bloco do meio lista o que o app
+//    viu — dias com registro, dispersão do horário — sem dar nota.
+// 2. **O caso oposto vem antecipado.** Dizer de antemão o que aconteceria se
+//    não batesse deixa claro que o app não confia cego, mas também não
+//    desconfia hostil.
+
+/**
+ * @param {{
+ *   visible: boolean,
+ *   metric: string,
+ *   copy: object,
+ *   evidence: Array<{label: string, value: string}>,
+ *   qualifies: boolean,
+ *   onDismiss: () => void,
+ *   onConfirm: () => void,
+ * }} props
+ */
+export default function SkipLevelSheet({
+  visible,
+  metric,
+  copy,
+  evidence,
+  qualifies,
+  onDismiss,
+  onConfirm,
+}) {
+  const t = useThemeTokens();
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="slide"
+      onRequestClose={onDismiss}
+    >
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Fechar"
+        onPress={onDismiss}
+        className="flex-1"
+        style={{ backgroundColor: "#0F141988" }}
+      />
+      <View className="rounded-t-3xl bg-white dark:bg-card-dark px-5 pt-5 pb-8">
+        <Text
+          className="text-xs uppercase tracking-wider text-label dark:text-label-dark"
+          style={{ fontFamily: "JetBrainsMono_500Medium" }}
+        >
+          {copy.claimLabel}
+        </Text>
+        <View className="mt-2 flex-row items-center gap-3">
+          <View
+            className={`items-center justify-center rounded-xl ${METRIC_TINT[metric] ?? ""}`}
+            style={{ width: 36, height: 36 }}
+          >
+            <MetricIcon metric={metric} size={20} color={t.primary} />
+          </View>
+          <Text
+            className="flex-1 text-base text-ink dark:text-ink-dark"
+            style={{ fontFamily: "Inter_500Medium" }}
+          >
+            {copy.claim}
+          </Text>
+        </View>
+
+        {/* O que o app viu. Fatos, não nota. */}
+        <Text
+          className="mt-4 text-xs uppercase tracking-wider text-label dark:text-label-dark"
+          style={{ fontFamily: "JetBrainsMono_500Medium" }}
+        >
+          {copy.evidenceLabel}
+        </Text>
+        <View className="mt-2 rounded-2xl border border-border-subtle dark:border-border-subtle-dark">
+          {evidence.map((linha, i) => (
+            <View
+              key={linha.label}
+              className={`flex-row items-center justify-between px-3.5 py-2.5 ${
+                i > 0
+                  ? "border-t border-border-subtle dark:border-border-subtle-dark"
+                  : ""
+              }`}
+            >
+              <Text
+                className="flex-1 text-sm text-body-secondary dark:text-body-secondary-dark"
+                style={{ fontFamily: "Inter_400Regular" }}
+              >
+                {linha.label}
+              </Text>
+              <Text
+                className="text-sm text-ink dark:text-ink-dark"
+                style={{ fontFamily: "JetBrainsMono_400Regular" }}
+              >
+                {linha.value}
+              </Text>
+            </View>
+          ))}
+        </View>
+
+        <Text
+          className="mt-3.5 text-sm text-ink dark:text-ink-dark"
+          style={{ fontFamily: "Inter_400Regular", lineHeight: 21 }}
+        >
+          {copy.verdict}
+        </Text>
+
+        {/* O desfecho oposto, dito de antemão. */}
+        <Text
+          className="mt-2 text-xs text-label dark:text-label-dark"
+          style={{ fontFamily: "Inter_400Regular", lineHeight: 18 }}
+        >
+          {copy.alternate}
+        </Text>
+
+        <View className="mt-4 flex-row gap-2">
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={copy.dismiss}
+            onPress={onDismiss}
+            className="flex-1 rounded-xl border border-border-strong dark:border-border-strong-dark py-3 active:opacity-70"
+          >
+            <Text
+              className="text-center text-sm text-ink dark:text-ink-dark"
+              style={{ fontFamily: "Inter_500Medium" }}
+            >
+              {copy.dismiss}
+            </Text>
+          </Pressable>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={copy.confirm}
+            onPress={qualifies ? onConfirm : onDismiss}
+            className="flex-1 rounded-xl bg-primary dark:bg-primary-dark py-3 active:opacity-70"
+          >
+            <Text
+              className="text-center text-sm text-white dark:text-on-primary-dark"
+              style={{ fontFamily: "Inter_600SemiBold" }}
+            >
+              {copy.confirm}
+            </Text>
+          </Pressable>
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/constants/journey.js
+++ b/constants/journey.js
@@ -164,7 +164,7 @@ export function isBroken(verdicts, cadence, porSemana = 3) {
  * topo, larga-se a carga mais nova e o foco volta pro hábito que está
  * sofrendo — que é a copy do design ("o foco volta pra água por um tempo").
  *
- * @param {{records: Array, goals?: object, now?: number, previousLevel?: number|null, thresholds?: object}} args
+ * @param {{records: Array, goals?: object, now?: number, previousLevel?: number|null, granted?: string[], thresholds?: object}} args
  * @returns {{level: number, habits: object, focus: string|null, regressed: boolean}}
  */
 export function deriveJourney({
@@ -172,6 +172,7 @@ export function deriveJourney({
   goals,
   now = Date.now(),
   previousLevel = null,
+  granted = [],
   thresholds = THRESHOLDS,
 }) {
   const janela = thresholds.window;
@@ -191,11 +192,16 @@ export function deriveJourney({
     // derrubar. Quem derruba é o portão. E hábito sem nenhum acerto na janela
     // não está quebrado: não começou.
     const comecou = signals.consistency.hits > 0;
+    // Concessão por conferência (#295): o hábito entra graduado sem esperar a
+    // barra alta. A evidência exigida foi a do portão, avaliada sobre o mesmo
+    // histórico — não é atalho, é reconhecimento antecipado.
+    const concedido = (granted ?? []).includes(metric);
     porMetrica[metric] = {
       signals,
-      graduated: passesGraduation(signals, thresholds),
-      gated: passesGate(signals, thresholds),
-      broken: comecou && isBroken(verdicts, GOAL_CADENCE[metric]),
+      granted: concedido,
+      graduated: concedido || passesGraduation(signals, thresholds),
+      gated: concedido || passesGate(signals, thresholds),
+      broken: !concedido && comecou && isBroken(verdicts, GOAL_CADENCE[metric]),
     };
   }
 

--- a/constants/journeySkip.js
+++ b/constants/journeySkip.js
@@ -1,0 +1,99 @@
+// @ts-nocheck -- helper puro; tipos vêm quando constants/ for tipado (ADR-002)
+
+// Pular nível com conferência do histórico (#295) — tela 4a·6 do Turno 4.
+//
+// ⚠️ **O critério pra pular é o MESMO critério do portão.** Não se pula o
+// portão: entra-se nele já qualificado, com evidência avaliada sobre a mesma
+// janela de 28 dias que qualquer um enfrenta. Não há o que burlar, porque a
+// exigência é idêntica à do caminho normal (§9 do modelo).
+//
+// O que a concessão encurta é a ESPERA: graduar normalmente exige a barra
+// alta sustentada; aqui a evidência do portão basta. Quem chega com o hábito
+// pronto não precisa provar de novo o que já está no histórico.
+//
+// Duas coisas da tela que não são decoração:
+//
+// - **números concretos, não veredito.** O app mostra o que viu — dias com
+//   registro, dispersão do horário — em vez de dar uma nota.
+// - **antecipa o caso oposto.** Dizer de antemão o que acontece se não bater
+//   é o que impede a tela de virar interrogatório: não confia cego, mas
+//   também não desconfia hostil.
+
+import { CATEGORY_MAP } from "@/components/categoryUtils";
+import { passesGate } from "./journey";
+
+const nomeDe = (metric) => CATEGORY_MAP[metric]?.displayName ?? metric;
+
+/**
+ * O histórico sustenta a alegação?
+ *
+ * Delegado inteiro ao `passesGate` de propósito: se um dia o portão mudar, o
+ * critério pra pular muda junto, sem ninguém precisar lembrar de sincronizar
+ * dois lugares.
+ *
+ * @param {object} signals Saída de `habitSignals`.
+ * @param {object} [thresholds]
+ * @returns {boolean}
+ */
+export function skipQualifies(signals, thresholds) {
+  return passesGate(signals, thresholds);
+}
+
+/**
+ * Os números que o app viu, prontos pra exibir.
+ *
+ * Cada linha é um fato observável, não uma avaliação. `—` quando não há
+ * amostra pra afirmar nada — dizer "0 min de variação" com dois registros
+ * seria inventar precisão.
+ *
+ * @param {object} signals
+ * @param {number} janela Dias da janela.
+ * @returns {Array<{label: string, value: string}>}
+ */
+export function skipEvidence(signals, janela) {
+  const { consistency, regularity } = signals ?? {};
+  const dias = consistency?.days ?? janela;
+  const sd = regularity?.sdMinutes;
+
+  return [
+    {
+      label: "Dias com registro",
+      value: `${consistency?.hits ?? 0} / ${dias} dias`,
+    },
+    {
+      label: "Variação do horário",
+      value: sd == null ? "—" : `± ${Math.round(sd)} min`,
+    },
+    {
+      label: "Registros na janela",
+      value: `${regularity?.n ?? 0}`,
+    },
+  ];
+}
+
+/**
+ * Copy da tela, nos dois desfechos.
+ *
+ * @param {{metric: string, claim?: string, qualifies: boolean, nextLevel: number}} args
+ */
+export function skipCopy({ metric, qualifies, nextLevel }) {
+  const nome = nomeDe(metric);
+
+  return {
+    claimLabel: "você disse",
+    claim: `"Já cuido de ${nome} — quero pular."`,
+    evidenceLabel: "o que o histórico mostra",
+
+    verdict: qualifies
+      ? `Bate com o que você disse. Você começa direto no lvl ${nextLevel} — ${nome} já entra estável.`
+      : `O histórico ainda não mostra isso. Começamos no lvl 1 e ${nome} entra estável quando os dados acompanharem.`,
+
+    // Antecipar o desfecho oposto tira o peso de julgamento dos dois lados.
+    alternate: qualifies
+      ? "Se não batesse, o app começaria no lvl 1 e observaria por duas semanas antes de considerar estável — sem drama."
+      : "Nada foi descartado: seus registros continuam contando, e a conferência refaz sozinha conforme o histórico cresce.",
+
+    dismiss: "Refazer",
+    confirm: qualifies ? `Começar no lvl ${nextLevel}` : "Entendi",
+  };
+}

--- a/infra/database.js
+++ b/infra/database.js
@@ -69,6 +69,11 @@ export const store = createMergeableStore()
     // Enquanto ligado, o peak NÃO sobe — senão sair do demo deixaria o app
     // permanentemente "regredido".
     journeyDemoLevel: { type: "number", default: -1 },
+    // Hábitos graduados por CONFERÊNCIA do histórico (#295), separados por
+    // vírgula. Graduar normalmente exige a barra alta e semanas de observação;
+    // pular concede com a evidência do portão — mesma exigência, sem espera.
+    // Persistido porque a derivação olha só a janela atual e esqueceria.
+    journeyGranted: { type: "string", default: "" },
   });
 
 // Espalha `details` (JSON) de volta pro topo. É espalhado por último de
@@ -272,6 +277,22 @@ export function setJourneyDemoLevel(level, realLevel) {
     store.setValue("journeyPeakLevel", realLevel);
     store.setValue("journeyAckLevel", realLevel);
   }
+}
+
+/** Hábitos graduados por conferência, como lista. */
+export function getGrantedHabits() {
+  return String(store.getValue("journeyGranted") ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/** Concede graduação a um hábito. Idempotente. */
+export function grantHabit(metric) {
+  if (!metric) return;
+  const atuais = getGrantedHabits();
+  if (atuais.includes(metric)) return;
+  store.setValue("journeyGranted", [...atuais, metric].join(","));
 }
 
 /** Marca o nível como visto. Chamar ao dispensar um momento. */

--- a/tests/journey-skip.test.js
+++ b/tests/journey-skip.test.js
@@ -1,0 +1,117 @@
+// @ts-nocheck -- teste; globals do jest não são tipados (ADR-002)
+import { skipCopy, skipEvidence, skipQualifies } from "@/constants/journeySkip";
+import { THRESHOLDS } from "@/constants/journey";
+import { deriveJourney, GRADUATED } from "@/constants/journey";
+
+// Pular nível (#295). O risco maior aqui não é técnico: é a tela virar
+// interrogatório, ou a concessão virar atalho que afrouxa o critério.
+
+const sinais = ({ rate = 1, n = 28, sd = 10, doubleMisses = 0 }) => ({
+  consistency: { rate, hits: Math.round(rate * 28), days: 28 },
+  regularity: { resultant: 0.99, sdMinutes: sd, n },
+  resilience: { rate: 1, recovered: 1, opportunities: 1, doubleMisses },
+});
+
+describe("skipQualifies", () => {
+  it("histórico bom qualifica", () => {
+    expect(skipQualifies(sinais({}), THRESHOLDS)).toBe(true);
+  });
+
+  // A trava contra "pular = atalho": a exigência é a MESMA do portão.
+  it("histórico fraco não qualifica", () => {
+    expect(skipQualifies(sinais({ rate: 0.3 }), THRESHOLDS)).toBe(false);
+  });
+
+  it("amostra pequena não qualifica, por mais concentrada que pareça", () => {
+    expect(skipQualifies(sinais({ n: 2, sd: 1 }), THRESHOLDS)).toBe(false);
+  });
+});
+
+describe("skipEvidence", () => {
+  const linhas = skipEvidence(sinais({ rate: 0.75, n: 21, sd: 24 }), 28);
+
+  it("mostra fatos observáveis, não notas", () => {
+    expect(linhas.map((l) => l.value).join(" ")).toMatch(
+      /21 \/ 28 dias|± 24 min/,
+    );
+  });
+
+  // Dizer "0 min de variação" com dois registros seria inventar precisão.
+  it("sem amostra, não inventa número", () => {
+    const semSd = skipEvidence(sinais({ sd: null, n: 1 }), 28);
+    expect(semSd.find((l) => l.label.match(/Variação/)).value).toBe("—");
+  });
+
+  it("nenhuma linha traz julgamento", () => {
+    const texto = linhas.map((l) => `${l.label} ${l.value}`).join(" ");
+    expect(texto).not.toMatch(/bom|ruim|ótimo|fraco|parab|falh/i);
+  });
+});
+
+describe("skipCopy", () => {
+  const ok = skipCopy({ metric: "sleep", qualifies: true, nextLevel: 2 });
+  const nao = skipCopy({ metric: "sleep", qualifies: false, nextLevel: 2 });
+
+  it("quando bate, concede e nomeia o nível", () => {
+    expect(ok.verdict).toMatch(/lvl 2/);
+    expect(ok.confirm).toBe("Começar no lvl 2");
+  });
+
+  // O movimento que impede a tela de virar interrogatório.
+  it("quando bate, antecipa o caso oposto", () => {
+    expect(ok.alternate).toMatch(/se não batesse/i);
+    expect(ok.alternate).toMatch(/sem drama/);
+  });
+
+  it("quando não bate, diz o que vai fazer em vez de acusar", () => {
+    expect(nao.verdict).toMatch(/ainda não mostra/);
+    expect(nao.alternate).toMatch(/nada foi descartado/i);
+  });
+
+  // A trava mais importante: o app não pode chamar a pessoa de mentirosa.
+  it("nunca acusa a pessoa, em nenhum desfecho", () => {
+    for (const c of [ok, nao]) {
+      const tudo = Object.values(c).join(" ");
+      expect(tudo).not.toMatch(
+        /mentiu|mentira|falso|não acredit|desconfi|prove|comprove/i,
+      );
+    }
+  });
+
+  it("não usa vocabulário de jogo", () => {
+    const tudo = Object.values(ok).join(" ");
+    expect(tudo).not.toMatch(/desbloque|conquist|parab|troféu|🎉/i);
+  });
+});
+
+describe("concessão no deriveJourney", () => {
+  const base = {
+    records: [],
+    goals: {},
+    now: Date.now(),
+    thresholds: THRESHOLDS,
+  };
+
+  it("hábito concedido entra graduado sem histórico", () => {
+    const j = deriveJourney({ ...base, granted: ["sleep"] });
+    expect(j.habits.sleep.status).toBe(GRADUATED);
+    expect(j.habits.sleep.granted).toBe(true);
+  });
+
+  it("concessão sobe o nível", () => {
+    const semGrant = deriveJourney({ ...base, granted: [] });
+    const comGrant = deriveJourney({ ...base, granted: ["sleep"] });
+    expect(comGrant.level).toBeGreaterThan(semGrant.level);
+  });
+
+  // Graduado não derruba ninguém — e concedido é graduado.
+  it("hábito concedido não é reportado como quebrado", () => {
+    const j = deriveJourney({ ...base, granted: ["sleep"] });
+    expect(j.habits.sleep.broken).toBe(false);
+  });
+
+  it("sem concessão, nada muda", () => {
+    const j = deriveJourney({ ...base });
+    expect(j.habits.sleep.granted).toBe(false);
+  });
+});


### PR DESCRIPTION
Fecha #295. Fatia 3b — tela **4a·6** do Turno 4.

## A decisão que o modelo não fechava

O portão **já é avaliado sobre o histórico**: quem tem o hábito bom já é colocado no nível certo automaticamente. Então "pular" só vale se fizer algo a mais.

**Faz: concede graduação, não só o nível.** Graduar normalmente exige a barra alta sustentada; pular concede com a evidência do **portão**, na mesma janela de 28 dias.

Isso **não afrouxa critério pra ninguém** — a exigência é idêntica à do caminho normal. O que encurta é a **espera** de quem chega com o hábito já formado.

`skipQualifies` delega inteiro ao `passesGate` de propósito: se o portão mudar um dia, o critério pra pular muda junto, sem dois lugares pra sincronizar e esquecer.

## O risco desta tela é virar interrogatório

Duas defesas, ambas vindas do design:

**Números concretos, não veredito.** O bloco do meio lista o que o app viu — dias com registro, dispersão do horário, tamanho da amostra — sem dar nota. E mostra `—` quando não há amostra: dizer `± 0 min` com dois registros seria inventar precisão que o dado não tem.

**O caso oposto vem antecipado.** _"Se não batesse, o app começaria no lvl 1 e observaria por duas semanas — sem drama."_ É o que deixa claro que o app não confia cego, mas também não desconfia hostil.

## Testes

235 → 250. A trava que mais importa: **em nenhum dos dois desfechos a copy pode acusar a pessoa** — barrado `mentiu|falso|não acredito|desconfio|prove|comprove`.

Mutação:

| mutação | testes que caem |
| --- | --- |
| conceder sempre (pular vira atalho) | 2 |
| inventar precisão sem amostra | 1 |
| não antecipar o caso oposto | 1 |

## Sem bump de versão

JS puro, OTA no runtime 1.2.0.

## Como validar no BoT Staging

**Ajustes → "Já tenho esse hábito"** → tocar em qualquer métrica.

⚠️ **Com o histórico atual nenhuma métrica vai qualificar.** Você vai ver o **desfecho negativo**, que é justamente o mais difícil de acertar no tom.

**A pergunta que vale responder:** soa como _"o app está observando"_ ou como _"o app não acreditou em mim"_? A segunda leitura seria falha do texto, não do mecanismo.

Pra ver o desfecho positivo seria preciso histórico que passe o portão — não dá com 10 dias de registro. O caminho está coberto por teste com dado sintético.
