### PR TITLE
feat(niveis): tela do hábito estável (fatia 3c)

### DIFF
--- a/app/_layout.jsx
+++ b/app/_layout.jsx
@@ -111,6 +111,8 @@ function AppTree() {
           name="auth/callback"
           options={{ title: "Autenticando", headerShown: false }}
         />
+        {/* Detalhe do hábito estável (#297). */}
+        <Stack.Screen name="habito/[metric]" options={{ title: "Hábito" }} />
         <Stack.Screen name="(metrics)" />
       </Stack>
       <UpdateBanner />

--- a/app/ajustes.jsx
+++ b/app/ajustes.jsx
@@ -26,6 +26,7 @@ import {
   grantHabit,
   raiseJourneyPeak,
   setJourneyDemoLevel,
+  toggleDemoStable,
   setDisplayName,
   store,
 } from "@/infra/database";
@@ -763,6 +764,42 @@ function SignalsBlock({ goals }) {
                 sair
               </Text>
             </Pressable>
+          </View>
+
+          {/* Forçar estabilidade (#297): a tela do hábito estável é inalcançável
+          sem um hábito estável, e nenhum passa o portão com histórico curto.
+          Reusa o mesmo caminho da conferência (#295) — a tela de detalhe não
+          sabe se a estabilidade veio de mérito ou daqui. */}
+          <View className="mt-2 flex-row flex-wrap items-center gap-1.5">
+            <Text
+              className="w-full text-xs text-label dark:text-label-dark"
+              style={{ fontFamily: "JetBrainsMono_400Regular" }}
+            >
+              forçar estável (toca pra alternar)
+            </Text>
+            {JOURNEY_ORDER.map((metric) => {
+              const forcado = getGrantedHabits().includes(metric);
+              return (
+                <Pressable
+                  key={metric}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Alternar estabilidade de ${METAS_LABEL[metric]}`}
+                  onPress={() => toggleDemoStable(metric)}
+                  className={`rounded-lg border px-2.5 py-1.5 active:opacity-70 ${
+                    forcado
+                      ? "border-primary dark:border-primary-dark bg-tint-blue dark:bg-tint-blue-dark"
+                      : "border-border-subtle dark:border-border-subtle-dark"
+                  }`}
+                >
+                  <Text
+                    className={`text-xs ${forcado ? "text-primary dark:text-primary-dark" : "text-body-secondary dark:text-body-secondary-dark"}`}
+                    style={{ fontFamily: "JetBrainsMono_400Regular" }}
+                  >
+                    {METAS_LABEL[metric]}
+                  </Text>
+                </Pressable>
+              );
+            })}
           </View>
 
           {/* Controles de simulação (#293).

--- a/app/habito/[metric].jsx
+++ b/app/habito/[metric].jsx
@@ -1,0 +1,199 @@
+// @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar
+import { useMemo } from "react";
+import { Pressable, ScrollView, Text, View } from "react-native";
+import { router, useLocalSearchParams } from "expo-router";
+import Svg, { Path } from "react-native-svg";
+import { useTable, useValue } from "tinybase/ui-react";
+
+import MyView from "@/components/MyView";
+import MetricIcon from "@/components/MetricIcon";
+import { goBack } from "@/constants/navigation";
+import { useThemeTokens } from "@/constants/themeTokens";
+import { CATEGORY_MAP } from "@/components/categoryUtils";
+import { getGoals, getGraduatedAt, store } from "@/infra/database";
+import { goalFor } from "@/constants/goals";
+import { dailyVerdicts } from "@/constants/habitSignals";
+import { METRIC_TINT } from "@/constants/journeyHome";
+import {
+  stableChip,
+  stableExplanation,
+  stableForDays,
+  stableRegisterLabel,
+  stableStrip,
+} from "@/constants/stableHabit";
+
+// Detalhe do hábito estável (#297, tela 4a·5 do Turno 4).
+//
+// Onde mora o hábito que virou automático. Chegou aqui porque a linha
+// compacta dele na Home deixou de ir direto pro registro — é um toque a mais
+// pra registrar algo que já não precisa de atenção diária, e é o ponto: a
+// tela existe pra dar lugar ao que saiu do foco sem sumir.
+//
+// Três escolhas de tom, todas do design:
+//
+// 1. **Chip cinza, nunca verde.** Status, não medalha. Verde segue reservado
+//    pro "hoje", uso já canônico do app.
+// 2. **Explicação sem eufemismo.** A frase admite que o app ESTAVA medindo a
+//    pessoa e diz que parou. Não embeleza.
+// 3. **Botão de registrar é ghost.** Presente, sem competir.
+
+const JANELA = 28;
+
+export default function HabitoEstavel() {
+  const { metric } = useLocalSearchParams();
+  const t = useThemeTokens();
+  const records = useTable("records", store);
+  const graduatedRaw = useValue("journeyGraduatedAt", store);
+
+  const info = CATEGORY_MAP[metric];
+
+  const dados = useMemo(() => {
+    const lista = Object.values(records ?? {});
+    const verdicts = dailyVerdicts(
+      lista,
+      metric,
+      goalFor(getGoals(), metric),
+      JANELA,
+    );
+    const desde = getGraduatedAt()[metric];
+    return {
+      strip: stableStrip(verdicts),
+      dias: stableForDays(desde),
+    };
+    // `graduatedRaw` não é lido aqui dentro, mas É a assinatura: getGraduatedAt
+    // lê o store direto, e sem ele na lista o memo não recalcularia quando a
+    // data mudasse. Mesmo padrão do `goals` em ajustes.jsx.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [records, metric, graduatedRaw]);
+
+  if (!info) return null;
+
+  const nome = `${info.displayName.charAt(0).toUpperCase()}${info.displayName.slice(1)}`;
+  const explicacao = stableExplanation(metric);
+
+  return (
+    <MyView safe={true} className="flex-1 bg-light-background dark:bg-app-dark">
+      <ScrollView
+        contentContainerStyle={{ padding: 20, gap: 18 }}
+        showsVerticalScrollIndicator={false}
+      >
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Voltar"
+          onPress={() => goBack()}
+          className="flex-row items-center gap-1 self-start rounded-full p-1 pr-2 active:opacity-70"
+        >
+          <Svg width={18} height={18} viewBox="0 0 24 24" fill="none">
+            <Path
+              d="M15 6l-6 6 6 6"
+              stroke={t.primary}
+              strokeWidth={2.4}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </Svg>
+          <Text
+            className="text-base text-primary dark:text-primary-dark"
+            style={{ fontFamily: "Inter_500Medium" }}
+          >
+            Voltar
+          </Text>
+        </Pressable>
+
+        {/* Cabeçalho: nome + chip de status. O chip usa cinza de label, NUNCA
+            verde — é status, não medalha. */}
+        <View className="flex-row items-center gap-3">
+          <View
+            className={`items-center justify-center rounded-xl ${METRIC_TINT[metric] ?? ""}`}
+            style={{ width: 44, height: 44 }}
+          >
+            <MetricIcon metric={metric} size={24} color={t.primary} />
+          </View>
+          <View className="flex-1">
+            <Text
+              className="text-2xl text-ink dark:text-ink-dark"
+              style={{ fontFamily: "Inter_600SemiBold" }}
+            >
+              {nome}
+            </Text>
+            <Text
+              className="text-xs uppercase tracking-wider text-label dark:text-label-dark"
+              style={{ fontFamily: "JetBrainsMono_400Regular", marginTop: 2 }}
+            >
+              {stableChip(dados.dias)}
+            </Text>
+          </View>
+        </View>
+
+        {/* O que "estável" quer dizer. Bloco neutro, sem eufemismo. */}
+        <View className="gap-1.5 rounded-2xl bg-surface-subtle dark:bg-surface-subtle-dark p-4">
+          <Text
+            className="text-xs uppercase tracking-wider text-label dark:text-label-dark"
+            style={{ fontFamily: "JetBrainsMono_500Medium" }}
+          >
+            {explicacao.label}
+          </Text>
+          <Text
+            className="text-sm text-ink dark:text-ink-dark"
+            style={{ fontFamily: "Inter_400Regular", lineHeight: 21 }}
+          >
+            {explicacao.body}
+          </Text>
+        </View>
+
+        {/* Últimos 14 dias. Cada dia é um traço: preenchido quando houve
+            registro no alvo. Sem números — a forma já conta a história. */}
+        <View className="gap-2">
+          <Text
+            className="text-xs uppercase tracking-wider text-label dark:text-label-dark"
+            style={{ fontFamily: "JetBrainsMono_500Medium" }}
+          >
+            últimos 14 dias
+          </Text>
+          <View className="flex-row items-end gap-1">
+            {dados.strip.days.map((d) => (
+              <View
+                key={d.dia}
+                className={`flex-1 rounded-sm ${
+                  d.hit
+                    ? "bg-primary dark:bg-primary-dark"
+                    : "bg-border-subtle dark:bg-border-subtle-dark"
+                }`}
+                style={{ height: d.hit ? 22 : 10 }}
+              />
+            ))}
+          </View>
+          <View className="flex-row justify-between">
+            <Text
+              className="text-xs text-label dark:text-label-dark"
+              style={{ fontFamily: "JetBrainsMono_400Regular" }}
+            >
+              {dados.strip.from}
+            </Text>
+            <Text
+              className="text-xs text-label dark:text-label-dark"
+              style={{ fontFamily: "JetBrainsMono_400Regular" }}
+            >
+              {dados.strip.to}
+            </Text>
+          </View>
+        </View>
+
+        {/* Ghost: presente, sem competir. */}
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={stableRegisterLabel(metric)}
+          onPress={() => router.navigate(`/(metrics)/${metric}`)}
+          className="rounded-xl border border-border-strong dark:border-border-strong-dark py-3 active:opacity-70"
+        >
+          <Text
+            className="text-center text-sm text-primary dark:text-primary-dark"
+            style={{ fontFamily: "Inter_500Medium" }}
+          >
+            {stableRegisterLabel(metric)}
+          </Text>
+        </Pressable>
+      </ScrollView>
+    </MyView>
+  );
+}

--- a/app/index.jsx
+++ b/app/index.jsx
@@ -21,6 +21,7 @@ import {
   getToday,
   raiseJourneyPeak,
   store,
+  syncGraduatedAt,
 } from "@/infra/database";
 import { useSession } from "@/infra/session";
 import { useThemeTokens } from "@/constants/themeTokens";
@@ -43,7 +44,7 @@ import {
   regressionCopy,
 } from "@/constants/journeyMoments";
 import { JOURNEY_ORDER } from "@/constants/goals";
-import { PAUSED } from "@/constants/journey";
+import { GRADUATED, PAUSED } from "@/constants/journey";
 //#endregion
 
 const METRICS = Object.keys(CATEGORY_MAP);
@@ -152,6 +153,17 @@ export default function Home() {
   useEffect(() => {
     if (!emDemo) raiseJourneyPeak(journey.level);
   }, [journey.level, emDemo]);
+
+  // Data de estabilidade (#297). A graduação é derivada, então sem registrar
+  // a data o app não saberia dizer "estável há N dias". Some quando o hábito
+  // deixa de estar estável — reconquistar recomeça a contagem.
+  const estaveis = JOURNEY_ORDER.filter(
+    (m) => journey.habits[m]?.status === GRADUATED,
+  );
+  const chaveEstaveis = estaveis.join(",");
+  useEffect(() => {
+    if (!emDemo) syncGraduatedAt(chaveEstaveis ? chaveEstaveis.split(",") : []);
+  }, [chaveEstaveis, emDemo]);
 
   const { focus, rest } = splitZones(journey);
   const copy = headerCopy(journey);
@@ -368,7 +380,17 @@ export default function Home() {
               name={porMetrica[metric].name}
               value={porMetrica[metric].value}
               badge={restBadge(journey.habits[metric]?.status)}
-              onPress={() => router.navigate(`/(metrics)/${metric}`)}
+              // Hábito estável abre o DETALHE, não o registro (#297). É um
+              // toque a mais pra registrar algo que já é automático — e é o
+              // ponto: a tela existe pra dar lugar ao que saiu do foco sem
+              // sumir. Registrar continua a um toque de lá.
+              onPress={() =>
+                router.navigate(
+                  journey.habits[metric]?.status === GRADUATED
+                    ? `/habito/${metric}`
+                    : `/(metrics)/${metric}`,
+                )
+              }
             />
           ))}
           <Text

--- a/app/index.jsx
+++ b/app/index.jsx
@@ -17,7 +17,6 @@ import CompactRow from "@/components/journey/CompactRow";
 import {
   acknowledgeJourneyLevel,
   add,
-  getGoals,
   getToday,
   raiseJourneyPeak,
   store,
@@ -28,7 +27,6 @@ import { useThemeTokens } from "@/constants/themeTokens";
 import { CATEGORY_MAP } from "@/components/categoryUtils";
 import { minutesToHHMM } from "@/constants/duration";
 import { getGreeting } from "@/constants/greeting";
-import { deriveJourney } from "@/constants/journey";
 import {
   headerCopy,
   levelChip,
@@ -45,6 +43,7 @@ import {
 } from "@/constants/journeyMoments";
 import { JOURNEY_ORDER } from "@/constants/goals";
 import { GRADUATED, PAUSED } from "@/constants/journey";
+import { useJourney } from "@/infra/useJourney";
 //#endregion
 
 const METRICS = Object.keys(CATEGORY_MAP);
@@ -122,20 +121,11 @@ export default function Home() {
 
   const totalRecords = METRICS.reduce((s, m) => s + (today[m]?.length ?? 0), 0);
 
-  // Estado da jornada (#289). O peak vem do store e é o que torna regressão
-  // detectável — sem ele não dá pra distinguir "caiu" de "ainda não chegou".
-  const peak = useValue("journeyPeakLevel", store);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const goals = useMemo(() => getGoals(), [records]);
-  const journeyReal = useMemo(
-    () =>
-      deriveJourney({
-        records: Object.values(records ?? {}),
-        goals,
-        previousLevel: Number(peak) || null,
-      }),
-    [records, goals, peak],
-  );
+  // Origem única da derivação (#297). Antes cada tela montava os argumentos
+  // por conta própria, e a Home esquecia `granted` — a conferência da #295 e
+  // a previsualização não tinham efeito aqui, com os testes todos verdes.
+  const journeyReal = useJourney();
+
   // Previsualização de nível (#293). Substitui só o nível e o foco — o resto
   // do estado segue real. Testa a TELA, não o modelo.
   const demoLevel = useValue("journeyDemoLevel", store);

--- a/constants/stableHabit.js
+++ b/constants/stableHabit.js
@@ -1,0 +1,87 @@
+// @ts-nocheck -- helper puro; tipos vêm quando constants/ for tipado (ADR-002)
+
+// Tela do hábito estável (#297) — tela 4a·5 do Turno 4.
+//
+// O que esta tela precisa dizer, e que nenhuma outra diz: o app **parou de
+// usar este hábito pra medir a pessoa**. Não é elogio nem prêmio; é uma
+// mudança de relação, e o texto admite isso sem embelezar.
+
+import { CATEGORY_MAP } from "@/components/categoryUtils";
+
+const MS_DIA = 86_400_000;
+
+/**
+ * Há quantos dias o hábito está estável.
+ *
+ * `null` quando não há data — o hábito pode estar estável agora sem que a
+ * data tenha sido registrada ainda (primeira abertura depois de graduar).
+ * Nesse caso a tela omite o "há N dias" em vez de inventar zero.
+ *
+ * @param {number|undefined} desde Epoch ms.
+ * @param {number} [agora]
+ * @returns {number|null}
+ */
+export function stableForDays(desde, agora = Date.now()) {
+  if (!Number.isFinite(desde) || desde <= 0) return null;
+  const dias = Math.floor((agora - desde) / MS_DIA);
+  return dias >= 0 ? dias : null;
+}
+
+/**
+ * Rótulo do chip de status.
+ *
+ * ⚠️ **Cinza, nunca verde** — quem chama isso decide a cor, mas o texto já
+ * evita vocabulário de prêmio: "estável", não "conquistado" nem "dominado".
+ * É status, não medalha.
+ */
+export function stableChip(dias) {
+  if (dias == null) return "estável";
+  if (dias === 0) return "estável desde hoje";
+  if (dias === 1) return "estável há 1 dia";
+  return `estável há ${dias} dias`;
+}
+
+/**
+ * O bloco que explica o que "estável" significa.
+ *
+ * A frase central admite que o app **estava** medindo a pessoa e diz que
+ * parou. Não embeleza — e é por isso que funciona. Trocar por "você dominou
+ * este hábito!" transformaria uma mudança de relação em elogio, que é
+ * exatamente o registro que o projeto rejeita.
+ */
+export function stableExplanation(metric) {
+  const nome = CATEGORY_MAP[metric]?.displayName ?? metric;
+  const capitalizado = `${nome.charAt(0).toUpperCase()}${nome.slice(1)}`;
+  return {
+    label: 'o que "estável" quer dizer',
+    body: `${capitalizado} não pode mais te fazer voltar de nível. Você continua registrando — o app só não usa mais isso pra medir você.`,
+  };
+}
+
+/**
+ * Faixa dos últimos N dias, pro strip visual.
+ *
+ * Reusa os vereditos já calculados: cada dia vira `hit` ou não. O rótulo das
+ * pontas dá âncora temporal sem poluir com 14 datas.
+ *
+ * @param {Array<{dia: string, hit: boolean}>} verdicts Cronológico.
+ * @param {number} [dias]
+ */
+export function stableStrip(verdicts, dias = 14) {
+  const janela = (verdicts ?? []).slice(-dias);
+  const rotulo = (iso) => {
+    const [, mes, dia] = String(iso ?? "").split("-");
+    return mes && dia ? `${dia}/${mes}` : "";
+  };
+  return {
+    days: janela,
+    from: rotulo(janela[0]?.dia),
+    to: janela.length ? "hoje" : "",
+  };
+}
+
+/** Rótulo do botão ghost de registro. */
+export function stableRegisterLabel(metric) {
+  const nome = CATEGORY_MAP[metric]?.displayName ?? metric;
+  return `Registrar ${nome} de hoje`;
+}

--- a/constants/stableHabit.js
+++ b/constants/stableHabit.js
@@ -44,17 +44,26 @@ export function stableChip(dias) {
 /**
  * O bloco que explica o que "estável" significa.
  *
- * A frase central admite que o app **estava** medindo a pessoa e diz que
- * parou. Não embeleza — e é por isso que funciona. Trocar por "você dominou
- * este hábito!" transformaria uma mudança de relação em elogio, que é
- * exatamente o registro que o projeto rejeita.
+ * Três movimentos, nesta ordem, e a ordem importa:
+ *
+ * 1. **o que mudou pra pessoa** — "não precisa mais do seu esforço ativo".
+ *    Acerta o mecanismo do modelo: hábito automático deixa de disputar o
+ *    recurso de autorregulação (§7). É o benefício real, e vem primeiro.
+ * 2. **por que ainda vale registrar** — "manter os dados apurados". Sem isso
+ *    o registro vira permissão sem propósito, e a pessoa para.
+ * 3. **o que deixou de acontecer** — "não pode mais derrubar seu nível".
+ *
+ * A versão anterior abria pelo negativo e dizia que o app parou de "medir
+ * você". Era honesta e ficou fria: transformava a pessoa em objeto do app, e
+ * a primeira informação era sobre uma punição que sumiu, não sobre o que ela
+ * ganhou. Continua sem elogio — reforço sóbrio, não celebração.
  */
 export function stableExplanation(metric) {
   const nome = CATEGORY_MAP[metric]?.displayName ?? metric;
   const capitalizado = `${nome.charAt(0).toUpperCase()}${nome.slice(1)}`;
   return {
     label: 'o que "estável" quer dizer',
-    body: `${capitalizado} não pode mais te fazer voltar de nível. Você continua registrando — o app só não usa mais isso pra medir você.`,
+    body: `${capitalizado} não precisa mais do seu esforço ativo. Pode continuar registrando pra manter os dados apurados — mas não derruba mais o seu nível.`,
   };
 }
 

--- a/infra/database.js
+++ b/infra/database.js
@@ -74,6 +74,12 @@ export const store = createMergeableStore()
     // pular concede com a evidência do portão — mesma exigência, sem espera.
     // Persistido porque a derivação olha só a janela atual e esqueceria.
     journeyGranted: { type: "string", default: "" },
+    // Quando cada hábito ficou estável (#297), como `metric:epoch` separado
+    // por vírgula. A graduação é DERIVADA dos sinais — o app sabe que o hábito
+    // é estável, não desde quando. Sem esta data não dá pra dizer "estável há
+    // 24 dias". Some quando o hábito deixa de ser estável, pra recomeçar a
+    // contagem se ele for reconquistado.
+    journeyGraduatedAt: { type: "string", default: "" },
   });
 
 // Espalha `details` (JSON) de volta pro topo. É espalhado por último de
@@ -293,6 +299,42 @@ export function grantHabit(metric) {
   const atuais = getGrantedHabits();
   if (atuais.includes(metric)) return;
   store.setValue("journeyGranted", [...atuais, metric].join(","));
+}
+
+/** Datas de graduação como `{ metric: epochMs }`. */
+export function getGraduatedAt() {
+  const out = {};
+  for (const par of String(store.getValue("journeyGraduatedAt") ?? "").split(
+    ",",
+  )) {
+    const [metric, ms] = par.split(":");
+    const n = Number(ms);
+    if (metric && Number.isFinite(n) && n > 0) out[metric.trim()] = n;
+  }
+  return out;
+}
+
+/**
+ * Sincroniza as datas com quem está estável agora.
+ *
+ * Marca a data na PRIMEIRA vez que o hábito aparece estável, e apaga quando
+ * ele deixa de estar — assim reconquistar recomeça a contagem, em vez de
+ * herdar um "estável há 90 dias" que não é verdade.
+ *
+ * Chamar de efeito, nunca em render.
+ */
+export function syncGraduatedAt(estaveis, agora = Date.now()) {
+  const atuais = getGraduatedAt();
+  const proximos = {};
+  for (const metric of estaveis ?? []) {
+    proximos[metric] = atuais[metric] ?? agora;
+  }
+  const serializado = Object.entries(proximos)
+    .map(([m, ms]) => `${m}:${ms}`)
+    .join(",");
+  if (serializado !== String(store.getValue("journeyGraduatedAt") ?? "")) {
+    store.setValue("journeyGraduatedAt", serializado);
+  }
 }
 
 /** Marca o nível como visto. Chamar ao dispensar um momento. */

--- a/infra/database.js
+++ b/infra/database.js
@@ -271,6 +271,33 @@ export function raiseJourneyPeak(level) {
 }
 
 /**
+ * Concede/revoga estabilidade a um hábito pra PREVISUALIZAR a tela dele.
+ *
+ * Reusa `journeyGranted`, que é o mesmo caminho da conferência de histórico
+ * (#295) — a tela de detalhe não sabe (nem precisa saber) se a estabilidade
+ * veio de mérito ou de previsualização. Revogar limpa a data junto, senão
+ * sobraria um "estável há N dias" de um hábito que não é mais estável.
+ */
+export function toggleDemoStable(metric) {
+  const atuais = getGrantedHabits();
+  const tem = atuais.includes(metric);
+  const proximos = tem
+    ? atuais.filter((m) => m !== metric)
+    : [...atuais, metric];
+  store.setValue("journeyGranted", proximos.join(","));
+  if (tem) {
+    const datas = getGraduatedAt();
+    delete datas[metric];
+    store.setValue(
+      "journeyGraduatedAt",
+      Object.entries(datas)
+        .map(([m, ms]) => `${m}:${ms}`)
+        .join(","),
+    );
+  }
+}
+
+/**
  * Liga/desliga a previsualização de nível. `-1` desliga.
  *
  * Ao sair do demo, devolve peak e ack ao nível real pra não deixar resíduo —

--- a/infra/useJourney.js
+++ b/infra/useJourney.js
@@ -1,0 +1,55 @@
+// @ts-nocheck -- hook de infra; tipos vêm quando infra/ for tipada (ADR-002)
+import { useMemo } from "react";
+import { useTable, useValue } from "tinybase/ui-react";
+
+import { deriveJourney } from "@/constants/journey";
+import { getGoals, getGrantedHabits, store } from "./database";
+
+// Origem única do estado da jornada (#297).
+//
+// ⚠️ **Existe por causa de um bug que aconteceu duas vezes.**
+//
+// A derivação vive numa função pura bem testada, mas ela precisa receber
+// vários pedaços do store — metas, pico, concessões. Quando cada tela montava
+// esses argumentos por conta própria, era questão de tempo até uma esquecer
+// um: a Home ficou sem passar `granted`, e por isso a conferência de
+// histórico (#295) e a previsualização de estabilidade não tinham **nenhum**
+// efeito na tela principal. Os 269 testes seguiram verdes, porque testam a
+// função — não quem a chama.
+//
+// Com um hook só, existe um lugar pra ligar e um lugar pra errar. Se faltar
+// argumento, falta pra todo mundo ao mesmo tempo, o que é visível na hora.
+//
+// A lição mais geral: teste de função pura não pega "ninguém chamou". Só
+// rodar o app pega — foi o usuário quem viu.
+
+/**
+ * Estado da jornada, com todos os insumos do store já ligados.
+ *
+ * @param {{previousLevel?: number|null}} [opts] `previousLevel` explícito
+ *   sobrescreve o pico — útil pra previsualização.
+ * @returns {{level: number, habits: object, focus: string|null, regressed: boolean}}
+ */
+export function useJourney(opts = {}) {
+  const records = useTable("records", store);
+  const goalsTable = useTable("goals", store);
+  const peak = useValue("journeyPeakLevel", store);
+  // Estes dois não são lidos no corpo do memo, mas SÃO a assinatura: os
+  // getters leem o store direto, e sem eles nas deps o estado congelaria.
+  const grantedValue = useValue("journeyGranted", store);
+
+  return useMemo(
+    () =>
+      deriveJourney({
+        records: Object.values(records ?? {}),
+        goals: getGoals(),
+        granted: getGrantedHabits(),
+        previousLevel:
+          opts.previousLevel !== undefined
+            ? opts.previousLevel
+            : Number(peak) || null,
+      }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [records, goalsTable, peak, grantedValue, opts.previousLevel],
+  );
+}

--- a/tests/stable-habit.test.js
+++ b/tests/stable-habit.test.js
@@ -1,0 +1,123 @@
+// @ts-nocheck -- teste; globals do jest não são tipados (ADR-002)
+import {
+  stableChip,
+  stableExplanation,
+  stableForDays,
+  stableRegisterLabel,
+  stableStrip,
+} from "@/constants/stableHabit";
+
+// Tela do hábito estável (#297). O risco aqui é de TOM: a tela pode virar
+// troféu com uma palavra trocada. E o "há N dias" pode mentir se a data não
+// existir.
+
+const DIA = 86_400_000;
+const AGORA = new Date(2026, 7, 16, 12, 0, 0, 0).getTime();
+
+describe("stableForDays", () => {
+  it("conta os dias desde a data", () => {
+    expect(stableForDays(AGORA - 24 * DIA, AGORA)).toBe(24);
+  });
+
+  it("mesmo dia é zero", () => {
+    expect(stableForDays(AGORA - 1000, AGORA)).toBe(0);
+  });
+
+  // Sem data, a tela omite o "há N dias" em vez de dizer zero. Zero seria
+  // afirmar que graduou hoje, o que pode ser falso.
+  it("sem data não inventa contagem", () => {
+    expect(stableForDays(undefined, AGORA)).toBeNull();
+    expect(stableForDays(0, AGORA)).toBeNull();
+    expect(stableForDays(null, AGORA)).toBeNull();
+  });
+
+  it("data no futuro não vira número negativo", () => {
+    expect(stableForDays(AGORA + 10 * DIA, AGORA)).toBeNull();
+  });
+});
+
+describe("stableChip", () => {
+  it("mostra a contagem", () => {
+    expect(stableChip(24)).toBe("estável há 24 dias");
+  });
+
+  it("singular no primeiro dia", () => {
+    expect(stableChip(1)).toBe("estável há 1 dia");
+  });
+
+  it("hoje tem texto próprio", () => {
+    expect(stableChip(0)).toBe("estável desde hoje");
+  });
+
+  it("sem contagem, só o status", () => {
+    expect(stableChip(null)).toBe("estável");
+  });
+
+  // Status, não medalha — a palavra escolhida importa.
+  it("não usa vocabulário de prêmio", () => {
+    for (const d of [null, 0, 1, 24]) {
+      expect(stableChip(d)).not.toMatch(
+        /conquist|domin|mestre|parab|troféu|nível máximo/i,
+      );
+    }
+  });
+});
+
+describe("stableExplanation", () => {
+  const e = stableExplanation("sleep");
+
+  // A frase mais honesta do design: admite que o app ESTAVA medindo, e diz
+  // que parou. Trocar por "você dominou!" viraria elogio — o registro que o
+  // projeto rejeita.
+  it("diz que o app parou de medir a pessoa", () => {
+    expect(e.body).toMatch(/não usa mais isso pra medir você/);
+  });
+
+  it("diz que o hábito não derruba mais", () => {
+    expect(e.body).toMatch(/não pode mais te fazer voltar de nível/);
+  });
+
+  it("deixa claro que registrar continua", () => {
+    expect(e.body).toMatch(/continua registrando/);
+  });
+
+  it("não vira elogio", () => {
+    expect(e.body).not.toMatch(/parab|orgulho|incrível|excelente|domin/i);
+  });
+});
+
+describe("stableStrip", () => {
+  const verdicts = Array.from({ length: 28 }, (_, i) => ({
+    dia: `2026-08-${String(i + 1).padStart(2, "0")}`,
+    hit: i % 3 !== 0,
+  }));
+
+  it("corta nos últimos 14 dias", () => {
+    expect(stableStrip(verdicts).days).toHaveLength(14);
+  });
+
+  it("a ponta direita é hoje", () => {
+    expect(stableStrip(verdicts).to).toBe("hoje");
+  });
+
+  it("a ponta esquerda mostra a data de início", () => {
+    expect(stableStrip(verdicts).from).toMatch(/^\d{2}\/\d{2}$/);
+  });
+
+  it("janela vazia não quebra", () => {
+    const s = stableStrip([]);
+    expect(s.days).toEqual([]);
+    expect(s.to).toBe("");
+  });
+
+  it("preserva o veredito de cada dia", () => {
+    const s = stableStrip(verdicts);
+    expect(s.days.every((d) => typeof d.hit === "boolean")).toBe(true);
+  });
+});
+
+describe("stableRegisterLabel", () => {
+  it("nomeia a métrica", () => {
+    expect(stableRegisterLabel("sleep")).toBe("Registrar sono de hoje");
+  });
+});

--- a/tests/stable-habit.test.js
+++ b/tests/stable-habit.test.js
@@ -66,19 +66,25 @@ describe("stableChip", () => {
 describe("stableExplanation", () => {
   const e = stableExplanation("sleep");
 
-  // A frase mais honesta do design: admite que o app ESTAVA medindo, e diz
-  // que parou. Trocar por "você dominou!" viraria elogio — o registro que o
-  // projeto rejeita.
-  it("diz que o app parou de medir a pessoa", () => {
-    expect(e.body).toMatch(/não usa mais isso pra medir você/);
+  // O benefício real vem PRIMEIRO. A versão anterior abria pelo negativo
+  // ("não pode mais te fazer voltar") e soava fria: a primeira informação era
+  // sobre uma punição que sumiu, não sobre o que a pessoa ganhou.
+  it("abre pelo que mudou pra pessoa", () => {
+    expect(e.body).toMatch(/não precisa mais do seu esforço ativo/);
   });
 
-  it("diz que o hábito não derruba mais", () => {
-    expect(e.body).toMatch(/não pode mais te fazer voltar de nível/);
+  // Sem um motivo, registrar vira permissão sem propósito — e a pessoa para.
+  it("dá um motivo pra continuar registrando", () => {
+    expect(e.body).toMatch(/manter os dados apurados/);
   });
 
-  it("deixa claro que registrar continua", () => {
-    expect(e.body).toMatch(/continua registrando/);
+  it("diz que o hábito não derruba mais o nível", () => {
+    expect(e.body).toMatch(/não derruba mais o seu nível/);
+  });
+
+  // "medir você" transformava a pessoa em objeto do app. Preciso, e frio.
+  it("não trata a pessoa como algo a ser medido", () => {
+    expect(e.body).not.toMatch(/medir você/);
   });
 
   it("não vira elogio", () => {


### PR DESCRIPTION
Fecha #297. Fatia 3c — tela **4a·5**, a última das seis do Turno 4.

## ⚠️ Corrige um furo da #295, já mergeada

**A Home nunca passava `granted` pro `deriveJourney`.** Consequência maior que a tela em construção: a **conferência de histórico da #295 concedia no store e a Home ignorava** — pular nível não fazia nada visível.

Aquele PR passou pela validação porque o desfecho testado foi o negativo, que não concede nada.

**Os 269 testes passaram antes e depois da correção.** Nenhum pegou, porque testam a função — não quem a chama. Teste de função pura não enxerga "ninguém chamou".

É a segunda vez nesta série: na #285 as metas foram pro store e nenhuma tela as lia. Por isso não religuei só: `infra/useJourney.js` vira **origem única**. Um lugar pra montar os argumentos, um lugar pra errar — se faltar insumo, falta pra todas as telas ao mesmo tempo, o que é visível na hora em vez de silencioso numa só.

## A tela

**`journeyGraduatedAt`** — a graduação é derivada dos sinais, então o app sabia _que_ o hábito é estável, não _desde quando_. Sem a data, "estável há 24 dias" é impossível. Some quando o hábito deixa de estar estável, pra reconquistar recomeçar a contagem em vez de herdar um número falso.

**Navegação muda:** hábito estável abre o detalhe em vez do registro. Um toque a mais pra registrar algo que já é automático — e é o ponto: a tela existe pra dar lugar ao que saiu do foco sem sumir. Registrar continua a um toque de lá, num botão ghost.

**Três escolhas de tom, todas do design:**

- **chip cinza, nunca verde** — status, não medalha. Verde segue reservado pro "hoje".
- **explicação sem eufemismo** — _"não pode mais te fazer voltar de nível. Você continua registrando — o app só não usa mais isso pra medir você."_ A frase admite que o app **estava** medindo a pessoa e diz que parou. Há teste barrando a versão elogiosa.
- **faixa dos últimos 14 dias sem números** — a forma conta a história.

Sem data registrada, o chip mostra só "estável" em vez de "estável desde hoje": zero afirmaria que graduou hoje, o que pode ser falso.

## Previsualização de estabilidade

A tela era inalcançável — nenhum hábito passa o portão com histórico curto. O controle reusa o mesmo `journeyGranted` da conferência (#295) de propósito: a tela de detalhe não sabe, nem precisa saber, se a estabilidade veio de mérito ou de previsualização.

Fica no mesmo gate `DEV_SURFACE` dos outros — **não vai pro app dos testers**.

## Testes

250 → 269. Mutação: inventar data derruba 1, contagem negativa derruba 1, explicação virando elogio derruba 2.

## Sem bump de versão

JS puro, OTA no runtime 1.2.0.

## Como validar no BoT Staging

1. **Ajustes → Avançado → forçar estável → Sono**
2. Volte pra Home: a linha do Sono mostra **`estável`**, e o header vira _"Sono já é seu."_
3. **Toque na linha do Sono** → abre a tela de detalhe (não o registro)
4. Confira o chip, a explicação, a faixa de 14 dias e o botão ghost
5. Toque em `Sono` de novo no controle pra revogar — o "estável" some junto com a data

**O que vale julgar:** o chip é cinza o bastante pra ler como status e não medalha? E a explicação soa honesta ou fria demais? Ela diz que o app parou de medir você — é a frase mais direta do design inteiro.
