### PR TITLE
chore(texto): tirar o travessão da copy visível (fatia 1 da #302)

### DIFF
--- a/app/feedback.jsx
+++ b/app/feedback.jsx
@@ -292,7 +292,7 @@ function SuccessState({ result, onSendAnother, onHome }) {
           style={{ fontFamily: "Inter_400Regular", marginTop: 2 }}
         >
           {result?.number
-            ? `Abrimos o chamado #${result.number}. Obrigado por reportar — dá pra acompanhar quando quiser.`
+            ? `Abrimos o chamado #${result.number}. Obrigado por reportar. Dá pra acompanhar quando quiser.`
             : "Obrigado por reportar."}
         </Text>
       </View>

--- a/app/login.jsx
+++ b/app/login.jsx
@@ -95,7 +95,7 @@ export default function Login() {
           <View className="gap-4">
             <SoftMessage
               title="Verifique seu email 📬"
-              body={`Enviamos um link mágico pra ${email}. Toque no link do email pra entrar — o app abre logado sozinho.`}
+              body={`Enviamos um link mágico pra ${email}. Toque no link do email pra entrar, e o app abre logado sozinho.`}
             />
             <SecondaryAction
               label="Não recebi, enviar de novo"

--- a/components/RetomadaState.jsx
+++ b/components/RetomadaState.jsx
@@ -30,8 +30,8 @@ export default function RetomadaState({ daysSinceLast, onDismiss }) {
 
   const title = isFirstTime ? "Bem-vindo." : "Que bom te ver de volta.";
   const subtitle = isFirstTime
-    ? "Sem pressa. O primeiro registro pode ser qualquer coisa — comece pelo mais fácil."
-    : `Faz ${daysSinceLast} ${daysSinceLast === 1 ? "dia" : "dias"} que nada foi registrado. Sem cobrança — o que importa é o próximo registro.`;
+    ? "Sem pressa. O primeiro registro pode ser qualquer coisa. Comece pelo mais fácil."
+    : `Faz ${daysSinceLast} ${daysSinceLast === 1 ? "dia" : "dias"} que nada foi registrado. Sem cobrança. O que importa é o próximo registro.`;
 
   return (
     <View className="flex-1 gap-6 p-6">

--- a/components/UpdateBanner.jsx
+++ b/components/UpdateBanner.jsx
@@ -159,7 +159,7 @@ export default function UpdateBanner() {
         color={t.accentToday}
         bottomPad={bottomPad}
         onPress={() => reloadAsync()}
-        accessibilityLabel="Atualização pronta — toque para reiniciar"
+        accessibilityLabel="Atualização pronta. Toque para reiniciar"
       >
         <Text
           className="text-center text-white"

--- a/components/metrics/SleepBespoke.jsx
+++ b/components/metrics/SleepBespoke.jsx
@@ -462,7 +462,7 @@ function TimeRow({ label, value, onChange, dayLabel, placeholder }) {
           value={value}
           onChangeText={onChange}
           placeholder={placeholder}
-          accessibilityLabel={`Horário — ${label}`}
+          accessibilityLabel={`Horário: ${label}`}
           style={{
             fontFamily: "JetBrainsMono_500Medium",
             fontSize: 24,

--- a/constants/journeyMoments.js
+++ b/constants/journeyMoments.js
@@ -76,7 +76,7 @@ export function levelUpCopy({ from, to, achieved, next }) {
     nextName: proximo ? capitalizar(proximo) : null,
     nextHint: proximo ? (CATEGORY_MAP[next]?.subtitle ?? null) : null,
     // O ponto mais importante da tela: a queda já vem anunciada, e sem peso.
-    reassurance: `${conquistado} continua na tela. Se ficar instável por uns dias, o foco volta pra ele — sem drama.`,
+    reassurance: `${conquistado} continua na tela. Se ficar instável por uns dias, o foco volta pra ele, sem drama.`,
     dismiss: "Depois",
     confirm: proximo ? `Começar com ${proximo}` : "Continuar",
   };
@@ -106,7 +106,7 @@ export function regressionCopy({ focus, paused }) {
 
   return {
     title: `voltamos pra ${foco}`,
-    body: `${quem} ${verbo} uns dias em branco. O foco volta pra ${foco} por um tempo — quando ela estiver de novo estável, o resto retoma.`,
+    body: `${quem} ${verbo} uns dias em branco. O foco volta pra ${foco} por um tempo. Quando ela estiver de novo estável, o resto retoma.`,
     // Dito em voz alta porque é a dúvida que a regressão levanta.
     preserved:
       "Nada do que você já registrou foi perdido. Você continua podendo registrar tudo.",

--- a/constants/journeySkip.js
+++ b/constants/journeySkip.js
@@ -81,16 +81,16 @@ export function skipCopy({ metric, qualifies, nextLevel }) {
 
   return {
     claimLabel: "você disse",
-    claim: `"Já cuido de ${nome} — quero pular."`,
+    claim: `"Já cuido de ${nome}, quero pular."`,
     evidenceLabel: "o que o histórico mostra",
 
     verdict: qualifies
-      ? `Bate com o que você disse. Você começa direto no lvl ${nextLevel} — ${nome} já entra estável.`
+      ? `Bate com o que você disse. Você começa direto no lvl ${nextLevel}, e ${nome} já entra estável.`
       : `O histórico ainda não mostra isso. Começamos no lvl 1 e ${nome} entra estável quando os dados acompanharem.`,
 
     // Antecipar o desfecho oposto tira o peso de julgamento dos dois lados.
     alternate: qualifies
-      ? "Se não batesse, o app começaria no lvl 1 e observaria por duas semanas antes de considerar estável — sem drama."
+      ? "Se não batesse, o app começaria no lvl 1 e observaria por duas semanas antes de considerar estável, sem drama."
       : "Nada foi descartado: seus registros continuam contando, e a conferência refaz sozinha conforme o histórico cresce.",
 
     dismiss: "Refazer",

--- a/constants/stableHabit.js
+++ b/constants/stableHabit.js
@@ -63,7 +63,7 @@ export function stableExplanation(metric) {
   const capitalizado = `${nome.charAt(0).toUpperCase()}${nome.slice(1)}`;
   return {
     label: 'o que "estável" quer dizer',
-    body: `${capitalizado} não precisa mais do seu esforço ativo. Pode continuar registrando pra manter os dados apurados — mas não derruba mais o seu nível.`,
+    body: `${capitalizado} não precisa mais do seu esforço ativo. Pode continuar registrando pra manter os dados apurados, mas não derruba mais o seu nível.`,
   };
 }
 


### PR DESCRIPTION
Closes #304. Primeira fatia da #302.

Só o texto que o tester lê: 12 literais de string em 8 arquivos. Zero mudança de comportamento, zero mudança de layout.

## A troca foi por leitura

Um `sed` global resolveria em um comando e estragaria o texto. Cada caso pediu uma coisa diferente:

**Ponto final**, onde as duas orações já se sustentam sozinhas:

> Sem cobrança. O que importa é o próximo registro.

**Vírgula**, onde a segunda oração começa com interpolação que vem minúscula do `CATEGORY_MAP`. Um ponto final ali produziria "sono já entra estável" com inicial minúscula:

> Você começa direto no lvl 2, e sono já entra estável.

**Dois-pontos** nos dois `accessibilityLabel`, que é o separador convencional de rótulo e valor pra leitor de tela:

> `Horário: deitou`

## O que ficou de fora, de propósito

Os **9 glifos `"—"`** de valor vazio continuam intactos (`formatGoal` sem alvo, `CompactRow`, `ajustes`, `journeySkip`). Eles marcam ausência de dado, e o `tests/journey-skip.test.js:42` afirma em cima de um deles.

**Comentário de código** fica pra fatia 3, inclusive os dois casos de antítese que a varredura achou (`constants/journey.js:197` e `components/RetomadaState.jsx:99`). A varredura por "não é X, é Y" em literal de string não achou nada, então a fatia 1 não tem antítese pra tratar.

## Verificação

- `grep` por ` — ` em literal de string dentro de `app/`, `components/` e `constants/`: **zero**
- 270 testes verdes. Os trechos que eles casam ("sem drama", "continua na tela", "não precisa mais do seu esforço ativo") foram preservados de propósito

## Como validar

As telas afetadas, na ordem de facilidade de alcançar:

1. **Retomada**: as duas variantes (primeiro registro, e "faz N dias")
2. **Pular nível** e os **momentos** de subida e regressão, pelos controles de previsualização do staging
3. **Hábito estável**, pela linha compacta na Home
4. **Login** e **feedback**, se sobrar fôlego

O que procurar: frase que ficou truncada, dois pontos finais seguidos, ou vírgula que mudou o sentido.