### PR TITLE
chore(texto): tirar o travessão dos 11 docs restantes (fatia 2b da #302)

### DIFF
--- a/docs/01-project-charter.md
+++ b/docs/01-project-charter.md
@@ -15,13 +15,13 @@ Nenhum dos dois pode ser sacrificado pelo outro: atalhos técnicos que compromet
 
 ## Justificativa
 
-Alguns meses de registro analógico de métricas de saúde e autodesenvolvimento trouxeram resultados sólidos, mas o processo se tornou caro em tempo à medida que a rotina de registro se consolidou. O projeto existe para resolver esse custo de tempo — sem perder o que fazia o método em papel funcionar.
+Alguns meses de registro analógico de métricas de saúde e autodesenvolvimento trouxeram resultados sólidos, mas o processo se tornou caro em tempo à medida que a rotina de registro se consolidou. O projeto existe para resolver esse custo de tempo, sem perder o que fazia o método em papel funcionar.
 
 ## O nome
 
-"Back on Track" — voltar aos trilhos. Essas métricas representam o mínimo necessário para estar em plena capacidade física e mental. O projeto não busca otimização extrema; busca manter o básico consistentemente em dia.
+"Back on Track" quer dizer voltar aos trilhos. Essas métricas representam o mínimo necessário para estar em plena capacidade física e mental. O projeto não busca otimização extrema; busca manter o básico consistentemente em dia.
 
-> A visão completa contempla seis métricas (incluindo autocuidado). O MVP entrega as cinco que já existem no app — água, sono, alimentação, atividade física e estudo — e autocuidado fica como expansão planejada (ver Escopo & MVP). A meta de longo prazo segue sendo as seis.
+> A visão completa contempla seis métricas (incluindo autocuidado). O MVP entrega as cinco que já existem no app (água, sono, alimentação, atividade física e estudo), e autocuidado fica como expansão planejada (ver Escopo & MVP). A meta de longo prazo segue sendo as seis.
 
 ## Público
 
@@ -39,4 +39,4 @@ Uso pessoal. Isso simplifica várias decisões (sem multi-usuário, sem necessid
 - O app substitui completamente o papel na rotina diária.
 - Registrar uma métrica leva poucos segundos, sem fricção.
 - Os dados sobrevivem a perda ou troca de aparelho.
-- Ao final, o conhecimento de React Native adquirido é transferível para outros projetos — não é conhecimento de "copiar tutorial".
+- Ao final, o conhecimento de React Native adquirido é transferível para outros projetos, acima do nível de "copiar tutorial".

--- a/docs/02-escopo-mvp.md
+++ b/docs/02-escopo-mvp.md
@@ -18,7 +18,7 @@ O MVP cobre **5 métricas**, que são as que já existem como tela no código at
 
 Como as 6 métricas compartilham estrutura, o sistema é modelado em torno de uma única entidade genérica - o **Registro** - em vez de 6 entidades separadas e desconectadas. Campos específicos de cada métrica fica isolada num campo de detalhes, mantendo o núcleo do modelo uniforme.
 
-> **Modelo-alvo (M2), não o schema atual.** A `interface Registro` abaixo é o **modelo maduro** que o projeto pretende alcançar no M2 — a forma final de seus campos ainda será decidida nesse marco, informada pelo uso real. Ela **não** descreve o schema em uso hoje. O schema atual é o **frouxo do ADR-008** (`type` / `date` / `details` / `createdAt`), no qual os campos específicos de cada métrica ficam serializados como JSON dentro de `details`.
+> **Modelo-alvo (M2), não o schema atual.** A `interface Registro` abaixo é o **modelo maduro** que o projeto pretende alcançar no M2. A forma final de seus campos ainda será decidida nesse marco, informada pelo uso real. Ela **não** descreve o schema em uso hoje. O schema atual é o **frouxo do ADR-008** (`type` / `date` / `details` / `createdAt`), no qual os campos específicos de cada métrica ficam serializados como JSON dentro de `details`.
 
 ```typescript
 interface Registro {
@@ -26,7 +26,7 @@ interface Registro {
   // "autocuidado" fica reservado para a expansão pós-MVP.
   tipo: "agua" | "sono" | "alimentacao" | "atividade_fisica" | "estudo";
   data: string; // dia do registro, formato ISO (YYYY-MM-DD)
-  quantidade: number; // valor principal — significado depende do tipo
+  quantidade: number; // valor principal; significado depende do tipo
   unidade: string; // "ml", "min", "sessao", etc.
   nota?: string; // observação livre, opcional
   detalhes?: Record<string, unknown>; // campos extras específicos do tipo

--- a/docs/03-decisoes-tecnicas.md
+++ b/docs/03-decisoes-tecnicas.md
@@ -6,59 +6,59 @@ Cada entrada documenta uma decisão de arquitetura: o contexto, a decisão tomad
 
 ---
 
-## ADR-001 — Framework: Expo
+## ADR-001: Framework: Expo
 
 **Contexto:** React Native é novo pra você; o objetivo inclui aprender de forma sólida, sem se perder em configuração nativa antes de aprender o essencial.
 
 **Decisão:** Expo (managed workflow com development builds), criado via `npx create-expo-app@latest`.
 
-**Alternativas consideradas:** React Native CLI puro (bare) — descartado por exigir configuração nativa (Xcode/Android Studio) desde o dia 1, aumentando a curva de aprendizado sem benefício proporcional pra este projeto.
+**Alternativas consideradas:** React Native CLI puro (bare), descartado por exigir configuração nativa (Xcode/Android Studio) desde o dia 1, aumentando a curva de aprendizado sem benefício proporcional pra este projeto.
 
 **Consequências:** builds em nuvem via EAS (sem depender de Xcode local), acesso a um SDK curado de módulos nativos, possibilidade de "ejetar" partes específicas no futuro se necessário. SDK atual: 57.
 
 ---
 
-## ADR-002 — Linguagem: JavaScript, com tipagem incremental opcional
+## ADR-002: Linguagem: JavaScript, com tipagem incremental opcional
 
-**Status:** revisado. A versão original desta entrada recomendava TypeScript pleno desde o commit inicial — decisão feita antes de eu saber que o código existente já está em JavaScript e funcionando. Reescrever um app que já anda só pra trocar a linguagem é custo sem retorno proporcional.
+**Status:** revisado. A versão original desta entrada recomendava TypeScript pleno desde o commit inicial, decisão feita antes de eu saber que o código existente já está em JavaScript e funcionando. Reescrever um app que já anda só pra trocar a linguagem é custo sem retorno proporcional.
 
 **Contexto:** você já sabe programar; tipagem estática ajudaria na parte que é nova (RN), mas o projeto já existe em JS.
 
-**Decisão:** manter JavaScript no código existente. Para ganhar checagem de tipos sem migrar arquivo por arquivo, usar o modo `checkJs` do TypeScript (`jsconfig.json`/`tsconfig.json` com `allowJs` + `checkJs`), documentando tipos via comentários JSDoc onde fizer sentido — sem renomear nenhum `.js` para `.tsx`.
+**Decisão:** manter JavaScript no código existente. Para ganhar checagem de tipos sem migrar arquivo por arquivo, usar o modo `checkJs` do TypeScript (`jsconfig.json`/`tsconfig.json` com `allowJs` + `checkJs`), documentando tipos via comentários JSDoc onde fizer sentido, sem renomear nenhum `.js` para `.tsx`.
 
-**Alternativas consideradas:** migração completa para TypeScript (recomendação original) — mantida como opção futura, não bloqueante. Arquivos novos podem nascer em `.ts`/`.tsx` se for mais natural no momento, sem forçar a base existente.
+**Alternativas consideradas:** migração completa para TypeScript (recomendação original), mantida como opção futura, não bloqueante. Arquivos novos podem nascer em `.ts`/`.tsx` se for mais natural no momento, sem forçar a base existente.
 
-**Implementação (#48):** `allowJs` (já vinha da base do Expo) + `checkJs` ligados no `tsconfig.json`. Para não migrar à força, os arquivos legados que ainda não passam no `checkJs` foram marcados com `// @ts-nocheck` (grandfather) — a checagem some só naquele arquivo, e o marcador deve ser removido quando o arquivo for tipado. Arquivos **novos** nascem checados e são barrados no CI (job `Types` em `linting.yaml`, via `npm run lint:types:check`) se tiverem erro de tipo.
+**Implementação (#48):** `allowJs` (já vinha da base do Expo) + `checkJs` ligados no `tsconfig.json`. Para não migrar à força, os arquivos legados que ainda não passam no `checkJs` foram marcados com `// @ts-nocheck` (grandfather): a checagem some só naquele arquivo, e o marcador deve ser removido quando o arquivo for tipado. Arquivos **novos** nascem checados e são barrados no CI (job `Types` em `linting.yaml`, via `npm run lint:types:check`) se tiverem erro de tipo.
 
 ---
 
-## ADR-003 — Navegação: Expo Router
+## ADR-003: Navegação: Expo Router
 
 **Contexto:** navegação é uma das primeiras decisões estruturais de qualquer app RN.
 
 **Decisão:** Expo Router (roteamento por arquivos, construído sobre o React Navigation).
 
-**Alternativas consideradas:** React Navigation configurado manualmente — descartado como ponto de partida porque hoje é o padrão para projetos novos no ecossistema Expo, já vem incluído no template, e reduz boilerplate justamente na parte que é nova pra você (estrutura de navegação).
+**Alternativas consideradas:** React Navigation configurado manualmente, descartado como ponto de partida porque hoje é o padrão para projetos novos no ecossistema Expo, já vem incluído no template, e reduz boilerplate justamente na parte que é nova pra você (estrutura de navegação).
 
-**Consequências:** a estrutura de pastas (`app/`) passa a _ser_ a estrutura de navegação. Deep linking automático. Continua sendo React Navigation por baixo — os conceitos aprendidos são transferíveis caso precise de controle manual no futuro.
+**Consequências:** a estrutura de pastas (`app/`) passa a _ser_ a estrutura de navegação. Deep linking automático. Continua sendo React Navigation por baixo, e os conceitos aprendidos são transferíveis caso precise de controle manual no futuro.
 
 ---
 
-## ADR-004 — Armazenamento local + sincronização: TinyBase
+## ADR-004: Armazenamento local + sincronização: TinyBase
 
-**Status:** revisado. A versão original desta entrada recomendava Firebase/Firestore — decisão feita antes de eu saber que o projeto já usava TinyBase em produção. Pesquisado de novo com esse contexto: TinyBase não é uma pendência a corrigir, é uma escolha tecnicamente boa pra esse caso.
+**Status:** revisado. A versão original desta entrada recomendava Firebase/Firestore, decisão feita antes de eu saber que o projeto já usava TinyBase em produção. Pesquisado de novo com esse contexto: TinyBase é uma escolha tecnicamente boa pra esse caso, e não uma pendência a corrigir.
 
-**Contexto:** o projeto já existente usa TinyBase como camada de dados, com resultados bons o suficiente pra manter o app "andando". A pergunta não é "qual escolher do zero", é "faz sentido manter" — e faz.
+**Contexto:** o projeto já existente usa TinyBase como camada de dados, com resultados bons o suficiente pra manter o app "andando". A pergunta certa é "faz sentido manter", em vez de "qual escolher do zero". E faz.
 
-**Decisão:** manter TinyBase como store local reativo, com sincronização via os Synchronizers nativos da própria lib (CRDT nativo — `MergeableStore` — sem depender de Yjs/Automerge externos). O transporte específico de sync (WebSocket próprio, PowerSync, Electric, etc.) fica em aberto até a milestone de sincronização.
+**Decisão:** manter TinyBase como store local reativo, com sincronização via os Synchronizers nativos da própria lib (CRDT nativo via `MergeableStore`, sem depender de Yjs/Automerge externos). O transporte específico de sync (WebSocket próprio, PowerSync, Electric, etc.) fica em aberto até a milestone de sincronização.
 
 **Por que não trocar por Firebase:**
 
-- TinyBase já resolve reatividade + persistência local + sync numa lib de ~6–13kB, sem dependências, com suporte first-class a Expo/React Native — a própria Expo publicou um guia oficial de como sincronizar apps local-first com TinyBase.
-- O CRDT nativo resolve merge determinístico entre dispositivos sem depender de um backend proprietário — diferente do Firestore, não amarra o projeto a um serviço fechado da Google.
+- TinyBase já resolve reatividade + persistência local + sync numa lib de ~6–13kB, sem dependências, com suporte first-class a Expo/React Native, e a própria Expo publicou um guia oficial de como sincronizar apps local-first com TinyBase.
+- O CRDT nativo resolve merge determinístico entre dispositivos sem depender de um backend proprietário. Diferente do Firestore, não amarra o projeto a um serviço fechado da Google.
 - Já está integrado e funcionando no código existente; trocar geraria retrabalho sem ganho técnico proporcional.
 
-**Alternativas descartadas:** Firebase/Firestore (recomendação original desta entrada) — perderia o trabalho já feito sem resolver nenhum problema real que o TinyBase tenha.
+**Alternativas descartadas:** Firebase/Firestore (recomendação original desta entrada), que perderia o trabalho já feito sem resolver nenhum problema real que o TinyBase tenha.
 
 **Consequências:**
 
@@ -68,28 +68,28 @@ Cada entrada documenta uma decisão de arquitetura: o contexto, a decisão tomad
 
 ---
 
-## ADR-005 — Gerenciamento de estado: Zustand
+## ADR-005: Gerenciamento de estado: Zustand
 
-**Contexto:** o app tem pouco estado verdadeiramente "global" — a maior parte dos dados vem diretamente da store do TinyBase.
+**Contexto:** o app tem pouco estado verdadeiramente "global", porque a maior parte dos dados vem diretamente da store do TinyBase.
 
 **Decisão:** Zustand para estado de UI (ex: data selecionada, filtros, estado de onboarding). Os dados de domínio (registros) são consumidos diretamente via os hooks reativos do TinyBase (`ui-react`), sem duplicar em uma store separada.
 
-**Alternativas consideradas:** Redux Toolkit — descartado por trazer mais estrutura/boilerplate do que o projeto precisa nesta escala. Context API puro — descartado por re-renderizar componentes de forma menos granular que o Zustand.
+**Alternativas consideradas:** Redux Toolkit, descartado por trazer mais estrutura/boilerplate do que o projeto precisa nesta escala. Context API puro, descartado por re-renderizar componentes de forma menos granular que o Zustand.
 
 ---
 
-## ADR-006 — Estilização visual: NativeWind como sistema único
+## ADR-006: Estilização visual: NativeWind como sistema único
 
-**Status:** decidido. A versão original desta entrada deixava a decisão em aberto para M2/M4 — mas a revisão do código existente revelou que o estilo já é uma fonte ativa de bugs no Android (a plataforma prioritária), então a decisão subiu de prioridade.
+**Status:** decidido. A versão original desta entrada deixava a decisão em aberto para M2/M4, mas a revisão do código existente revelou que o estilo já é uma fonte ativa de bugs no Android (a plataforma prioritária), então a decisão subiu de prioridade.
 
-**Contexto:** o código atual mistura três coisas na mesma tela — `StyleSheet`/`useThemedStyles`, `className` (NativeWind) e valores de CSS web que **não são nativos do React Native** (`fontSize: "1.6rem"`, `boxShadow`, `width: "fit"`, `borderRadius: "100%"`). Esses valores renderizam no preview do navegador mas são ignorados ou quebram no Android — a causa mais provável de o app parecer "mais visual do que funcional". Além disso, as cores estavam duplicadas entre `constants/Colors.js` e `tailwind.config.js`, e a `shadow` central era uma string de `box-shadow` de CSS web propagada para todo o app.
+**Contexto:** o código atual mistura três coisas na mesma tela: `StyleSheet`/`useThemedStyles`, `className` (NativeWind) e valores de CSS web que **não são nativos do React Native** (`fontSize: "1.6rem"`, `boxShadow`, `width: "fit"`, `borderRadius: "100%"`). Esses valores renderizam no preview do navegador mas são ignorados ou quebram no Android, a causa mais provável de o app parecer "mais visual do que funcional". Além disso, as cores estavam duplicadas entre `constants/Colors.js` e `tailwind.config.js`, e a `shadow` central era uma string de `box-shadow` de CSS web propagada para todo o app.
 
 **Decisão:** adotar **NativeWind** como sistema de estilo único, eliminando o `StyleSheet` das telas. Consolidar as cores numa fonte única (`constants/Colors.js`), com o `tailwind.config.js` importando dela em vez de repetir os valores. Corrigir a `shadow` para um objeto RN nativo (`elevation` no Android). Migração feita componente a componente, validando no Android antes/depois (ver guia de migração de estilo).
 
 **Alternativas consideradas:**
 
-- **StyleSheet puro** (trocar todo `rem` por número, remover NativeWind) — válido e mais "purista", mas descartaria o `tailwind.config.js` com temas já configurado e não aproveitaria o dark mode nativo do NativeWind (`dark:`).
-- **Expo UI (componentes nativos)** — cedo demais; abstração maior do que o projeto precisa nesta fase.
+- **StyleSheet puro** (trocar todo `rem` por número, remover NativeWind), válido e mais "purista", mas descartaria o `tailwind.config.js` com temas já configurado e não aproveitaria o dark mode nativo do NativeWind (`dark:`).
+- **Expo UI (componentes nativos)**: cedo demais; abstração maior do que o projeto precisa nesta fase.
 
 **Consequências:**
 
@@ -99,103 +99,103 @@ Cada entrada documenta uma decisão de arquitetura: o contexto, a decisão tomad
 
 ---
 
-## ADR-007 — Modelagem da store TinyBase: uma tabela, não seis
+## ADR-007: Modelagem da store TinyBase (uma tabela, não seis)
 
-**Contexto:** o código de armazenamento existente já era genérico por `tableName` (uma função `add`/`get` reaproveitada entre métricas), mas nada garantia que cada tabela manteria o mesmo formato de dados ao longo do tempo — exatamente o tipo de fragmentação silenciosa que costuma virar a "arquitetura que não escala" dos reboots anteriores.
+**Contexto:** o código de armazenamento existente já era genérico por `tableName` (uma função `add`/`get` reaproveitada entre métricas), mas nada garantia que cada tabela manteria o mesmo formato de dados ao longo do tempo, exatamente o tipo de fragmentação silenciosa que costuma virar a "arquitetura que não escala" dos reboots anteriores.
 
-**Decisão:** uma única tabela `records`, com o campo `type` distinguindo as métricas (5 no MVP), e um `TablesSchema` do TinyBase (`setTablesSchema`) que obriga todo registro — de qualquer métrica — a manter o formato-base definido no documento de Escopo & MVP.
+**Decisão:** uma única tabela `records`, com o campo `type` distinguindo as métricas (5 no MVP), e um `TablesSchema` do TinyBase (`setTablesSchema`) que obriga todo registro, de qualquer métrica, a manter o formato-base definido no documento de Escopo & MVP.
 
 **Consequências:**
 
 - A query da tela "hoje" (tudo que foi registrado hoje, não importa a métrica) vira uma leitura só, não cinco.
-- O schema barra, em tempo de execução, qualquer registro que fuja do formato combinado — a fragmentação fica estruturalmente mais difícil de acontecer de novo.
+- O schema barra, em tempo de execução, qualquer registro que fuja do formato combinado, e a fragmentação fica estruturalmente mais difícil de acontecer de novo.
 - Campos específicos de cada métrica (ex: horário de dormir do sono) continuam possíveis via o campo `details`, sem abrir mão do formato comum.
-- Adicionar a 6ª métrica (autocuidado) no futuro é só um novo valor de `type` — sem tabela nova, sem migração de schema.
+- Adicionar a 6ª métrica (autocuidado) no futuro é só um novo valor de `type`, sem tabela nova e sem migração de schema.
 
 ---
 
-## ADR-008 — Schema frouxo com `details` JSON durante o desenvolvimento
+## ADR-008: Schema frouxo com `details` JSON durante o desenvolvimento
 
-**Status:** decidido, e explicitamente temporário. Refina o ADR-007 (tabela única) para a fase de desenvolvimento — não o contradiz.
+**Status:** decidido, e explicitamente temporário. Refina o ADR-007 (tabela única) para a fase de desenvolvimento, sem contradizê-lo.
 
-**Contexto:** o ADR-007 definiu uma tabela única `records` com um formato-base. Mas os dados reais de hoje são heterogêneos entre métricas: água tem `min`/`max`/`ideal`/`quantity`, exercício tem `training`/`cardio`/`trainingTime`/`duration`, estudo tem `duration`, todas têm `score`/`observation`. Definir agora um schema rígido que contemple todos esses campos exigiria decidir a forma final do dado **antes** de ter uso real que informe o que é necessário e o que sobra. Isso é decisão prematura — o tipo de over-engineering que trava o desenvolvimento sem retorno.
+**Contexto:** o ADR-007 definiu uma tabela única `records` com um formato-base. Mas os dados reais de hoje são heterogêneos entre métricas: água tem `min`/`max`/`ideal`/`quantity`, exercício tem `training`/`cardio`/`trainingTime`/`duration`, estudo tem `duration`, todas têm `score`/`observation`. Definir agora um schema rígido que contemple todos esses campos exigiria decidir a forma final do dado **antes** de ter uso real que informe o que é necessário e o que sobra. Isso é decisão prematura, o tipo de over-engineering que trava o desenvolvimento sem retorno.
 
 **Decisão:** durante o desenvolvimento (até o M2 fechar com uso real), usar um schema deliberadamente **frouxo**: apenas os campos comuns a todas as métricas ficam no nível superior do registro; tudo que é específico de cada métrica vai serializado como JSON num único campo `details`.
 
 Campos de topo (estáveis, comuns a todas as métricas):
 
-- `type` — "water", "sleep", "exercise", "feeding", "study"
-- `date` — data do registro (ISO)
-- `createdAt` — timestamp
+- `type`: "water", "sleep", "exercise", "feeding", "study"
+- `date`: data do registro (ISO)
+- `createdAt`: timestamp
 
 Campo flexível:
 
-- `details` — string JSON com todo o resto (`score`, `observation`, e os campos próprios de cada métrica). O schema não conhece nem valida o conteúdo de `details`.
+- `details`: string JSON com todo o resto (`score`, `observation`, e os campos próprios de cada métrica). O schema não conhece nem valida o conteúdo de `details`.
 
 **Por que assim, agora:**
 
-- Não perde nenhum dado atual — todos os campos existentes cabem em `details` sem conversão.
+- Não perde nenhum dado atual: todos os campos existentes cabem em `details` sem conversão.
 - Não obriga a decidir a forma final do dado antes do uso real.
 - Destrava a persistência (#47) imediatamente: dá pra persistir hoje, com os dados como estão.
 - É reversível: quando o schema maduro chegar (M2+), lê-se o `details` JSON dos registros antigos e transforma-se no formato novo, uma vez só.
 
-**Trade-off aceito:** com `details` como JSON string, perde-se validação de tipo por campo e queries diretas por campo interno (ex: "registros com `score > 3`" fica mais trabalhoso). Na fase de desenvolvimento isso não é necessário — query por campo interno é otimização de quando houver uso e volume. Troca-se validação futura por flexibilidade agora, conscientemente.
+**Trade-off aceito:** com `details` como JSON string, perde-se validação de tipo por campo e queries diretas por campo interno (ex: "registros com `score > 3`" fica mais trabalhoso). Na fase de desenvolvimento isso não é necessário: query por campo interno é otimização de quando houver uso e volume. Troca-se validação futura por flexibilidade agora, conscientemente.
 
-**Quando revisitar:** ao entrar no M2 (modelo unificado maduro), com base no que o uso real mostrar ser necessário/desnecessário. Este ADR existe justamente para que essa decisão temporária não seja confundida com descuido no futuro — o `details` como JSON solto é deliberado, não acidental.
+**Quando revisitar:** ao entrar no M2 (modelo unificado maduro), com base no que o uso real mostrar ser necessário/desnecessário. Este ADR existe justamente para que essa decisão temporária não seja confundida com descuido no futuro: o `details` como JSON solto é deliberado, e não acidental.
 
 ---
 
-## ADR-009 — Transporte de sincronização: WebSocket próprio no homeserver
+## ADR-009: Transporte de sincronização: WebSocket próprio no homeserver
 
 **Status:** decidido. Fecha o ponto que o ADR-004 deixou explicitamente em aberto ("transporte específico de sync fica em aberto até a milestone de sincronização"). Escrito na fatia 1 do M6 (#192).
 
-**Contexto:** o M6 quer que os dados sobrevivam a perda/troca de aparelho. A camada de dados (TinyBase) já suporta sync via `MergeableStore` (CRDT nativo) — o que falta é escolher o **transporte** (o que carrega bytes entre client e server) e onde ele mora. Contexto do projeto que pesa:
+**Contexto:** o M6 quer que os dados sobrevivam a perda/troca de aparelho. A camada de dados (TinyBase) já suporta sync via `MergeableStore` (CRDT nativo), e o que falta é escolher o **transporte** (o que carrega bytes entre client e server) e onde ele mora. Contexto do projeto que pesa:
 
-- **Escala pequena**: single-user hoje, 5-6 testers, longo prazo dezenas — não milhares.
-- **Homeserver com Docker rodando** e ops estabelecidas (`docker-ce 29.6.1`, Evolution API já em produção lá — [[docker-snap-apparmor-broken]], [[evolution-api-testers-stack]]).
+- **Escala pequena**: single-user hoje, 5-6 testers, longo prazo dezenas: não milhares.
+- **Homeserver com Docker rodando** e ops estabelecidas (`docker-ce 29.6.1`, Evolution API já em produção lá, ver [[docker-snap-apparmor-broken]], [[evolution-api-testers-stack]]).
 - **Objetivo:** minimizar ops de longo prazo. O app é pra durar anos.
-- **Sync eventual (minutos) é aceitável** — realtime não é requisito.
+- **Sync eventual (minutos) é aceitável**: realtime não é requisito.
 - **Modelo de dados** (ADR-007/008): uma tabela `records` + `details` JSON, pouca superfície pra conflito de merge.
 
-**Decisão:** WebSocket próprio no homeserver via `createWsSynchronizer` (client) + `createWsServer` (server) do TinyBase. Client migra de `Store` pra `MergeableStore` (pré-requisito de qualquer sync). Server roda em Node.js dentro do Docker do homeserver, atrás do reverse proxy que já existe, com persistência em arquivo (via `createFilePersister`) ou SQLite (via `createSqlite3Persister`) — decisão adiada pra próxima fatia, quando implementarmos.
+**Decisão:** WebSocket próprio no homeserver via `createWsSynchronizer` (client) + `createWsServer` (server) do TinyBase. Client migra de `Store` pra `MergeableStore` (pré-requisito de qualquer sync). Server roda em Node.js dentro do Docker do homeserver, atrás do reverse proxy que já existe, com persistência em arquivo (via `createFilePersister`) ou SQLite (via `createSqlite3Persister`), decisão adiada pra próxima fatia, quando implementarmos.
 
 **Alternativas consideradas:**
 
-- **PowerSync** (SaaS ou self-hosted com Postgres). Sync engine maduro, backend Postgres, SDK Expo/RN oficial, Sync Rules pra filtrar dados por usuário. Descartado como default hoje por três motivos: (a) exige adicionar Postgres como novo serviço no homeserver (ou pagar SaaS) — mais uma dependência de ops sem ganho proporcional pra escala atual; (b) lock-in maior — o `createPowerSyncPersister` do TinyBase substitui o `expo-sqlite` persister e o modelo de dados vira SQLite + Sync Rules, mudança maior que trocar `Store` → `MergeableStore`; (c) reversível — se em algum momento a escala pedir (100+ users, Sync Rules complexos, queries analíticas fora do app), migrar do WS próprio pra PowerSync é possível, e adiar essa escolha até ter demanda concreta é mais barato do que assumir agora.
+- **PowerSync** (SaaS ou self-hosted com Postgres). Sync engine maduro, backend Postgres, SDK Expo/RN oficial, Sync Rules pra filtrar dados por usuário. Descartado como default hoje por três motivos: (a) exige adicionar Postgres como novo serviço no homeserver (ou pagar SaaS), mais uma dependência de ops sem ganho proporcional pra escala atual; (b) lock-in maior, porque o `createPowerSyncPersister` do TinyBase substitui o `expo-sqlite` persister e o modelo de dados vira SQLite + Sync Rules, mudança maior que trocar `Store` → `MergeableStore`; (c) reversível: se em algum momento a escala pedir (100+ users, Sync Rules complexos, queries analíticas fora do app), migrar do WS próprio pra PowerSync é possível, e adiar essa escolha até ter demanda concreta é mais barato do que assumir agora.
 - **CRDT com Yjs** (`YjsPersister` + `y-websocket`/`y-webrtc`). Descartado por redundância: o `MergeableStore` do TinyBase já é CRDT nativo determinístico; adicionar Yjs por cima só faz sentido se precisar de features exclusivas do Yjs (rich text/drawing collab), o que não é o caso.
-- **Só backup (export/import JSON)**, sem sync ativo. Alternativa mais barata e já prevista como item do M8 ("Exportação/backup de dados"). Não substitui sync — não resolve "usar em dois aparelhos ao mesmo tempo" nem restaura automaticamente ao reinstalar. Fica como fallback complementar, não como escolha do M6.
-- **Cloudflare Durable Objects** (`WsServerDurableObject`). Zero ops, escala infinita, custo baixo em escala pequena. Descartado por ir contra o princípio "usar a infra que já tem" — introduzir Cloudflare como dependência nova quando o homeserver já resolve é assumir vendor lock-in de graça, e o tempo pra provisionar/aprender > tempo pra rodar um contêiner Node.
+- **Só backup (export/import JSON)**, sem sync ativo. Alternativa mais barata e já prevista como item do M8 ("Exportação/backup de dados"). Não substitui sync, porque não resolve "usar em dois aparelhos ao mesmo tempo" nem restaura automaticamente ao reinstalar. Fica como fallback complementar, não como escolha do M6.
+- **Cloudflare Durable Objects** (`WsServerDurableObject`). Zero ops, escala infinita, custo baixo em escala pequena. Descartado por ir contra o princípio "usar a infra que já tem": introduzir Cloudflare como dependência nova quando o homeserver já resolve é assumir vendor lock-in de graça, e o tempo pra provisionar/aprender > tempo pra rodar um contêiner Node.
 
 **Consequências:**
 
 - **Positivo:** zero custo recorrente; owner completo do estado; menor delta de código (Store → MergeableStore + Synchronizer, sem trocar persister do client); zero lock-in de fornecedor; usa infra e prática de ops que você já tem.
-- **Negativo aceito:** uptime do server é responsabilidade sua (o homeserver já é), reverse proxy + TLS (wss://) precisam ser configurados uma vez, reconnect/retry ficam por conta do que o TinyBase resolve (o essencial já vem pronto no `WsSynchronizer`, mas edge cases podem exigir cuidado). Server persistence via `createFilePersister` é rústica — se ficar apertado, dá pra trocar por `createSqlite3Persister` sem afetar o client.
-- **Auth:** por enquanto o path do WebSocket é a "sala" (ex.: `wss://.../<userId>`). Sem autenticação real na primeira versão — dogfooding continua sendo os 5-6 testers conhecidos. Auth entra em fatia própria do M6 quando a escala/exposição pedir.
+- **Negativo aceito:** uptime do server é responsabilidade sua (o homeserver já é), reverse proxy + TLS (wss://) precisam ser configurados uma vez, reconnect/retry ficam por conta do que o TinyBase resolve (o essencial já vem pronto no `WsSynchronizer`, mas edge cases podem exigir cuidado). Server persistence via `createFilePersister` é rústica, e se ficar apertado, dá pra trocar por `createSqlite3Persister` sem afetar o client.
+- **Auth:** por enquanto o path do WebSocket é a "sala" (ex.: `wss://.../<userId>`). Sem autenticação real na primeira versão, já que o dogfooding continua sendo os 5-6 testers conhecidos. Auth entra em fatia própria do M6 quando a escala/exposição pedir.
 - **Migração:** o próprio `createMergeableStore` é compatível com `expo-sqlite` persister via `MergeableContentPersister` (ou o `Sqlite3Persister` server-side no server); os dados existentes de testers continuam válidos, só ganham metadados de CRDT.
 
-**Quando revisitar:** se a escala passar de ~50 usuários ativos, se Sync Rules ficarem necessárias (particionar dados por permissão complexa), ou se o ops do homeserver se tornar problemático. Nesses casos, considerar PowerSync (SaaS ou self-hosted) — a migração exige troca de persister do client (ExpoSqlite → PowerSync), mas a shape do TinyBase Store persiste.
+**Quando revisitar:** se a escala passar de ~50 usuários ativos, se Sync Rules ficarem necessárias (particionar dados por permissão complexa), ou se o ops do homeserver se tornar problemático. Nesses casos, considerar PowerSync (SaaS ou self-hosted), lembrando que a migração exige troca de persister do client (ExpoSqlite → PowerSync), mas a shape do TinyBase Store persiste.
 
 ---
 
-## ADR-010 — Autenticação: Supabase Auth (hospedado) com magic link
+## ADR-010: Autenticação: Supabase Auth (hospedado) com magic link
 
 **Status:** decidido. Fecha o item "Autenticação/identificação mínima do dispositivo" do M6. Escolha feita ao completar a fatia 3 (#202) e planejar a fatia de identidade/multi-device.
 
-**Contexto:** o M6 quer que "os dados sobrevivam a perda/troca de aparelho". Após as fatias 1-3 (#195, #198, #202), o transporte de sync funciona ponta a ponta, mas cada install gera um `syncRoomId` aleatório — dois devices do mesmo usuário NÃO sincronizam sozinhos, e reinstall perde dados. Falta identificar o usuário de forma que:
+**Contexto:** o M6 quer que "os dados sobrevivam a perda/troca de aparelho". Após as fatias 1-3 (#195, #198, #202), o transporte de sync funciona ponta a ponta, mas cada install gera um `syncRoomId` aleatório, então dois devices do mesmo usuário NÃO sincronizam sozinhos, e reinstall perde dados. Falta identificar o usuário de forma que:
 
 - 2 devices do mesmo usuário compartilhem estado (web + native, ou 2 celulares).
 - Reinstall recupere dados sem depender de export/import manual.
-- Testers fiquem isolados uns dos outros (o que hoje o roomId aleatório já garante — não regredir).
+- Testers fiquem isolados uns dos outros (o que hoje o roomId aleatório já garante, e não pode regredir).
 - O server WS possa validar quem tem direito a ler/escrever em cada sala.
 
 Contexto do projeto que pesa:
 
 - **Escala pequena** hoje (5-6 testers), longo prazo dezenas.
-- **Baixo apetite por manter senha/reset/hash/rotate** — o app é pra durar anos, e o dev principal é o próprio usuário.
+- **Baixo apetite por manter senha/reset/hash/rotate**: o app é pra durar anos, e o dev principal é o próprio usuário.
 - **Homeserver já cheio** de containers (server WS, Evolution API, outros do túnel `home server`).
-- **Já usamos Vercel functions** (`api/feedback.js`) — não é anátema ter SaaS na stack.
+- **Já usamos Vercel functions** (`api/feedback.js`), então não é anátema ter SaaS na stack.
 
-**Decisão:** usar **Supabase Auth hospedado** (`supabase.com`), método único **magic link por email**. Cliente usa `@supabase/supabase-js` com persistência de sessão local. Server WS valida o JWT emitido pelo Supabase (HS256, secret compartilhado) na conexão e deriva o `roomId` do `sub` (userId). Client `syncRoomId` deixa de ser gerado localmente — passa a ser o userId. Dados anônimos existentes migram pra sala do usuário no primeiro sign-in.
+**Decisão:** usar **Supabase Auth hospedado** (`supabase.com`), método único **magic link por email**. Cliente usa `@supabase/supabase-js` com persistência de sessão local. Server WS valida o JWT emitido pelo Supabase (HS256, secret compartilhado) na conexão e deriva o `roomId` do `sub` (userId). Client `syncRoomId` deixa de ser gerado localmente e passa a ser o userId. Dados anônimos existentes migram pra sala do usuário no primeiro sign-in.
 
 **Fluxo:**
 
@@ -208,7 +208,7 @@ Contexto do projeto que pesa:
 **Alternativas consideradas:**
 
 - **Auth próprio no homeserver** (Node + bcrypt + JWT + SQLite). Alinha 100% com ADR-009 ("infra que já tem, zero SaaS"). Descartado por custo/valor: reset de senha, entrega confiável de email transacional, patches de segurança, e o teto de "single dev cuidando de tudo" não compensam o ganho de "não ter dependência SaaS" pra 5-6 usuários.
-- **Supabase self-hosted no homeserver**. Traria a stack toda pra dentro do docker (Postgres + GoTrue + PostgREST + Realtime + Storage + Studio + Kong = 7+ containers). Manutenção do Postgres + migrations do `supabase-cli` + backups viram responsabilidade da casa. Descartado — se vamos aceitar o custo de manter Supabase, o managed é objetivamente mais barato em ops.
+- **Supabase self-hosted no homeserver**. Traria a stack toda pra dentro do docker (Postgres + GoTrue + PostgREST + Realtime + Storage + Studio + Kong = 7+ containers). Manutenção do Postgres + migrations do `supabase-cli` + backups viram responsabilidade da casa. Descartado: se vamos aceitar o custo de manter Supabase, o managed é objetivamente mais barato em ops.
 - **Clerk**. UX polida, mas free até 10k MAU depois pago; lock-in maior (menos APIs standard) e Supabase resolve o mesmo problema no free tier atual.
 - **Firebase Auth**. SDK maduro, tier free grande, mas puxa Firebase inteiro pro bundle e reforça o ecossistema Google numa stack que não usa mais nada dele. Descartado.
 - **Email + senha em vez de magic link**. Adiciona: validação de força de senha, telas de esqueci-a-senha, superfície de credential stuffing. Sem valor pra 5-6 pessoas que sabem checar email. Fica como follow-up se algum tester pedir.
@@ -217,17 +217,17 @@ Contexto do projeto que pesa:
 **Consequências:**
 
 - **Positivo:** identidade + reset + delivery de email delegados; SDK RN oficial; free tier resolve escala prevista sem pagar; zero senha pra usuário lembrar; JWT verificável offline pelo server WS (HS256, sem chamar Supabase a cada mensagem).
-- **Negativo aceito:** dependência de SaaS (contradiz parcialmente ADR-009 — reconhecido no trade-off acima); precisa configurar SMTP no Supabase ou usar o SMTP dele (rate-limitado no free); vendor lock-in moderado (migrar de Supabase Auth pra qualquer outra coisa exigirá refluxo — mas o formato de user é padrão o suficiente pra ser refazível).
+- **Negativo aceito:** dependência de SaaS (contradiz parcialmente ADR-009: reconhecido no trade-off acima); precisa configurar SMTP no Supabase ou usar o SMTP dele (rate-limitado no free); vendor lock-in moderado (migrar de Supabase Auth pra qualquer outra coisa exigirá refluxo, mas o formato de user é padrão o suficiente pra ser refazível).
 - **Server WS:** ganha dependência de `SUPABASE_JWT_SECRET` (env). Verifica JWT no `verifyClient` do `ws.Server`; pathId ignora o que o cliente pede na URL e usa `sub` do token. Sem JWT válido, upgrade rejeitado.
 - **Client:** ganha telas de login/logout, `SessionProvider` pra expor user pro resto do app, e um pequeno passo de migração no 1º sign-in (mover dados do roomId anônimo pro roomId = userId, apagar o anônimo depois).
-- **Testers em rollout:** primeiro launch pós-deploy pede login. Ninguém perde dados (script de migração cobre), mas o mecanismo de bootstrap muda — precisa aviso via WhatsApp (Evolution API — ver [[evolution-api-testers-stack]]).
+- **Testers em rollout:** primeiro launch pós-deploy pede login. Ninguém perde dados (script de migração cobre), mas o mecanismo de bootstrap muda, e precisa aviso via WhatsApp (Evolution API, ver [[evolution-api-testers-stack]]).
 
 **Quando revisitar:** se escala passar de 50 MAU (approaching free tier limits), se precisarmos de multi-tenant complexo (organizações, roles), ou se Supabase mudar preço/termos de forma inaceitável. Migração de saída passa por reexportar user list + reissue de magic links de outra fonte.
 
 **Fatiamento pra M6:**
 
 - **Fatia A (setup):** projeto Supabase criado, `@supabase/supabase-js` no client, telas de login/callback/logout, sessão persistida, `SessionProvider`. Sync ainda não usa a sessão. App usa magic link mas continua sincronizando anonimamente por baixo.
-- **Fatia B (server valida JWT):** server WS ganha `SUPABASE_JWT_SECRET`, verifica no upgrade, deriva pathId de `sub`. Client passa `?token=<jwt>` na URL do WS. Rooms passam a ser por-userId. Testers precisam relogar (sem migração — dados anônimos ficam no roomId antigo, invisíveis).
+- **Fatia B (server valida JWT):** server WS ganha `SUPABASE_JWT_SECRET`, verifica no upgrade, deriva pathId de `sub`. Client passa `?token=<jwt>` na URL do WS. Rooms passam a ser por-userId. Testers precisam relogar (sem migração: dados anônimos ficam no roomId antigo, invisíveis).
 - **Fatia C (migração de anônimo → user):** no 1º sign-in, se local tem `syncRoomId` anônimo com dados, faz merge desses dados pra sala do userId e apaga o roomId anônimo. Encerra o M6.
 
 ---

--- a/docs/05-guia-migracao-estilo.md
+++ b/docs/05-guia-migracao-estilo.md
@@ -1,4 +1,4 @@
-# Guia de Migração de Estilo — CSS-web → NativeWind
+# Guia de Migração de Estilo: CSS-web → NativeWind
 
 O código atual mistura três coisas: `StyleSheet`/`useThemedStyles`, `className` (NativeWind) e valores de CSS web (`rem`, `boxShadow`, `fit-content`) que não são nativos do React Native. Eles renderizam no preview do navegador, mas quebram ou são ignorados no Android.
 
@@ -8,32 +8,32 @@ Este guia é o mapa "de → para" pra migrar cada tela pra um sistema só (Nativ
 
 Não existe `rem` no React Native nativo. `16px` no navegador ≈ `1rem`. A base do RN é o **número puro** (`fontSize: 16`), sem unidade. Na prática, para converter `rem` → número: **multiplique por 16** (`1.6rem` → `26`, arredondando; `.4rem` → `6`; `1.2rem` → `19`). Ajuste no olho depois, rodando no Android.
 
-No NativeWind, o Tailwind já usa uma escala própria (`text-base`, `p-2`, etc.) que resolve isso — então prefira as classes da escala a valores arbitrários `[..]`.
+No NativeWind, o Tailwind já usa uma escala própria (`text-base`, `p-2`, etc.) que resolve isso, então prefira as classes da escala a valores arbitrários `[..]`.
 
 ## Tabela de conversão
 
-| CSS-web (atual)                            | NativeWind (className)                | Observação                                 |
-| ------------------------------------------ | ------------------------------------- | ------------------------------------------ |
-| `fontSize: "1.6rem"`                       | `text-2xl` (~24px) ou `text-[24px]`   | prefira a escala; evite `text-[1.6rem]`    |
-| `fontSize: "1.2rem"`                       | `text-lg` (~18px)                     |                                            |
-| `fontSize: 18`                             | `text-lg`                             | número já era válido, mas unifique         |
-| `fontWeight: "bold"`                       | `font-bold`                           |                                            |
-| `padding: ".4rem"`                         | `p-1.5` (~6px)                        |                                            |
-| `padding: 10`                              | `p-2.5` (10px)                        |                                            |
-| `gap: "1rem"`                              | `gap-4` (16px)                        |                                            |
-| `gap: ".6rem"`                             | `gap-2.5` (~10px)                     |                                            |
-| `borderRadius: ".6rem"`                    | `rounded-md`                          |                                            |
-| `borderRadius: "100%"`                     | `rounded-full`                        | `100%` não existe em RN                    |
-| `maxWidth: "40rem"`                        | `max-w-[640px]`                       |                                            |
-| `width: "fit"` / `"fit-content"`           | `self-start` ou remover               | RN não tem fit-content; a View já encolhe  |
-| `height: "fit-content"`                    | remover                               | idem                                       |
-| `display: "flex"`                          | remover                               | tudo em RN já é flex; string dá warning    |
-| `flexDirection: "row"`                     | `flex-row`                            |                                            |
-| `border: "solid 1px #333"`                 | `border border-[#333]`                | RN quer borderWidth + borderColor          |
-| `boxShadow: Colors.shadow`                 | `style={shadow}` (import)             | ver abaixo — sombra fica fora do className |
-| `backgroundColor: "#333"` / `bg-[#333333]` | `bg-dark-background`                  | use o token, não o hex hardcoded           |
-| `color: "white"`                           | `text-white`                          |                                            |
-| `color: theme.text`                        | `text-light-text dark:text-dark-text` | NativeWind resolve dark/light sozinho      |
+| CSS-web (atual)                            | NativeWind (className)                | Observação                                |
+| ------------------------------------------ | ------------------------------------- | ----------------------------------------- |
+| `fontSize: "1.6rem"`                       | `text-2xl` (~24px) ou `text-[24px]`   | prefira a escala; evite `text-[1.6rem]`   |
+| `fontSize: "1.2rem"`                       | `text-lg` (~18px)                     |                                           |
+| `fontSize: 18`                             | `text-lg`                             | número já era válido, mas unifique        |
+| `fontWeight: "bold"`                       | `font-bold`                           |                                           |
+| `padding: ".4rem"`                         | `p-1.5` (~6px)                        |                                           |
+| `padding: 10`                              | `p-2.5` (10px)                        |                                           |
+| `gap: "1rem"`                              | `gap-4` (16px)                        |                                           |
+| `gap: ".6rem"`                             | `gap-2.5` (~10px)                     |                                           |
+| `borderRadius: ".6rem"`                    | `rounded-md`                          |                                           |
+| `borderRadius: "100%"`                     | `rounded-full`                        | `100%` não existe em RN                   |
+| `maxWidth: "40rem"`                        | `max-w-[640px]`                       |                                           |
+| `width: "fit"` / `"fit-content"`           | `self-start` ou remover               | RN não tem fit-content; a View já encolhe |
+| `height: "fit-content"`                    | remover                               | idem                                      |
+| `display: "flex"`                          | remover                               | tudo em RN já é flex; string dá warning   |
+| `flexDirection: "row"`                     | `flex-row`                            |                                           |
+| `border: "solid 1px #333"`                 | `border border-[#333]`                | RN quer borderWidth + borderColor         |
+| `boxShadow: Colors.shadow`                 | `style={shadow}` (import)             | ver abaixo, sombra fica fora do className |
+| `backgroundColor: "#333"` / `bg-[#333333]` | `bg-dark-background`                  | use o token, não o hex hardcoded          |
+| `color: "white"`                           | `text-white`                          |                                           |
+| `color: theme.text`                        | `text-light-text dark:text-dark-text` | NativeWind resolve dark/light sozinho     |
 
 ## Cores: use os tokens, não os hex
 
@@ -45,7 +45,7 @@ Depois que o `tailwind.config.js` passa a importar do `Colors.js`, você tem est
 - `text-light-text` / `text-dark-text`
 - `bg-light-backgroundCard` / `bg-dark-backgroundCard`
 
-Nunca mais escreva `bg-[#2E5A88]` ou `bg-[#333333]` — quando a cor mudar no `Colors.js`, o token acompanha sozinho; o hex hardcoded não.
+Nunca mais escreva `bg-[#2E5A88]` ou `bg-[#333333]`. Quando a cor mudar no `Colors.js`, o token acompanha sozinho; o hex hardcoded não.
 
 ## Dark mode
 
@@ -62,17 +62,17 @@ const theme = Colors[colorScheme] ?? Colors.light;
 
 Pra isso funcionar, garanta que o `darkMode` do NativeWind está ativo (o preset já cuida disso na maioria dos setups) e que o app declara suporte a dark mode no `app.json` (`"userInterfaceStyle": "automatic"`).
 
-> **Estado atual (#65):** o `app.json` já está em `"userInterfaceStyle": "automatic"` — o tema claro/escuro real está ligado e segue o sistema. Sempre escreva as duas variantes (`text-light-x dark:text-dark-x`); classes fixas como `text-white` só valem sobre fundo que é escuro nos dois temas.
+> **Estado atual (#65):** o `app.json` já está em `"userInterfaceStyle": "automatic"`, e o tema claro/escuro real está ligado e segue o sistema. Sempre escreva as duas variantes (`text-light-x dark:text-dark-x`); classes fixas como `text-white` só valem sobre fundo que é escuro nos dois temas.
 
 ## Cache: reinicie com `--clear` ao mexer em fontes de build
 
-Nem tudo é resolvido em runtime. Algumas coisas são compiladas em **build** e ficam no cache do Metro — editá-las **não reflete** no app até reiniciar limpando o cache:
+Nem tudo é resolvido em runtime. Algumas coisas são compiladas em **build** e ficam no cache do Metro, e editá-las **não reflete** no app até reiniciar limpando o cache:
 
 ```bash
 npx expo start --tunnel --clear
 ```
 
-Isso vale para: `constants/Colors.js` e `tailwind.config.js` (as cores de `className` são geradas em build), `babel.config.js`, e qualquer arquivo importado via `babel-plugin-inline-import` (ex.: o `docs/04-roadmap-milestones.md` exibido na Home). Sintoma clássico: você troca uma cor no `Colors.js` ou edita o roadmap e "nada acontece" — é o cache. Já mudanças em `style={{...}}` ou em `Colors.x` usados via JS atualizam na hora (são runtime).
+Isso vale para: `constants/Colors.js` e `tailwind.config.js` (as cores de `className` são geradas em build), `babel.config.js`, e qualquer arquivo importado via `babel-plugin-inline-import` (ex.: o `docs/04-roadmap-milestones.md` exibido na Home). Sintoma clássico: você troca uma cor no `Colors.js` ou edita o roadmap e "nada acontece". É o cache. Já mudanças em `style={{...}}` ou em `Colors.x` usados via JS atualizam na hora (são runtime).
 
 ## Sombra: o único caso que NÃO vai pro className
 
@@ -84,16 +84,16 @@ import { shadow } from "@/constants/Colors";
 <View className="bg-light-backgroundCard rounded-md p-2.5" style={shadow} />;
 ```
 
-Pode combinar `className` + `style` no mesmo elemento sem problema — o `className` cuida do layout/cor, o `style` cuida da sombra.
+Pode combinar `className` + `style` no mesmo elemento sem problema: o `className` cuida do layout/cor, o `style` cuida da sombra.
 
 ## Ordem de ataque, por arquivo
 
 1. Comece por **um** arquivo já unificado como referência (sugiro `water.jsx`, a métrica mais simples).
-2. Rode no Android **antes e depois** — compare lado a lado.
+2. Rode no Android **antes e depois**, comparando lado a lado.
 3. Só passe pro próximo arquivo quando o anterior renderizar igual (ou melhor) no Android.
-4. Componentes compartilhados primeiro (`MyView`, `MyButton`, `Score`, `MyCheckbox`), telas depois — assim a correção do componente já beneficia todas as telas que o usam.
+4. Componentes compartilhados primeiro (`MyView`, `MyButton`, `Score`, `MyCheckbox`), telas depois, assim a correção do componente já beneficia todas as telas que o usam.
 
 ## Não esqueça
 
 - Os **componentes compartilhados já foram migrados** em #60 (`MyButton`/`MyIconButton` reescritos com `Pressable` + `className`, `MyView`, `Score`, `MyCheckbox`, `MyHeader`, e `MyInput` implementado). Ao migrar as telas, confie neles: passe `className`/`titleClassName` ao `MyButton` (a API antiga `styles`/`titleStyle` foi removida) e use os tokens de cor em vez de hex.
-- O `MyButton` agora expõe `className`, `titleClassName`, `style` (escape hatch p/ objeto RN como a `shadow`) — não passe mais valores CSS-web (`marginHorizontal: "1rem"`, `height: "fit-content"`); use `mx-4`, `self-start`, etc.
+- O `MyButton` agora expõe `className`, `titleClassName`, `style` (escape hatch p/ objeto RN como a `shadow`). Não passe mais valores CSS-web (`marginHorizontal: "1rem"`, `height: "fit-content"`); use `mx-4`, `self-start`, etc.

--- a/docs/06-guia-testes.md
+++ b/docs/06-guia-testes.md
@@ -1,8 +1,8 @@
-# Guia de Testes — Back on Track
+# Guia de Testes do Back on Track
 
 O M4 (Rede de Segurança) montou o alicerce: eslint enxergando o app (#128), jest-expo com job no CI (#134), e testes concretos cobrindo o `database.js`, `duration.js`, o parser do roadmap, a corrida da persistência do #108 e a função `api/feedback.js` com a compat do #116.
 
-Este guia registra o **critério** — pra quem contribuir depois saber, em segundos, "isto exige teste? sim/não?" — sem cair em teatro de cobertura.
+Este guia registra o **critério**, pra quem contribuir depois saber em segundos "isto exige teste? sim/não?", sem cair em teatro de cobertura.
 
 ## O critério, curto
 
@@ -12,26 +12,26 @@ Isso pesa a favor de testar coisas que **quebram em silêncio** (não crashan, s
 
 ## Teste isto
 
-- **Comportamento assíncrono** — o #108 foi uma corrida entre `startAutoLoad()` da persistência e o `useFocusEffect`. Nenhum linter pegaria; passar pelo navegador à mão passava em silêncio. Ver `tests/persistence-reactivity.test.jsx`.
-- **Compat de payload/dados** — o #116 introduziu `environment`/`bundle`/`userAgent` mas manteve `device` do bundle antigo. Um `else if` a menos e o canal de feedback dos testers quebra sem aviso. Ver `tests/feedback-api.test.js` (caso "payload LEGADO").
-- **Funções puras de domínio** — `hhmmToMinutes`/`minutesToHHMM`, `parseRoadmap`, `getToday`/`getByDate`. Barato de cobrir, alto valor: mudança acidental de comportamento é frequente e o teste roda em milissegundos.
-- **Integração com serviço externo** — `api/feedback.js` chama a API do GitHub. Mocka o `fetch`, exercita guardas (401/500/400) e verifica o corpo enviado. Não bater no serviço real: teste rápido, determinístico, sem criar issue lixo.
-- **Armadilhas conhecidas** — quando uma limitação existe de propósito (o `cleanText` do parser que engasga em parênteses aninhados), **trave por teste**. Se alguém "consertar" sem entender, o teste avisa.
+- **Comportamento assíncrono**: o #108 foi uma corrida entre `startAutoLoad()` da persistência e o `useFocusEffect`. Nenhum linter pegaria; passar pelo navegador à mão passava em silêncio. Ver `tests/persistence-reactivity.test.jsx`.
+- **Compat de payload/dados**: o #116 introduziu `environment`/`bundle`/`userAgent` mas manteve `device` do bundle antigo. Um `else if` a menos e o canal de feedback dos testers quebra sem aviso. Ver `tests/feedback-api.test.js` (caso "payload LEGADO").
+- **Funções puras de domínio**: `hhmmToMinutes`/`minutesToHHMM`, `parseRoadmap`, `getToday`/`getByDate`. Barato de cobrir, alto valor: mudança acidental de comportamento é frequente e o teste roda em milissegundos.
+- **Integração com serviço externo**: `api/feedback.js` chama a API do GitHub. Mocka o `fetch`, exercita guardas (401/500/400) e verifica o corpo enviado. Não bater no serviço real: teste rápido, determinístico, sem criar issue lixo.
+- **Armadilhas conhecidas**: quando uma limitação existe de propósito (o `cleanText` do parser que engasga em parênteses aninhados), **trave por teste**. Se alguém "consertar" sem entender, o teste avisa.
 
 ## Não teste isto
 
-- **Layout, estilo e cor** — caro e frágil. O eslint pega o que importa (referências mortas); o resto é visual, e a preview da Vercel + o build web servem melhor que snapshot.
-- **UI que só passa props** — `MyButton`, `MyView`, `MyInput`. O valor é baixo; se quebrar, quebra em toda tela e você vê na hora.
-- **Config e scripts one-shot** — `vercel.json`, `docker-compose.yml`, `notify-testers.mjs`. O próprio uso é o teste. Escrever teste pra config é encenação.
-- **O que quebra visível ao abrir a tela** — não precisa de teste automatizado. O teste manual no navegador/device custa segundos e ainda pega o visual.
+- **Layout, estilo e cor**: caro e frágil. O eslint pega o que importa (referências mortas); o resto é visual, e a preview da Vercel + o build web servem melhor que snapshot.
+- **UI que só passa props**: `MyButton`, `MyView`, `MyInput`. O valor é baixo; se quebrar, quebra em toda tela e você vê na hora.
+- **Config e scripts one-shot**: `vercel.json`, `docker-compose.yml`, `notify-testers.mjs`. O próprio uso é o teste. Escrever teste pra config é encenação.
+- **O que quebra visível ao abrir a tela**: não precisa de teste automatizado. O teste manual no navegador/device custa segundos e ainda pega o visual.
 
 ## Padrões técnicos do projeto
 
 - Testes em `tests/*.test.{js,jsx}`. `npm test` roda tudo; job `Test` no CI (`.github/workflows/linting.yaml`).
-- **jest-expo** com preset padrão. Detalhes de setup e armadilhas em `~/.claude/.../memory/jest-setup-gotchas.md` — inclui o alinhamento do jest no 29, o peer `test-renderer`, e o `renderHook` **async** da RNTL 14.
+- **jest-expo** com preset padrão. Detalhes de setup e armadilhas em `~/.claude/.../memory/jest-setup-gotchas.md`, que inclui o alinhamento do jest no 29, o peer `test-renderer`, e o `renderHook` **async** da RNTL 14.
 - **Mockar `fetch`** com `jest.fn()` em `beforeEach`, restaurar em `afterEach`. Nunca bater em serviço real.
 - Testes levam `// @ts-nocheck` no topo (globals do jest não são tipados; ADR-002).
-- `no-undef` como **erro** no eslint — cobre todos os `.jsx`. Um `setTick` órfão como o do #126 quebra o CI antes do commit.
+- `no-undef` como **erro** no eslint, cobrindo todos os `.jsx`. Um `setTick` órfão como o do #126 quebra o CI antes do commit.
 
 ## Nota honesta sobre E2E
 
@@ -41,4 +41,4 @@ Se o número de testers crescer muito ou o dogfooding parar, revisite.
 
 ## Antes de mergear um PR novo
 
-Uma pergunta rápida: **este PR muda algum comportamento das categorias em "Teste isto"?** Se sim, o teste existe (ou o PR adiciona um). Se não sabe, prove por injeção — remova o comportamento e veja se algum teste falha; se nenhum falhar, ele não estava coberto.
+Uma pergunta rápida: **este PR muda algum comportamento das categorias em "Teste isto"?** Se sim, o teste existe (ou o PR adiciona um). Se não sabe, prove por injeção: remova o comportamento e veja se algum teste falha; se nenhum falhar, ele não estava coberto.

--- a/docs/07-auditoria-ui.md
+++ b/docs/07-auditoria-ui.md
@@ -1,6 +1,6 @@
-# Auditoria de UI — Back on Track
+# Auditoria de UI do Back on Track
 
-Primeiro item do M5 (Design System & Consistência de UI). Levantamento do estado atual — sem mudar código — pra virar alvo dos próximos itens da milestone (tokens, componentização, revisão do `MyHeader`, responsividade web).
+Primeiro item do M5 (Design System & Consistência de UI). Levantamento do estado atual, sem mudar código, pra virar alvo dos próximos itens da milestone (tokens, componentização, revisão do `MyHeader`, responsividade web).
 
 Cada achado aponta arquivo/linha. Onde fez sentido, a severidade: **funcional** (comportamento diverge do esperado, não só estética) vs **visual/manutenção** (inconsistente, mas não quebra nada sozinho).
 
@@ -24,11 +24,11 @@ O roadmap já sinalizava "`CARD`/`LABEL` repetidos em 3 telas". Na prática são
 
 Fora esse grupo, **mais três variantes** do mesmo conceito "card", cada uma com um valor ligeiramente diferente e nenhuma delas usando a constante acima:
 
-- `components/MyHistory.jsx:72` — `rounded-md`, `p-2.5`, `gap-2.5` (não `rounded-lg`/`p-4`)
-- `components/metrics/MetricScreen.jsx:96` — `gap-8`, `p-2.5`, sem `w-full`
-- `components/metrics/fields.jsx:20-21` (`CARD` local) — `items-center gap-8 p-2.5`, sem `max-w`
+- `components/MyHistory.jsx:72`: `rounded-md`, `p-2.5`, `gap-2.5` (não `rounded-lg`/`p-4`)
+- `components/metrics/MetricScreen.jsx:96`: `gap-8`, `p-2.5`, sem `w-full`
+- `components/metrics/fields.jsx:20-21` (`CARD` local): `items-center gap-8 p-2.5`, sem `max-w`
 
-**Ação sugerida:** extrair `Card`/`CardLabel` como componentes reais (não string constante repetida) em `components/`, com uma única fonte para raio/padding/gap. Decidir se o raio "card" é `md` ou `lg` — hoje as duas coexistem sem critério.
+**Ação sugerida:** extrair `Card`/`CardLabel` como componentes reais (não string constante repetida) em `components/`, com uma única fonte para raio/padding/gap. Decidir se o raio "card" é `md` ou `lg`. Hoje as duas coexistem sem critério.
 
 ## 2. Raio (`rounded-*`) sem escala única
 
@@ -41,98 +41,98 @@ Quatro valores de raio em uso, sem token que diga qual serve pra quê:
 | `rounded-md`             | `MyHistory.jsx:72` (card), `registry.jsx:132/139` (inputs pequenos)                  |
 | `rounded` (default, 4px) | `MyInput.jsx:25`                                                                     |
 
-Nenhuma dessas escolhas parece intencional — é o valor que a pessoa que escreveu aquele trecho escolheu no momento.
+Nenhuma dessas escolhas parece intencional. É o valor que a pessoa que escreveu aquele trecho escolheu no momento.
 
 ## 3. Cor: sistema parcial, hex cru por fora
 
-`constants/Colors.js` centraliza `primary`/`secondary`/`light`/`dark`, e o `tailwind.config.js` os expõe como token (`bg-primary`, `text-light-text`, etc.) — isso funciona bem onde é usado. Mas boa parte do app passa por fora do sistema com hex/paleta Tailwind default direto no `className`:
+`constants/Colors.js` centraliza `primary`/`secondary`/`light`/`dark`, e o `tailwind.config.js` os expõe como token (`bg-primary`, `text-light-text`, etc.), e isso funciona bem onde é usado. Mas boa parte do app passa por fora do sistema com hex/paleta Tailwind default direto no `className`:
 
-- `border-[#333]` — `MyInput.jsx:25`, `MyButton.jsx:54` (`MyIconButton`) — **não tem variante `dark:`**, então em tema escuro a borda (#333) some contra o fundo escuro (`dark.background` também é `#333333`, [Colors.js:13](../constants/Colors.js))
-- `placeholderTextColor="#888"` — `MyInput.jsx:30`, fixo pros dois temas
-- `color="#333"` no ícone de `MyButton` (`MyButton.jsx:33`) — ícone sempre escuro, mesmo dentro de um botão `bg-primary` escuro ou em tema escuro
+- `border-[#333]`: `MyInput.jsx:25`, `MyButton.jsx:54` (`MyIconButton`): **não tem variante `dark:`**, então em tema escuro a borda (#333) some contra o fundo escuro (`dark.background` também é `#333333`, [Colors.js:13](../constants/Colors.js))
+- `placeholderTextColor="#888"`: `MyInput.jsx:30`, fixo pros dois temas
+- `color="#333"` no ícone de `MyButton` (`MyButton.jsx:33`): ícone sempre escuro, mesmo dentro de um botão `bg-primary` escuro ou em tema escuro
 - `android_ripple={{ color: "#00000022" }}` repetido em `MyButton.jsx:21` e `:57`
-- `text-red-500` pra erro em `app/feedback.jsx:159` — única cor de "erro" do app, e não é um token do projeto, é a paleta default do Tailwind
+- `text-red-500` pra erro em `app/feedback.jsx:159`: única cor de "erro" do app, e vem da paleta default do Tailwind em vez de um token do projeto
 
-**Achado funcional:** a borda de `MyInput` (item acima) provavelmente fica invisível em tema escuro — vale conferir visualmente antes de decidir o token de borda.
+**Achado funcional:** a borda de `MyInput` (item acima) provavelmente fica invisível em tema escuro, e vale conferir visualmente antes de decidir o token de borda.
 
 ### 3.1 `bg-secondary` com três significados diferentes
 
 O mesmo token é reaproveitado pra três papéis semânticos sem relação entre si:
 
-1. **Selecionado/ativo** — chip de métrica e categoria selecionados (`MyButton.jsx:18`)
-2. **Nota máxima** — badge de pontuação quando `obj.score === 5` (`MyHistory.jsx:83`)
-3. **Ação destrutiva** — botão "Remover" tester (`app/admin.jsx:148`, `className="bg-secondary px-3 py-1"`)
+1. **Selecionado/ativo**: chip de métrica e categoria selecionados (`MyButton.jsx:18`)
+2. **Nota máxima**: badge de pontuação quando `obj.score === 5` (`MyHistory.jsx:83`)
+3. **Ação destrutiva**: botão "Remover" tester (`app/admin.jsx:148`, `className="bg-secondary px-3 py-1"`)
 
-Não há token de "destrutivo"/"perigo" no projeto — o "Remover" (delete) usa a mesma cor do "está selecionado" e do "nota perfeita".
+Não há token de "destrutivo"/"perigo" no projeto, então o "Remover" (delete) usa a mesma cor do "está selecionado" e do "nota perfeita".
 
 ## 4. Tipografia: três escalas coexistindo
 
-- **Escala Tailwind** (`text-xs` a `text-2xl`) — a mais usada, nas 5 telas topo-nível e em `MyHistory`.
-- **Pixels crus fora da escala** — `text-[26px]` (`fields.jsx:19,35,131`, `registry.jsx:29`), `text-[19px]` (`MetricScreen.jsx:112`, no `TextInput` de observação). Não correspondem a nenhum degrau do Tailwind (`text-2xl` = 24px, `text-3xl` = 30px).
-- **`font-size: 62.5%` global** ([global.css:5-6](../global.css)), **só no bundle web** (é CSS puro, RN nativo ignora): aplicado ao seletor universal `*`, não a `html`/`:root`. O truque do "10px base" normalmente vai numa única regra na raiz — aqui, como todo elemento herda `font-size` do pai e o `*` reaplica 62.5% _de novo_ em cada nível, o tamanho efetivo composto depende da profundidade de aninhamento em vez de ser previsível. É provável causa de texto desproporcionalmente pequeno no web em árvores mais profundas — vale confirmar no navegador e, se confirmado, mover a regra pra `html`/`:root` (ou remover, já que RN nativo não tem o problema que o truque resolve).
+- **Escala Tailwind** (`text-xs` a `text-2xl`): a mais usada, nas 5 telas topo-nível e em `MyHistory`.
+- **Pixels crus fora da escala**: `text-[26px]` (`fields.jsx:19,35,131`, `registry.jsx:29`), `text-[19px]` (`MetricScreen.jsx:112`, no `TextInput` de observação). Não correspondem a nenhum degrau do Tailwind (`text-2xl` = 24px, `text-3xl` = 30px).
+- **`font-size: 62.5%` global** ([global.css:5-6](../global.css)), **só no bundle web** (é CSS puro, RN nativo ignora): aplicado ao seletor universal `*`, em vez de `html`/`:root`. O truque do "10px base" normalmente vai numa única regra na raiz. Aqui, como todo elemento herda `font-size` do pai e o `*` reaplica 62.5% _de novo_ em cada nível, o tamanho efetivo composto depende da profundidade de aninhamento em vez de ser previsível. É provável causa de texto desproporcionalmente pequeno no web em árvores mais profundas, e vale confirmar no navegador e, se confirmado, mover a regra pra `html`/`:root` (ou remover, já que RN nativo não tem o problema que o truque resolve).
 
-Além disso, dois arquivos diferentes definem uma constante chamada `LABEL` com **papéis distintos** e nomes iguais — pode confundir quem for procurar "o token de label":
+Além disso, dois arquivos diferentes definem uma constante chamada `LABEL` com **papéis distintos** e nomes iguais, o que pode confundir quem for procurar "o token de label":
 
 - Telas topo-nível: `font-bold text-xs ... opacity-60` (rótulo de seção, tipo "MÉTRICAS DE HOJE")
 - `MetricScreen.jsx:24` / `fields.jsx:17`: `font-bold text-lg ...` sem opacidade (rótulo de campo de formulário)
 
 ## 5. `MyHeader`: navegação global vs. chips de métrica
 
-O roadmap já desconfiava disso e a leitura do código confirma: `MyHeader` foi desenhado como a faixa de chips de métrica (água, sono, etc. — `components/MyHeader.jsx:39-47`, itera `CATEGORY_MAP`), mas é importado como se fosse **o header genérico do app**, inclusive em telas que não são de métrica:
+O roadmap já desconfiava disso e a leitura do código confirma: `MyHeader` foi desenhado como a faixa de chips de métrica (água, sono, etc., em `components/MyHeader.jsx:39-47`, que itera `CATEGORY_MAP`), mas é importado como se fosse **o header genérico do app**, inclusive em telas que não são de métrica:
 
-- `app/admin.jsx:89`, `app/feedback.jsx:81`, `app/roadmap.jsx:50` — nenhuma tem relação com as 5 métricas, mas mostram a faixa de chips assim mesmo
-- `app/(metrics)/_layout.jsx:23` já renderiza `MyHeader` no layout — e ainda assim `app/index.jsx`, `app/history.jsx` etc. importam e renderizam o próprio de novo na tela (duplicação do import/mount, não só do estilo)
+- `app/admin.jsx:89`, `app/feedback.jsx:81`, `app/roadmap.jsx:50`: nenhuma tem relação com as 5 métricas, mas mostram a faixa de chips assim mesmo
+- `app/(metrics)/_layout.jsx:23` já renderiza `MyHeader` no layout, e ainda assim `app/index.jsx`, `app/history.jsx` etc. importam e renderizam o próprio de novo na tela (duplicação do import/mount, não só do estilo)
 
-Não há, hoje, um componente de "header de navegação genérico" (voltar, título da tela) — o app depende do `Stack` do Expo Router com `headerShown: false` ([app/_layout.jsx:23](../app/_layout.jsx)) e usa `MyHeader` (chips) como substituto em todo lugar, mesmo onde chips de métrica não fazem sentido.
+Não há, hoje, um componente de "header de navegação genérico" (voltar, título da tela). O app depende do `Stack` do Expo Router com `headerShown: false` ([app/_layout.jsx:23](../app/_layout.jsx)) e usa `MyHeader` (chips) como substituto em todo lugar, mesmo onde chips de métrica não fazem sentido.
 
-**Achado funcional (tema escuro):** `app/_layout.jsx:5` e `app/(metrics)/_layout.jsx:5` leem `useColorScheme` de **`react-native`** (tema do SO), enquanto `app/index.jsx:5` e `MyButton.jsx:3` leem de **`nativewind`** (que responde ao `toggleColorScheme()` manual do botão "Alternar tema" nos Utilitários). Resultado: o `backgroundColor` inline calculado nesses dois `_layout.jsx` (via `Colors[colorScheme]`) **não muda** quando o usuário troca o tema manualmente — só as classes `dark:` (controladas pelo NativeWind) mudam. Vale confirmar visualmente se sobra uma faixa/contorno na cor do tema errado ao alternar manualmente.
+**Achado funcional (tema escuro):** `app/_layout.jsx:5` e `app/(metrics)/_layout.jsx:5` leem `useColorScheme` de **`react-native`** (tema do SO), enquanto `app/index.jsx:5` e `MyButton.jsx:3` leem de **`nativewind`** (que responde ao `toggleColorScheme()` manual do botão "Alternar tema" nos Utilitários). Resultado: o `backgroundColor` inline calculado nesses dois `_layout.jsx` (via `Colors[colorScheme]`) **não muda** quando o usuário troca o tema manualmente, porque só as classes `dark:` (controladas pelo NativeWind) mudam. Vale confirmar visualmente se sobra uma faixa/contorno na cor do tema errado ao alternar manualmente.
 
-**Achado funcional (padding duplicado):** `app/(metrics)/_layout.jsx:19` aplica `paddingTop: insets.top` na `View` raiz do grupo `(metrics)`, e a tela dentro dele (`MetricScreen.jsx:75`, via `MyView safe={true}`) aplica o mesmo `insets.top` de novo. As 5 telas topo-nível (`index`, `history`, etc.) não têm esse layout intermediário, então só pagam o inset uma vez. Ou seja, as telas de métrica podem ter espaço extra no topo comparado às demais — vale medir na tela.
+**Achado funcional (padding duplicado):** `app/(metrics)/_layout.jsx:19` aplica `paddingTop: insets.top` na `View` raiz do grupo `(metrics)`, e a tela dentro dele (`MetricScreen.jsx:75`, via `MyView safe={true}`) aplica o mesmo `insets.top` de novo. As 5 telas topo-nível (`index`, `history`, etc.) não têm esse layout intermediário, então só pagam o inset uma vez. Ou seja, as telas de métrica podem ter espaço extra no topo comparado às demais, e vale medir na tela.
 
 ## 6. `MyView safe={true}` como default arriscado
 
-`MyView` ([components/MyView.jsx:5](../components/MyView.jsx)) aplica `paddingTop/Bottom: insets.top/bottom` quando `safe` não é passado — e o default é `true`. Isso é correto para o container de tela inteira, mas dois componentes pequenos e reutilizáveis **esquecem de passar `safe={false}`** e herdam o padding de safe-area por engano:
+`MyView` ([components/MyView.jsx:5](../components/MyView.jsx)) aplica `paddingTop/Bottom: insets.top/bottom` quando `safe` não é passado, e o default é `true`. Isso é correto para o container de tela inteira, mas dois componentes pequenos e reutilizáveis **esquecem de passar `safe={false}`** e herdam o padding de safe-area por engano:
 
-- `components/MyCheckbox.jsx:10` — `<MyView className="flex-row items-center gap-1.5">`, usado dentro de formulários (`registry.jsx:199,204,265`)
-- `components/Score.jsx:10` — idem, usado dentro do card de nota em toda tela de métrica
+- `components/MyCheckbox.jsx:10`: `<MyView className="flex-row items-center gap-1.5">`, usado dentro de formulários (`registry.jsx:199,204,265`)
+- `components/Score.jsx:10`: idem, usado dentro do card de nota em toda tela de métrica
 
 Na prática isso deveria inflar essas linhas com o inset do dispositivo (tipicamente 20-50px), o que não parece intencional pra uma checkbox ou uma fileira de botões de nota. Vale checar visualmente se o espaçamento aparece.
 
 ## 7. Botão: `disabled` sem estado visual consistente
 
-`MyButton` não tem tratamento de `disabled` embutido — cada tela resolve na mão, de formas diferentes:
+`MyButton` não tem tratamento de `disabled` embutido, então cada tela resolve na mão, de formas diferentes:
 
-- `app/history.jsx:92` — `style={isToday ? { opacity: 0.4 } : undefined}`
-- `app/admin.jsx:122`, `app/feedback.jsx:168` — `className={cond ? "" : "opacity-50"}`
+- `app/history.jsx:92`: `style={isToday ? { opacity: 0.4 } : undefined}`
+- `app/admin.jsx:122`, `app/feedback.jsx:168`: `className={cond ? "" : "opacity-50"}`
 
 Duas opacidades diferentes (`0.4` vs `opacity-50` = 0.5) pro mesmo conceito de "desabilitado", e nenhuma centralizada no componente.
 
 ## 8. Responsividade web: um único breakpoint hardcoded
 
-Não há uso de `sm:`/`md:`/`lg:` do Tailwind, nem `useWindowDimensions`, em nenhum arquivo do projeto. A única estratégia de responsividade é o literal `max-w-[640px]`, repetido (não extraído como token) em **8 arquivos**: `app/{index,history,admin,feedback,roadmap}.jsx`, `components/MyHistory.jsx`, `components/InstallApp.web.jsx`, `components/metrics/MetricScreen.jsx` (e variantes menores em `fields.jsx`/`registry.jsx` com `max-w-[160px]`/`max-w-[38px]`). Layout abaixo de 640px (mobile, que é o alvo principal) não tem nenhum ajuste dedicado — o app é o mesmo layout de coluna única esticando ou não até 640px.
+Não há uso de `sm:`/`md:`/`lg:` do Tailwind, nem `useWindowDimensions`, em nenhum arquivo do projeto. A única estratégia de responsividade é o literal `max-w-[640px]`, repetido (não extraído como token) em **8 arquivos**: `app/{index,history,admin,feedback,roadmap}.jsx`, `components/MyHistory.jsx`, `components/InstallApp.web.jsx`, `components/metrics/MetricScreen.jsx` (e variantes menores em `fields.jsx`/`registry.jsx` com `max-w-[160px]`/`max-w-[38px]`). Layout abaixo de 640px (mobile, que é o alvo principal) não tem nenhum ajuste dedicado: o app é o mesmo layout de coluna única esticando ou não até 640px.
 
 ## 9. Tela órfã sem estilo
 
-`app/export.jsx` é um placeholder puro (`<Text>Hello World!</Text>`, sem `MyView`/`MyHeader`/tema) — rota já registrada em `app/_layout.jsx:30` (título "Exportação"), esperando a feature do M8 ("Exportação/backup de dados"). Não é uma inconsistência de design em si, mas se alguém navegar até `/export` hoje, quebra a experiência visual (fundo branco fixo, sem safe-area, sem dark mode) em vez de simplesmente não existir. Fora do escopo do M5, mas vale registrar pra quem for implementar o M8.
+`app/export.jsx` é um placeholder puro (`<Text>Hello World!</Text>`, sem `MyView`/`MyHeader`/tema), com rota já registrada em `app/_layout.jsx:30` (título "Exportação"), esperando a feature do M8 ("Exportação/backup de dados"). Não é uma inconsistência de design em si, mas se alguém navegar até `/export` hoje, quebra a experiência visual (fundo branco fixo, sem safe-area, sem dark mode) em vez de simplesmente não existir. Fora do escopo do M5, mas vale registrar pra quem for implementar o M8.
 
 ## 10. Possível bug de layout: `Text` com `flex-row`
 
-`components/MyHistory.jsx:75` — `<Text className="w-full flex-row justify-between">` envolvendo dois `<Text>` filhos. Propriedades de flexbox (`flex-row`, `justify-between`) em RN só têm efeito em `View`, não em `Text` (que não é um container flex) — o alinhamento "nome à esquerda, nota à direita" pretendido pode não estar realmente acontecendo, e sim empilhando/fluindo como texto normal. Vale conferir visualmente no card de histórico.
+`components/MyHistory.jsx:75` traz `<Text className="w-full flex-row justify-between">` envolvendo dois `<Text>` filhos. Propriedades de flexbox (`flex-row`, `justify-between`) em RN só têm efeito em `View`, não em `Text` (que não é um container flex), então o alinhamento "nome à esquerda, nota à direita" pretendido pode estar empilhando e fluindo como texto normal em vez de alinhar. Vale conferir visualmente no card de histórico.
 
 ---
 
-## Resumo — o que isso alimenta nos próximos itens do M5
+## Resumo: o que isso alimenta nos próximos itens do M5
 
 - **Tokens canônicos:** decidir e centralizar raio (`md` vs `lg`), cor de borda/placeholder, cor de "erro"/"destrutivo", e resolver o `LABEL` duplicado com papéis diferentes (§3, §4).
 - **Componentizar:** `Card`/`CardLabel` de verdade em vez de string repetida em 6+ arquivos; estado `disabled` embutido no `MyButton` (§1, §7).
-- **Revisar `MyHeader`:** separar "chips de métrica" (só faz sentido nas 5 telas de registro) de um header de navegação genérico pras demais telas — e resolver a divergência `useColorScheme` (react-native vs nativewind) e o padding duplicado no grupo `(metrics)` (§5).
+- **Revisar `MyHeader`:** separar "chips de métrica" (só faz sentido nas 5 telas de registro) de um header de navegação genérico pras demais telas, e resolver a divergência `useColorScheme` (react-native vs nativewind) e o padding duplicado no grupo `(metrics)` (§5).
 - **Consertar o default de `MyView`:** `MyCheckbox` e `Score` devem passar `safe={false}` (§6).
 - **Web:** revisar o truque `font-size: 62.5%` (aplicado a `*`, não à raiz) e considerar breakpoints reais em vez do `max-w-[640px]` hardcoded repetido (§4, §8).
 - **Confirmar visualmente** (não dá pra provar só lendo código): borda invisível do `MyInput` no dark mode, alinhamento do `HistoryCard` (§10), padding extra nas telas de métrica (§5), e o efeito real do `font-size: 62.5%` no web (§4).
 
 ---
 
-## QA visual final (M5) — #189
+## QA visual final (M5), #189
 
 Passada sistemática de validação em cada tela, nos dois temas (claro/escuro) e nos dois layouts (mobile/web). Fecho oficial do milestone.
 
@@ -140,14 +140,14 @@ Passada sistemática de validação em cada tela, nos dois temas (claro/escuro) 
 
 Grep pelo repo depois de todas as fatias do M5:
 
-- **Bug real (corrigido inline no #189):** [`MyIconButton`](../components/MyButton.jsx#L57) usava `border border-[#333]` **sem `dark:` variant** — mesmo achado que resolvemos pro `MyInput` no #152, mas o `MyIconButton` foi esquecido. Provavelmente invisível no dark. Usado no `CounterField` da tela **Alimentação**. Fix aplicado: `dark:border-[#888]` (mesmo pattern do `MyInput`).
+- **Bug real (corrigido inline no #189):** [`MyIconButton`](../components/MyButton.jsx#L57) usava `border border-[#333]` **sem `dark:` variant**, mesmo achado que resolvemos pro `MyInput` no #152, mas o `MyIconButton` foi esquecido. Provavelmente invisível no dark. Usado no `CounterField` da tela **Alimentação**. Fix aplicado: `dark:border-[#888]` (mesmo pattern do `MyInput`).
 - **Hex crus documentados** (decisões conscientes, confirmar visualmente):
-  - `MyInput.jsx:30` — `placeholderTextColor="#888"` (mesmo em ambos os temas)
-  - `MyCheckbox.jsx:12` — `color={value ? Colors.primary : "gray"}` no unselected
-  - `InstallApp.web.jsx:60,64,65` — wrapper e cores do QR code (`bg-white` intencional, alto contraste)
-- **Dead code confirmado:** `MyButton.jsx:35` (`Icon size={24} color="#333"`) — nenhum call-site passa `Icon`; sem impacto visual, cabe follow-up de cleanup.
+  - `MyInput.jsx:30`: `placeholderTextColor="#888"` (mesmo em ambos os temas)
+  - `MyCheckbox.jsx:12`: `color={value ? Colors.primary : "gray"}` no unselected
+  - `InstallApp.web.jsx:60,64,65`: wrapper e cores do QR code (`bg-white` intencional, alto contraste)
+- **Dead code confirmado:** `MyButton.jsx:35` (`Icon size={24} color="#333"`): nenhum call-site passa `Icon`; sem impacto visual, cabe follow-up de cleanup.
 - **Stack native header** (Roadmap/Feedback/Admin): sem código local, é do Expo Router. Conferir fundo/título/back arrow em cada tema.
-- **Layout:** único breakpoint é `max-w-[640px]` — no desktop o card centraliza com espaço lateral vazio. Conferir se está aceitável.
+- **Layout:** único breakpoint é `max-w-[640px]`, e no desktop o card centraliza com espaço lateral vazio. Conferir se está aceitável.
 
 ### Checklist por tela
 
@@ -158,19 +158,19 @@ Rodar cada tela em:
 - ☀️ Claro
 - 🌙 Escuro (toggle via botão "Alternar tema" nos Utilitários da Home)
 
-| Tela            | Rota                  | Focar em                                                                                                                                       |
-| --------------- | --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Home**        | `/`                   | Card resumo, "MÉTRICAS DE HOJE", "UTILITÁRIOS", InstallApp (só web), wordmark do rodapé, versão/bundle                                         |
-| **Histórico**   | `/history`            | Nav de data (◀ ▶ + "Hoje"), estado vazio, `HistoryCard` (badge de nota, botões editar/excluir)                                                 |
-| **Água**        | `/(metrics)/water`    | Card outer, `MinMaxIdealField` (MIN/MAX/IDEAL), `QuantityField`, botão Salvar                                                                  |
-| **Sono**        | `/(metrics)/sleep`    | `MinMaxIdealField`, card interno de hora/minuto                                                                                                |
-| **Alimentação** | `/(metrics)/feeding`  | `CounterField` (⚠️ **MyIconButton borda invisível no dark**)                                                                                   |
-| **Exercício**   | `/(metrics)/exercise` | Checkboxes Treino/Cardio, card "Hora do treino", `DurationField`                                                                               |
-| **Estudo**      | `/(metrics)/study`    | Checkbox Feito, `DurationField`                                                                                                                |
-| **Roadmap**     | `/roadmap`            | Stack header nativo (título + back arrow), cards de progresso/atual/recentes                                                                   |
-| **Feedback**    | `/feedback`           | Stack header nativo, form (categoria, título, descrição), estado ok, estado error                                                              |
-| **Admin**       | `/admin` (deep link)  | Stack header nativo, form (nome, número), lista de testers, botão "Remover" em vermelho, "Exportar lista"                                      |
-| **Export**      | `/export`             | ⚠️ Placeholder sabidamente órfão (`<Text>Hello World!</Text>`) — sem estilo, sem safe-area, sem dark mode. §9 desta auditoria. Pertence ao M8. |
+| Tela            | Rota                  | Focar em                                                                                                                                      |
+| --------------- | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Home**        | `/`                   | Card resumo, "MÉTRICAS DE HOJE", "UTILITÁRIOS", InstallApp (só web), wordmark do rodapé, versão/bundle                                        |
+| **Histórico**   | `/history`            | Nav de data (◀ ▶ + "Hoje"), estado vazio, `HistoryCard` (badge de nota, botões editar/excluir)                                                |
+| **Água**        | `/(metrics)/water`    | Card outer, `MinMaxIdealField` (MIN/MAX/IDEAL), `QuantityField`, botão Salvar                                                                 |
+| **Sono**        | `/(metrics)/sleep`    | `MinMaxIdealField`, card interno de hora/minuto                                                                                               |
+| **Alimentação** | `/(metrics)/feeding`  | `CounterField` (⚠️ **MyIconButton borda invisível no dark**)                                                                                  |
+| **Exercício**   | `/(metrics)/exercise` | Checkboxes Treino/Cardio, card "Hora do treino", `DurationField`                                                                              |
+| **Estudo**      | `/(metrics)/study`    | Checkbox Feito, `DurationField`                                                                                                               |
+| **Roadmap**     | `/roadmap`            | Stack header nativo (título + back arrow), cards de progresso/atual/recentes                                                                  |
+| **Feedback**    | `/feedback`           | Stack header nativo, form (categoria, título, descrição), estado ok, estado error                                                             |
+| **Admin**       | `/admin` (deep link)  | Stack header nativo, form (nome, número), lista de testers, botão "Remover" em vermelho, "Exportar lista"                                     |
+| **Export**      | `/export`             | ⚠️ Placeholder sabidamente órfão (`<Text>Hello World!</Text>`): sem estilo, sem safe-area, sem dark mode. §9 desta auditoria. Pertence ao M8. |
 
 ### Onde entrar cada tipo de achado
 

--- a/docs/08-design-tokens.md
+++ b/docs/08-design-tokens.md
@@ -1,37 +1,37 @@
-# Design Tokens — Back on Track
+# Design Tokens do Back on Track
 
-> **Nota (M5-B, agosto 2026):** o redesign completo baseado no Turno 2 do Claude Design vive em [09-design-v2.md](09-design-v2.md). Este doc segue como baseline pra telas ainda não migradas — os dois convergem quando todas as fatias 1-6 do v2 estiverem em produção.
+> **Nota (M5-B, agosto 2026):** o redesign completo baseado no Turno 2 do Claude Design vive em [09-design-v2.md](09-design-v2.md). Este doc segue como baseline pra telas ainda não migradas, e os dois convergem quando todas as fatias 1-6 do v2 estiverem em produção.
 
-Referência viva do design system do M5. Cada seção fecha uma decisão sobre um **eixo** (raio, tipografia, espaçamento, cor…) e mostra onde ela vale. O objetivo é matar as escolhas ad-hoc que a auditoria pegou em [docs/07-auditoria-ui.md](07-auditoria-ui.md) — de forma que "qual valor uso aqui?" tenha uma resposta óbvia em cada eixo.
+Referência viva do design system do M5. Cada seção fecha uma decisão sobre um **eixo** (raio, tipografia, espaçamento, cor…) e mostra onde ela vale. O objetivo é matar as escolhas ad-hoc que a auditoria pegou em [docs/07-auditoria-ui.md](07-auditoria-ui.md), de forma que "qual valor uso aqui?" tenha uma resposta óbvia em cada eixo.
 
 O doc cresce em fatias: começa com raio (fatia 1); tipografia, espaçamento, sombra e cor entram conforme a milestone avança. Cada fatia deve ter um PR próprio e um item ✅ no roadmap.
 
 ---
 
-## Raio (`rounded-*`) — fatia 1
+## Raio (`rounded-*`), fatia 1
 
 **Regra:** três valores canônicos, um papel cada. Zero uso do `rounded` (default) ou de raio ad-hoc (`rounded-[Npx]`).
 
-| Token          | Papel                                     | Onde usar                                                              |
-| -------------- | ----------------------------------------- | ---------------------------------------------------------------------- |
-| `rounded-full` | Pills — o "elemento é circular / cápsula" | Botões, chips de métrica, badge de nota                                |
-| `rounded-lg`   | Cards — containers de conteúdo            | Card do topo das telas, `HistoryCard`, card do form da tela de métrica |
-| `rounded-md`   | Controles — inputs e caixas pequenas      | `MyInput`, inputs de duração/quantidade, inputs pequenos do `registry` |
+| Token          | Papel                                    | Onde usar                                                              |
+| -------------- | ---------------------------------------- | ---------------------------------------------------------------------- |
+| `rounded-full` | Pills: o "elemento é circular / cápsula" | Botões, chips de métrica, badge de nota                                |
+| `rounded-lg`   | Cards: containers de conteúdo            | Card do topo das telas, `HistoryCard`, card do form da tela de métrica |
+| `rounded-md`   | Controles: inputs e caixas pequenas      | `MyInput`, inputs de duração/quantidade, inputs pequenos do `registry` |
 
 ### Rationale
 
 - **Escolher pelo papel, não pelo tamanho.** Um card grande e um card pequeno usam o mesmo raio; um input grande e um input pequeno também. Assim `qual raio?` fica em função de `o que é isso?`, e a mudança futura de token (`rounded-lg` → `rounded-xl`, se um dia) muda tudo consistente.
 - **Três valores é o mínimo útil.** Menos que isso mata a diferença card × control (fica tudo uniforme, sem hierarquia visual); mais que isso volta ao problema de escolha ad-hoc.
-- **Alinha com o Tailwind default**, sem tokens custom no `tailwind.config.js` — barato de manter, sem camada de indireção.
+- **Alinha com o Tailwind default**, sem tokens custom no `tailwind.config.js`, barato de manter, sem camada de indireção.
 
 ### O que a fatia mudou (#154)
 
-- `MyInput.jsx` — `rounded` → `rounded-md` (mata o default órfão)
-- `MyHistory.jsx` `HistoryCard` — `rounded-md` → `rounded-lg` (é card, não control)
-- `fields.jsx` inputs de duração / MIN-MAX-IDEAL / QuantityField — `rounded-lg` → `rounded-md`
-- `registry.jsx` `INPUT_LG` — `rounded-lg` → `rounded-md`
+- `MyInput.jsx`: `rounded` → `rounded-md` (mata o default órfão)
+- `MyHistory.jsx` `HistoryCard`: `rounded-md` → `rounded-lg` (é card, não control)
+- `fields.jsx` inputs de duração / MIN-MAX-IDEAL / QuantityField: `rounded-lg` → `rounded-md`
+- `registry.jsx` `INPUT_LG`: `rounded-lg` → `rounded-md`
 
-Cards que já estavam em `rounded-lg` (as 6 telas topo-nível, `InstallApp.web`, `MetricScreen`, `fields.jsx` CARD, `registry.jsx` linhas 126/216) ficaram como estavam — eles já seguiam o token do papel deles.
+Cards que já estavam em `rounded-lg` (as 6 telas topo-nível, `InstallApp.web`, `MetricScreen`, `fields.jsx` CARD, `registry.jsx` linhas 126/216) ficaram como estavam, porque já seguiam o token do papel deles.
 
 ### Como validar
 
@@ -45,13 +45,13 @@ Deve retornar apenas `rounded-full`, `rounded-lg` e `rounded-md`.
 
 ### O que NÃO está resolvido aqui
 
-- **Card duplicado como string constante** em 6 telas (§1 da auditoria) — vem no item "Componentizar" do M5, não aqui.
-- **Tokens semânticos de cor**, incluindo o `bg-secondary` reciclado pra 3 papéis (§3.1) — vem numa fatia própria de cor.
-- **Escala tipográfica**, incluindo os `text-[26px]`/`text-[19px]` fora da escala e o truque `font-size: 62.5%` (§4) — fatia própria.
+- **Card duplicado como string constante** em 6 telas (§1 da auditoria): vem no item "Componentizar" do M5, não aqui.
+- **Tokens semânticos de cor**, incluindo o `bg-secondary` reciclado pra 3 papéis (§3.1), vem numa fatia própria de cor.
+- **Escala tipográfica**, incluindo os `text-[26px]`/`text-[19px]` fora da escala e o truque `font-size: 62.5%` (§4): fatia própria.
 
 ---
 
-## Tipografia (`text-*`) — fatia 2
+## Tipografia (`text-*`), fatia 2
 
 **Regra:** escala custom em `tailwind.config.js`, em px direto, ergonômica pra mobile. Zero uso de `text-[Npx]` (pixel cru fora da escala).
 
@@ -59,7 +59,7 @@ Deve retornar apenas `rounded-full`, `rounded-lg` e `rounded-md`.
 | ----------- | --- | -------------------------------------------------- | ------------------------------------------------------------------------------ |
 | `text-xs`   | 13  | Rótulo de seção (SECTION LABEL)                    | "MÉTRICAS DE HOJE", "UTILITÁRIOS", "HISTÓRICO"… nos cards das telas topo-nível |
 | `text-sm`   | 15  | Secondary                                          | Detalhe do item, texto de rodapé menor                                         |
-| `text-base` | 17  | Corpo — iOS body                                   | Linhas de métrica, item de histórico, input de observação, descrições          |
+| `text-base` | 17  | Corpo: iOS body                                    | Linhas de métrica, item de histórico, input de observação, descrições          |
 | `text-lg`   | 19  | Rótulo de campo (FIELD LABEL) e valores destacados | "MIN"/"MAX"/"IDEAL", "OBS:", "Nota", "Hora do treino", badge da nota           |
 | `text-xl`   | 22  | Subtitle                                           | reservado (sem uso ainda)                                                      |
 | `text-2xl`  | 28  | Título de card                                     | "Hoje", "Enviar feedback", "Testers", inputs grandes de métrica                |
@@ -67,17 +67,17 @@ Deve retornar apenas `rounded-full`, `rounded-lg` e `rounded-md`.
 ### Rationale
 
 - **Body = 17px alinha com o padrão iOS** (`system body` = 17pt) e sente confortável em web também. Tailwind default de 16px estava ficando apertado, sobretudo em telas maiores.
-- **Escala custom em px direto** — resolve a raiz do §4 da auditoria: o `font-size: 62.5%` mal aplicado tentava fazer `rem` virar "1 = 10px", mas comportamento não era previsível. Definindo em px, cortamos a dependência do `font-size` do html e do NativeWind gerar rem/px.
-- **Um valor por papel.** Nome do papel importa mais que o número — `LABEL` estava sendo usado com dois significados diferentes (rótulo de seção `text-xs opacity-60` × rótulo de campo `text-lg`) e a fatia adota `FIELD_LABEL` nos arquivos de métrica pra desambiguar. O `LABEL` das telas topo-nível fica como está até a fatia de componentização, quando vira `SectionLabel` como componente.
-- **Escala Tailwind, valores custom.** Manter os nomes canônicos (`text-xs`, `text-base`, `text-lg`, `text-2xl`) permite trocar valores num único arquivo (`tailwind.config.js`) sem caçar pixel cru pelo repo depois — decisão fica em um lugar só.
+- **Escala custom em px direto**: resolve a raiz do §4 da auditoria: o `font-size: 62.5%` mal aplicado tentava fazer `rem` virar "1 = 10px", mas comportamento não era previsível. Definindo em px, cortamos a dependência do `font-size` do html e do NativeWind gerar rem/px.
+- **Um valor por papel.** Nome do papel importa mais que o número: `LABEL` estava sendo usado com dois significados diferentes (rótulo de seção `text-xs opacity-60` × rótulo de campo `text-lg`) e a fatia adota `FIELD_LABEL` nos arquivos de métrica pra desambiguar. O `LABEL` das telas topo-nível fica como está até a fatia de componentização, quando vira `SectionLabel` como componente.
+- **Escala Tailwind, valores custom.** Manter os nomes canônicos (`text-xs`, `text-base`, `text-lg`, `text-2xl`) permite trocar valores num único arquivo (`tailwind.config.js`) sem caçar pixel cru pelo repo depois, com a decisão em um lugar só.
 
 ### O que a fatia mudou (#157)
 
-- `tailwind.config.js` — nova escala `fontSize` custom (xs 13, sm 15, base 17, lg 19, xl 22, 2xl 28) sobrescrevendo a default do Tailwind.
-- `global.css` — remove `font-size: 62.5%` aplicado em `*` (compunha por nível de aninhamento — §4 da auditoria).
-- `components/metrics/fields.jsx` (3×) e `components/metrics/registry.jsx` (1×) — `text-[26px]` → `text-2xl` (agora 28px).
-- `components/metrics/MetricScreen.jsx` — `text-[19px]` → `text-base` (17px) no `TextInput` de observação. Bate com o corpo, sem mais mismatch input/corpo.
-- `components/metrics/MetricScreen.jsx`, `components/metrics/fields.jsx`, `components/metrics/registry.jsx` — `LABEL` → `FIELD_LABEL`. Escopo local (constantes por arquivo), não afeta consumidores.
+- `tailwind.config.js`: nova escala `fontSize` custom (xs 13, sm 15, base 17, lg 19, xl 22, 2xl 28) sobrescrevendo a default do Tailwind.
+- `global.css`: remove `font-size: 62.5%` aplicado em `*` (compunha por nível de aninhamento, §4 da auditoria).
+- `components/metrics/fields.jsx` (3×) e `components/metrics/registry.jsx` (1×): `text-[26px]` → `text-2xl` (agora 28px).
+- `components/metrics/MetricScreen.jsx`: `text-[19px]` → `text-base` (17px) no `TextInput` de observação. Bate com o corpo, sem mais mismatch input/corpo.
+- `components/metrics/MetricScreen.jsx`, `components/metrics/fields.jsx`, `components/metrics/registry.jsx`: `LABEL` → `FIELD_LABEL`. Escopo local (constantes por arquivo), não afeta consumidores.
 
 ### Como validar
 
@@ -89,35 +89,35 @@ git grep -nE 'text-\[[0-9]+px\]' -- '*.jsx' '*.js' '*.css'
 
 Deve retornar vazio.
 
-Ajustar a escala depois: só editar `theme.extend.fontSize` no `tailwind.config.js` — todo o repo herda o novo valor.
+Ajustar a escala depois: só editar `theme.extend.fontSize` no `tailwind.config.js`, e todo o repo herda o novo valor.
 
 ### O que NÃO está resolvido aqui
 
-- **Constante `LABEL` das telas topo-nível** (6 arquivos, mesma string byte a byte) — vai virar `SectionLabel` na fatia de componentização, junto com `CardLabel`/`Card` (§1 da auditoria).
-- **Peso e altura de linha** (`font-bold`, `leading-*`) — hoje `font-bold` é aplicado direto onde aparece; se um dia virar decisão de token, fica pra fatia própria.
+- **Constante `LABEL` das telas topo-nível** (6 arquivos, mesma string byte a byte): vai virar `SectionLabel` na fatia de componentização, junto com `CardLabel`/`Card` (§1 da auditoria).
+- **Peso e altura de linha** (`font-bold`, `leading-*`): hoje `font-bold` é aplicado direto onde aparece; se um dia virar decisão de token, fica pra fatia própria.
 
 ---
 
-## Espaçamento (`gap-*` / `p-*`) — fatia 3
+## Espaçamento (`gap-*` / `p-*`), fatia 3
 
 **Regra:** escala default do Tailwind (grid de 4px), zero fracionários. Um valor por papel.
 
-| Token | px  | Papel                                                                 |
-| ----- | --- | --------------------------------------------------------------------- |
-| `-1`  | 4   | tight — só quando `-2` sente exagerado (raro)                         |
-| `-2`  | 8   | dense — itens adjacentes numa linha (checkbox + label, ícone + texto) |
-| `-3`  | 12  | medium — cards compactos, gap entre itens numa lista                  |
-| `-4`  | 16  | comfortable — padding padrão de card, gap entre linhas de seção       |
-| `-6`  | 24  | spacious — reservado; sem uso hoje, disponível se aparecer o degrau   |
-| `-8`  | 32  | big — separação vertical entre seções grandes de form                 |
+| Token | px  | Papel                                                                |
+| ----- | --- | -------------------------------------------------------------------- |
+| `-1`  | 4   | tight: só quando `-2` sente exagerado (raro)                         |
+| `-2`  | 8   | dense: itens adjacentes numa linha (checkbox + label, ícone + texto) |
+| `-3`  | 12  | medium: cards compactos, gap entre itens numa lista                  |
+| `-4`  | 16  | comfortable: padding padrão de card, gap entre linhas de seção       |
+| `-6`  | 24  | spacious: reservado; sem uso hoje, disponível se aparecer o degrau   |
+| `-8`  | 32  | big: separação vertical entre seções grandes de form                 |
 
-Serve pra `gap-*` (entre filhos) e `p-*` (dentro do container). `gap-*` e `p-*` **usam a mesma escala** — se dois cards vizinhos estão com padding `p-3` e o espaço entre eles é `gap-3`, o ritmo visual fecha.
+Serve pra `gap-*` (entre filhos) e `p-*` (dentro do container). `gap-*` e `p-*` **usam a mesma escala**: se dois cards vizinhos estão com padding `p-3` e o espaço entre eles é `gap-3`, o ritmo visual fecha.
 
 ### Rationale
 
 - **Grid de 4px é padrão de mercado** (iOS 8pt/4pt subgrid, Material 4dp/8dp). Todo múltiplo de 4 fica alinhado a qualquer coisa que a plataforma render em cima; múltiplos de 2 (`gap-1.5`, `gap-2.5`) quebram esse alinhamento sem ganhar nada.
-- **Escala do Tailwind default já é o grid** — `-1`/`-2`/`-3`/`-4`/`-6`/`-8` mapeiam pra 4/8/12/16/24/32px. Não vale customizar em `tailwind.config.js` como fizemos com tipografia; aqui a default já é a decisão.
-- **Um valor por papel.** A auditoria pegou `p-4`/`p-2.5`/`gap-8`/`gap-2.5` misturados sem critério — a diferença entre `p-3` (12px) e `p-2.5` (10px) não é uma decisão de design, é um pixel arbitrário.
+- **Escala do Tailwind default já é o grid**: `-1`/`-2`/`-3`/`-4`/`-6`/`-8` mapeiam pra 4/8/12/16/24/32px. Não vale customizar em `tailwind.config.js` como fizemos com tipografia; aqui a default já é a decisão.
+- **Um valor por papel.** A auditoria pegou `p-4`/`p-2.5`/`gap-8`/`gap-2.5` misturados sem critério, e a diferença entre `p-3` (12px) e `p-2.5` (10px) é um pixel arbitrário, sem decisão de design por trás.
 
 ### O que a fatia mudou (#160)
 
@@ -125,13 +125,13 @@ Substituições em ~10 arquivos (`app/*.jsx`, `components/*.jsx`, `components/me
 
 - `gap-1.5` → `gap-2` (6×)
 - `gap-2.5` → `gap-3` (5×)
-- `gap-5` → `gap-4` (1×, CounterField — único off-grid)
+- `gap-5` → `gap-4` (1×, CounterField, único off-grid)
 - `p-1.5` → `p-2` (5×)
 - `p-2.5` → `p-3` (6×)
 
 Efeito visual: +2px na maioria dos casos (imperceptível), -4px no CounterField.
 
-Nada muda no `tailwind.config.js` — a decisão é usar a escala default como-é. O `px-*`/`py-*` assimétrico de botões e inputs (`px-2 py-1`, `px-4 py-2`) fica como está — a assimetria horizontal/vertical é intencional pra esse tipo de controle.
+Nada muda no `tailwind.config.js`: a decisão é usar a escala default como-é. O `px-*`/`py-*` assimétrico de botões e inputs (`px-2 py-1`, `px-4 py-2`) fica como está, porque a assimetria horizontal/vertical é intencional pra esse tipo de controle.
 
 ### Como validar
 
@@ -145,12 +145,12 @@ Deve retornar vazio.
 
 ### O que NÃO está resolvido aqui
 
-- **`px-*`/`py-*` de botões/inputs** — hoje `MyButton` usa `px-4 py-2`, `MyInput` usa `px-2 py-1`. São decisões de forma do controle, não de layout — ficam pra fatia de componentização, quando componentes ganharem forma canônica.
-- **Marginação por classe** (`mx-`, `my-`, `mt-`, `mb-`) — o repo mal usa margin (o layout é quase todo `gap-*` em flex). Se aparecer, cai na mesma escala.
+- **`px-*`/`py-*` de botões/inputs**: hoje `MyButton` usa `px-4 py-2`, `MyInput` usa `px-2 py-1`. São decisões de forma do controle, não de layout, então ficam pra fatia de componentização, quando componentes ganharem forma canônica.
+- **Marginação por classe** (`mx-`, `my-`, `mt-`, `mb-`): o repo mal usa margin (o layout é quase todo `gap-*` em flex). Se aparecer, cai na mesma escala.
 
 ---
 
-## Sombra (`shadow`) — fatia 4
+## Sombra (`shadow`), fatia 4
 
 **Regra:** um único nível de elevação, aplicado por `style`. Não há hierarquia de sombra hoje.
 
@@ -164,17 +164,17 @@ Uso: `style={shadow}` ou `style={[shadow, otherStyle]}`.
 
 1. **Top-level card** (direto no `ScrollView`, topo do conteúdo da tela) → aplica `shadow`.
 2. **Nested card** (dentro de outro card, tipo `DurationField` dentro do form) → **sem** shadow. Evita dupla elevação.
-3. **Controle** (`MyButton`, `MyIconButton`) → shadow embutido no componente — quem usa não precisa lembrar.
+3. **Controle** (`MyButton`, `MyIconButton`) → shadow embutido no componente, e quem usa não precisa lembrar.
 
 ### Rationale
 
-- **Um nível é o mínimo útil hoje.** O app não tem modal, dropdown, popover ou drawer flutuante — o único plano acima do fundo é "card + botão". Adicionar níveis (ex: `shadow-sm`, `shadow-lg`) só ganha valor quando houver hierarquia visual pedindo.
-- **Objeto RN, não Tailwind class.** `shadow-*` do Tailwind gera `box-shadow` CSS — no web funciona, no native o NativeWind traduz mas com semântica diferente (elevation Android vs shadowX iOS). Manter em objeto RN é explícito e portável entre plataformas.
+- **Um nível é o mínimo útil hoje.** O app não tem modal, dropdown, popover ou drawer flutuante: o único plano acima do fundo é "card + botão". Adicionar níveis (ex: `shadow-sm`, `shadow-lg`) só ganha valor quando houver hierarquia visual pedindo.
+- **Objeto RN, não Tailwind class.** `shadow-*` do Tailwind gera `box-shadow` CSS: no web funciona, no native o NativeWind traduz mas com semântica diferente (elevation Android vs shadowX iOS). Manter em objeto RN é explícito e portável entre plataformas.
 - **`style={shadow}` como pattern.** Consistente com `Snackbar`/inputs que já usam `style` inline pra props RN puras.
 
 ### O que a fatia mudou (#163)
 
-- `components/metrics/MetricScreen.jsx` — adiciona `import { shadow }` e aplica `style={shadow}` no card top-level do form. Alinha com as 6 telas topo-nível que já tinham (index, history, admin, feedback, roadmap, InstallApp.web). Miss de quando `MetricScreen` foi montado (M2, #80).
+- `components/metrics/MetricScreen.jsx`: adiciona `import { shadow }` e aplica `style={shadow}` no card top-level do form. Alinha com as 6 telas topo-nível que já tinham (index, history, admin, feedback, roadmap, InstallApp.web). Miss de quando `MetricScreen` foi montado (M2, #80).
 
 ### Como validar
 
@@ -184,26 +184,26 @@ Todos os cards top-level do repo têm `style={shadow}`:
 git grep -B1 -A2 '${CARD}\|max-w-\[640px\].*rounded-lg' -- '*.jsx'
 ```
 
-Deve mostrar `style={shadow}` acompanhando cada card top-level (com exceção dos cards nested como `DurationField` — regra 2).
+Deve mostrar `style={shadow}` acompanhando cada card top-level (com exceção dos cards nested como `DurationField`, regra 2).
 
 ### O que NÃO está resolvido aqui
 
-- **Migrar pra `tailwind.config.js` `boxShadow`** — requer validar NativeWind renderizando igual em native (elevation/shadowX). Fora de escopo; hoje o objeto RN é a fonte da verdade.
-- **Segundo nível de elevação** (`shadow-lg` pra modal, `shadow-sm` pra chip) — só faz sentido quando o app ganhar esses componentes; fatia própria.
+- **Migrar pra `tailwind.config.js` `boxShadow`**: requer validar NativeWind renderizando igual em native (elevation/shadowX). Fora de escopo; hoje o objeto RN é a fonte da verdade.
+- **Segundo nível de elevação** (`shadow-lg` pra modal, `shadow-sm` pra chip), só faz sentido quando o app ganhar esses componentes; fatia própria.
 
 ---
 
-## Cor (`bg-*` / `text-*`) — fatia 5
+## Cor (`bg-*` / `text-*`), fatia 5
 
 **Regra:** paleta base em `constants/Colors.js`, exposta em `tailwind.config.js`. Um token por papel semântico. Zero uso da paleta Tailwind default pra sinal (`text-red-*`, `bg-green-*`, etc).
 
 ### Paleta base
 
-| Token       | Valor     | Papel                                                            |
-| ----------- | --------- | ---------------------------------------------------------------- |
-| `primary`   | `#2E5A88` | Botão padrão, elementos-chave da marca                           |
-| `secondary` | `#4CAF50` | Selecionado/ativo/positivo (verde da marca — Material green-500) |
-| `danger`    | `#F44336` | Ação destrutiva ou erro visível (Material red-500)               |
+| Token       | Valor     | Papel                                                           |
+| ----------- | --------- | --------------------------------------------------------------- |
+| `primary`   | `#2E5A88` | Botão padrão, elementos-chave da marca                          |
+| `secondary` | `#4CAF50` | Selecionado/ativo/positivo (verde da marca, Material green-500) |
+| `danger`    | `#F44336` | Ação destrutiva ou erro visível (Material red-500)              |
 
 ### Tokens de superfície (por tema)
 
@@ -218,24 +218,24 @@ Continuam em `Colors.light` / `Colors.dark`, expostos como `light-*` / `dark-*` 
 
 ### Regras semânticas
 
-- `bg-primary` — botão padrão (marca).
-- `bg-secondary` — selecionado, ativo, nota máxima, progresso positivo. É o verde da marca; mesmo papel visual serve os 4 usos.
-- `bg-danger` / `text-danger` — só onde é **destrutivo** (excluir/remover) ou **erro** visível ao usuário.
+- `bg-primary`: botão padrão (marca).
+- `bg-secondary`: selecionado, ativo, nota máxima, progresso positivo. É o verde da marca; mesmo papel visual serve os 4 usos.
+- `bg-danger` / `text-danger`: só onde é **destrutivo** (excluir/remover) ou **erro** visível ao usuário.
 
-Nunca reciclar um token pra um papel diferente do declarado. Se um novo papel semântico aparecer (`warning`, `info`), ele ganha token próprio — não pega carona no `secondary`.
+Nunca reciclar um token pra um papel diferente do declarado. Se um novo papel semântico aparecer (`warning`, `info`), ele ganha token próprio, sem pegar carona no `secondary`.
 
 ### Rationale
 
 - **Nome do papel importa mais que a cor.** A auditoria pegou `bg-secondary` sendo usado com 3 significados diferentes: chip selecionado, badge de nota máxima, e botão "Remover" tester (§3.1). Os dois primeiros compartilham "positivo/verde-da-marca"; o "Remover" é destrutivo e precisa de cor própria.
-- **Material green-500 + Material red-500** — o `secondary` já era Material green-500 (`#4CAF50`), então o `danger` como Material red-500 (`#F44336`) casa em saturação e peso visual, sem precisar reafinar o `secondary`.
-- **Não temos `success`, `warning`, `info` — de propósito.** O app não tem sinal semântico que exija cores próprias hoje. Se surgir, entra em fatia própria com token semântico próprio, sem sobrescrever nenhum existente.
+- **Material green-500 + Material red-500**: o `secondary` já era Material green-500 (`#4CAF50`), então o `danger` como Material red-500 (`#F44336`) casa em saturação e peso visual, sem precisar reafinar o `secondary`.
+- **Não temos `success`, `warning`, `info`, de propósito.** O app não tem sinal semântico que exija cores próprias hoje. Se surgir, entra em fatia própria com token semântico próprio, sem sobrescrever nenhum existente.
 
 ### O que a fatia mudou (#166)
 
-- `constants/Colors.js` — adiciona `Colors.danger = "#F44336"` no topo (paralelo a `primary` e `secondary`).
-- `tailwind.config.js` — expõe `danger: Colors.danger` no `colors.extend`.
-- `app/admin.jsx` — botão "Remover" tester: `bg-secondary` → `bg-danger`. O fix real: hoje o "Remover" tá verde, mesma cor do "está selecionado".
-- `app/feedback.jsx` — mensagem de erro do submit: `text-red-500` → `text-danger`. Traz o único uso da paleta Tailwind default pra dentro do sistema.
+- `constants/Colors.js`: adiciona `Colors.danger = "#F44336"` no topo (paralelo a `primary` e `secondary`).
+- `tailwind.config.js`: expõe `danger: Colors.danger` no `colors.extend`.
+- `app/admin.jsx`: botão "Remover" tester: `bg-secondary` → `bg-danger`. O fix real: hoje o "Remover" tá verde, mesma cor do "está selecionado".
+- `app/feedback.jsx`: mensagem de erro do submit: `text-red-500` → `text-danger`. Traz o único uso da paleta Tailwind default pra dentro do sistema.
 
 ### Como validar
 
@@ -249,18 +249,18 @@ Deve retornar vazio.
 
 ### O que NÃO está resolvido aqui
 
-- **Cor de borda** (`border-[#333]` / `dark:border-[#888]` inline em `MyInput` e `MyIconButton`) — funciona nos dois temas depois do fix funcional (#153). Virar token exigiria redesenho de `MyInput`/`MyIconButton` (props ou variantes); fatia própria se aparecer segunda cor de borda semântica.
-- **Cor de placeholder** (`placeholderTextColor="#888"` em `MyInput`) — hex cru mas funcional em ambos os temas. Vira token quando componentizarmos `MyInput`.
-- **Ícone hex fixo** (`color="#333"` em `MyButton`) — cosmético, sem trigger claro.
-- **Cor de ripple** (`android_ripple={{ color: "#00000022" }}`) — detalhe de plataforma Android, não vira token.
+- **Cor de borda** (`border-[#333]` / `dark:border-[#888]` inline em `MyInput` e `MyIconButton`): funciona nos dois temas depois do fix funcional (#153). Virar token exigiria redesenho de `MyInput`/`MyIconButton` (props ou variantes); fatia própria se aparecer segunda cor de borda semântica.
+- **Cor de placeholder** (`placeholderTextColor="#888"` em `MyInput`): hex cru mas funcional em ambos os temas. Vira token quando componentizarmos `MyInput`.
+- **Ícone hex fixo** (`color="#333"` em `MyButton`): cosmético, sem trigger claro.
+- **Cor de ripple** (`android_ripple={{ color: "#00000022" }}`): detalhe de plataforma Android, e não vira token.
 
 ---
 
 ## Componentes derivados dos tokens
 
-Não são tokens em si; são **componentes-base** que juntam vários tokens num único uso comum. Ficam em `components/*.jsx` e servem pra três coisas: (a) matar a duplicação byte a byte que a auditoria (§1, §4) pegou; (b) transformar a decisão "qual token nesse papel?" em "importa o componente certo"; (c) barrar drift — mexer no token muda todo o app, não só o arquivo aberto.
+Não são tokens em si; são **componentes-base** que juntam vários tokens num único uso comum. Ficam em `components/*.jsx` e servem pra três coisas: (a) matar a duplicação byte a byte que a auditoria (§1, §4) pegou; (b) transformar a decisão "qual token nesse papel?" em "importa o componente certo"; (c) barrar drift: mexer no token muda todo o app, e não só o arquivo aberto.
 
-### `Card` — [components/Card.jsx](../components/Card.jsx)
+### `Card`: [components/Card.jsx](../components/Card.jsx)
 
 Container top-level das telas topo-nível. Composição:
 
@@ -273,9 +273,9 @@ Container top-level das telas topo-nível. Composição:
 
 Aceita `className` (pra `gap-N` interno) e `style` (mesclado com `shadow`). Também é o card outer do form de métrica (`MetricScreen`), que passa `cardClass` custom (ex.: `overflow-hidden` pra alimentação) via `className`.
 
-**Cards nested** (dentro de outro `Card` — o form de métrica é o único caso hoje): usam a mesma superfície + raio, mas sem shadow (regra 2 da fatia sombra: evita dupla elevação) e **sempre com `w-full`** — assim o filho estica pra largura do outer e o ritmo visual fecha entre as 5 telas de métrica. Não são componentizados porque ainda são poucos e a composição interna varia (input + label × card com múltiplos inputs); se aparecerem 3+ variantes iguais, vira `<CardNested>`.
+**Cards nested** (dentro de outro `Card`, e o form de métrica é o único caso hoje): usam a mesma superfície + raio, mas sem shadow (regra 2 da fatia sombra: evita dupla elevação) e **sempre com `w-full`**, assim o filho estica pra largura do outer e o ritmo visual fecha entre as 5 telas de métrica. Não são componentizados porque ainda são poucos e a composição interna varia (input + label × card com múltiplos inputs); se aparecerem 3+ variantes iguais, vira `<CardNested>`.
 
-### `SectionLabel` — [components/SectionLabel.jsx](../components/SectionLabel.jsx)
+### `SectionLabel`: [components/SectionLabel.jsx](../components/SectionLabel.jsx)
 
 Rótulo de seção dentro de card. Composição:
 
@@ -285,7 +285,7 @@ Rótulo de seção dentro de card. Composição:
 
 Uso: "MÉTRICAS DE HOJE", "UTILITÁRIOS", "HISTÓRICO", "CATEGORIA (OPCIONAL)"…
 
-### `MyHeader` — [components/MyHeader.jsx](../components/MyHeader.jsx)
+### `MyHeader`: [components/MyHeader.jsx](../components/MyHeader.jsx)
 
 Faixa horizontal de **chips das 5 métricas** (água, sono, alimentação, exercício, estudo). Clicar num chip navega pra tela de registro daquela métrica; clicar num chip já selecionado volta pra Home.
 
@@ -293,23 +293,23 @@ Faixa horizontal de **chips das 5 métricas** (água, sono, alimentação, exerc
 
 **Onde usar:**
 
-- `app/index.jsx` (Home — hub de acesso rápido)
+- `app/index.jsx` (Home: hub de acesso rápido)
 - `app/history.jsx` (do histórico se pula direto pra registrar)
 - `components/metrics/MetricScreen.jsx` (switch entre métricas)
 
 **Onde NÃO usar** (chips seriam ruído sem contexto):
 
-- `app/admin.jsx`, `app/feedback.jsx`, `app/roadmap.jsx` — essas telas ativam o header nativo do Expo Router (`headerShown: true` na `Stack.Screen` do `app/_layout.jsx`) que fornece título + back arrow.
+- `app/admin.jsx`, `app/feedback.jsx`, `app/roadmap.jsx`: essas telas ativam o header nativo do Expo Router (`headerShown: true` na `Stack.Screen` do `app/_layout.jsx`) que fornece título + back arrow.
 
-**Altura travada em três camadas:** o `ScrollView` horizontal usa `h-16 shrink-0` (64px, não cede) e o chip usa `h-10` (40px) — os dois casam com o `p-3` (24px) vertical do ScrollView (`64 - 24 = 40`). Sem essas fixações, três bugs visuais aconteciam:
+**Altura travada em três camadas:** o `ScrollView` horizontal usa `h-16 shrink-0` (64px, não cede) e o chip usa `h-10` (40px), e os dois casam com o `p-3` (24px) vertical do ScrollView (`64 - 24 = 40`). Sem essas fixações, três bugs visuais aconteciam:
 
 - Sem `h-16` no ScrollView, a faixa herdava a altura intrínseca dos filhos e reflowava a cada re-render/`router.navigate`, esticando visualmente durante a transição de rota.
-- Sem `h-10` no chip, o RN Web re-media o `Pressable` ao trocar `bg-primary ↔ bg-secondary` e o chip piscava de tamanho a cada seleção — mesmo sem qualquer mudança de padding/tipografia.
+- Sem `h-10` no chip, o RN Web re-media o `Pressable` ao trocar `bg-primary ↔ bg-secondary` e o chip piscava de tamanho a cada seleção, mesmo sem qualquer mudança de padding/tipografia.
 - Sem `shrink-0` no ScrollView, telas com muito conteúdo (Home) espremiam o header via `flex-shrink: 1` default do flex column pai, e o padding do primeiro card visualmente invadia a área dos chips. Formulários curtos (MetricScreen) não expunham o bug.
 
 Se um dia mudar o padding do ScrollView ou a tipografia do chip, revisitar os três juntos.
 
-### `FieldLabel` — [components/FieldLabel.jsx](../components/FieldLabel.jsx)
+### `FieldLabel`: [components/FieldLabel.jsx](../components/FieldLabel.jsx)
 
 Rótulo de campo de formulário. Composição:
 
@@ -322,20 +322,20 @@ Uso: "MIN"/"MAX"/"IDEAL", "OBS:", "Nota", "Hora do treino", `h`/`min` de duraç�
 ### O que a fatia mudou (#169)
 
 - Cria `components/Card.jsx`, `components/SectionLabel.jsx`, `components/FieldLabel.jsx`.
-- Migra 6 telas topo-nível — `app/{index,history,admin,feedback,roadmap}.jsx` e `components/InstallApp.web.jsx` — pra usar `Card` + `SectionLabel`. Remove os constantes locais `CARD` e `LABEL` (que estavam byte a byte iguais em cada arquivo).
+- Migra 6 telas topo-nível (`app/{index,history,admin,feedback,roadmap}.jsx` e `components/InstallApp.web.jsx`) pra usar `Card` + `SectionLabel`. Remove os constantes locais `CARD` e `LABEL` (que estavam byte a byte iguais em cada arquivo).
 - Migra `components/metrics/{MetricScreen,fields,registry}.jsx` pra usar `FieldLabel`. Remove os constantes locais `FIELD_LABEL`.
 
 ### O que NÃO está resolvido aqui
 
-- **Card do form de métrica** (`MetricScreen.jsx:100`) + cards nested em `fields.jsx` e `registry.jsx` — largura, padding e estrutura diferentes; casam com o follow-up "padronizar largura dos forms de métrica" e viram fatia própria.
-- **`HistoryCard`** — já é componente próprio com estrutura interna própria (badge de nota, botões editar/excluir, exercício); segue como está.
-- **Revisar `MyHeader`** (papel de navegação vs. chips) — item próprio do M5.
+- **Card do form de métrica** (`MetricScreen.jsx:100`) + cards nested em `fields.jsx` e `registry.jsx`, com largura, padding e estrutura diferentes; casam com o follow-up "padronizar largura dos forms de métrica" e viram fatia própria.
+- **`HistoryCard`**: já é componente próprio com estrutura interna própria (badge de nota, botões editar/excluir, exercício); segue como está.
+- **Revisar `MyHeader`** (papel de navegação vs. chips): item próprio do M5.
 
 ## Estados canônicos
 
-Contratos de estado embutidos nos componentes-base — o consumidor passa a **intenção** (`disabled`, `isSelected`, etc.), não a implementação visual.
+Contratos de estado embutidos nos componentes-base: o consumidor passa a **intenção** (`disabled`, `isSelected`, etc.), não a implementação visual.
 
-### `disabled` — [`MyButton`](../components/MyButton.jsx) / `MyIconButton`
+### `disabled`: [`MyButton`](../components/MyButton.jsx) / `MyIconButton`
 
 - **Prop:** `disabled` (boolean, default `false`).
 - **Visual:** aplica `opacity-40` internamente.
@@ -347,18 +347,18 @@ Uso:
 <MyButton title="Enviar" onPress={send} disabled={!canSend} />
 ```
 
-Rationale: `opacity-40` (0.4) alinha com convenção iOS e resolve §7 da auditoria — antes cada tela reinventava (`0.4` vs `opacity-50`), com o visual e o bloqueio de `onPress` desconectados. Agora é um contrato só.
+Rationale: `opacity-40` (0.4) alinha com convenção iOS e resolve §7 da auditoria, porque antes cada tela reinventava (`0.4` vs `opacity-50`), com o visual e o bloqueio de `onPress` desconectados. Agora é um contrato só.
 
 ---
 
 ## Identidade visual
 
-O sistema até aqui é técnico (tokens de raio, tipografia, cor por papel). Esta seção fecha a parte **de marca**: nome, tagline, metáfora, tom de voz — e como esses tokens já são também escolhas de identidade.
+O sistema até aqui é técnico (tokens de raio, tipografia, cor por papel). Esta seção fecha a parte **de marca**: nome, tagline, metáfora, tom de voz, e como esses tokens já são também escolhas de identidade.
 
 ### Nome e slug
 
-- **Nome (display):** "Back on Track" — o que aparece no launcher/browser tab, no wordmark da UI, na documentação e na comunicação com testers.
-- **Slug técnico:** `backOnTrack` — identificador interno do Expo/EAS (`app.json`, `bundleIdentifier`, `package`, `projectId`). **Não mexer** — mudar quebra deploy/OTA/store.
+- **Nome (display):** "Back on Track": o que aparece no launcher/browser tab, no wordmark da UI, na documentação e na comunicação com testers.
+- **Slug técnico:** `backOnTrack`, identificador interno do Expo/EAS (`app.json`, `bundleIdentifier`, `package`, `projectId`). **Não mexer**: mudar quebra deploy/OTA/store.
 
 ### Tagline
 
@@ -368,42 +368,42 @@ A promessa é a **retomada**: o app é pra quem já saiu da rotina e quer voltar
 
 ### Metáfora
 
-**Trilhos, estrada, sinalização de trânsito.** O nome sugere caminho de volta; `assets/trecho-em-obras.png` (placa laranja de "trecho em obras") já sinaliza a direção. Qualquer ilustração/ícone/motivo gráfico futuro deve conversar com esse universo — sem forçar (não precisa de trilhos literais em tudo).
+**Trilhos, estrada, sinalização de trânsito.** O nome sugere caminho de volta; `assets/trecho-em-obras.png` (placa laranja de "trecho em obras") já sinaliza a direção. Qualquer ilustração/ícone/motivo gráfico futuro deve conversar com esse universo, sem forçar (não precisa de trilhos literais em tudo).
 
 ### Tom de voz
 
 - **Gentileza da retomada**, não exigência. "Registrado", "hoje", "métricas do dia". Nunca "meta cumprida", "falhou", "streak quebrado".
-- Verbos no infinitivo pra ação do usuário ("Alternar tema", "Limpar todos os dados", "Enviar feedback") — não imperativo pesado ("ALTERE TUDO").
+- Verbos no infinitivo pra ação do usuário ("Alternar tema", "Limpar todos os dados", "Enviar feedback"), sem imperativo pesado ("ALTERE TUDO").
 - Erro é conversado, não julgado: "Não consegui enviar (…). Tenta de novo em instantes." (feedback.jsx).
 
 ### Paleta como marca
 
 Os tokens de cor já são decisões semânticas ([seção Cor](#cor-bg--text----fatia-5)); ganham aqui também um significado de identidade:
 
-| Token       | Hex       | Marca                                                            |
-| ----------- | --------- | ---------------------------------------------------------------- |
-| `primary`   | `#2E5A88` | Navy da **confiança/estabilidade** — o "chão firme" da retomada  |
-| `secondary` | `#4CAF50` | Verde da **retomada positiva** — selecionado, ativo, nota máxima |
-| `danger`    | `#F44336` | Vermelho da **exceção** — só destrutivo/erro, reservado          |
+| Token       | Hex       | Marca                                                           |
+| ----------- | --------- | --------------------------------------------------------------- |
+| `primary`   | `#2E5A88` | Navy da **confiança/estabilidade**, o "chão firme" da retomada  |
+| `secondary` | `#4CAF50` | Verde da **retomada positiva**: selecionado, ativo, nota máxima |
+| `danger`    | `#F44336` | Vermelho da **exceção**: só destrutivo/erro, reservado          |
 
-Superfícies (`light-background`, `dark-background`) são neutras por design — o protagonismo visual fica pros dados, não pra decoração.
+Superfícies (`light-background`, `dark-background`) são neutras por design, e o protagonismo visual fica pros dados, não pra decoração.
 
 ### Onde a marca aparece na UI
 
 - Launcher / browser tab: nome "Back on Track" (`app.json`)
-- Splash: fundo `#F8F9FA` (mesmo do app light) + splash-icon (Parte B — placeholder do Expo hoje)
+- Splash: fundo `#F8F9FA` (mesmo do app light) + splash-icon (Parte B, placeholder do Expo hoje)
 - **Home:** wordmark discreto no rodapé da tela ("Back on Track · de volta aos trilhos, um registro por vez"), abaixo do card Utilitários
 - **Roadmap:** título + tagline no primeiro card ("Back on Track" + "De volta aos trilhos, um registro por vez.")
 
-### Parte B — entregue (#228)
+### Parte B: entregue (#228)
 
 Assets visuais substituídos por design real. Direção **1c · Linha que sobe** do projeto no Claude Design (`Back on Track - Icon Directions`, ID `4565395c-...`), escolhida entre 3 propostas por melhor traduzir o tom "retomada, não conquista": curva suave subindo + ponto verde ancorando o início (o "aqui, hoje"). Sem seta, sem streak, sem literalismo de trilho.
 
-- `assets/icon.png` — 1024×1024, fundo navy (`#2E5A88`) + curva branca (`#F8F9FA`) + ponto verde (`#4CAF50`). Launcher iOS/Android legacy.
-- `assets/adaptive-icon.png` — 1024×1024, símbolo navy sobre transparência. Android compõe com `adaptiveIcon.backgroundColor` (`#F8F9FA`).
-- `assets/splash-icon.png` — 1024×1024, símbolo navy sobre transparência. Centralizado sobre `splash.backgroundColor` (`#F8F9FA`).
-- `assets/favicon.png` — 96×96, fundo navy + curva branca (contraste alto no browser tab pequeno).
+- `assets/icon.png`: 1024×1024, fundo navy (`#2E5A88`) + curva branca (`#F8F9FA`) + ponto verde (`#4CAF50`). Launcher iOS/Android legacy.
+- `assets/adaptive-icon.png`: 1024×1024, símbolo navy sobre transparência. Android compõe com `adaptiveIcon.backgroundColor` (`#F8F9FA`).
+- `assets/splash-icon.png`: 1024×1024, símbolo navy sobre transparência. Centralizado sobre `splash.backgroundColor` (`#F8F9FA`).
+- `assets/favicon.png`: 96×96, fundo navy + curva branca (contraste alto no browser tab pequeno).
 
-**SVGs source** vivem em `assets/source/` — re-export via `./scripts/build-icons.sh` (ImageMagick). Mexer nos SVGs, rodar o script, commitar o par SVG+PNG junto.
+**SVGs source** vivem em `assets/source/`, com re-export via `./scripts/build-icons.sh` (ImageMagick). Mexer nos SVGs, rodar o script, commitar o par SVG+PNG junto.
 
-**Racional da escolha (1c vs 1a/1b):** 1a era seta+trilho (mais literal, beira o esperado); 1b era trilho em perspectiva (risco de virar "V" em 24px); 1c é linha subindo (mais gentil, mais original, sem clichê de "conquista"). Bônus: só o ponto verde carrega a segunda cor — o resto da forma é monocromática, o que sobrevive melhor em launcher pequeno e favicon.
+**Racional da escolha (1c vs 1a/1b):** 1a era seta+trilho (mais literal, beira o esperado); 1b era trilho em perspectiva (risco de virar "V" em 24px); 1c é linha subindo (mais gentil, mais original, sem clichê de "conquista"). Bônus: só o ponto verde carrega a segunda cor, e o resto da forma é monocromática, o que sobrevive melhor em launcher pequeno e favicon.

--- a/docs/09-design-v2.md
+++ b/docs/09-design-v2.md
@@ -1,6 +1,6 @@
-# Design v2 — Back on Track
+# Design v2 do Back on Track
 
-Este documento é a fonte única dos tokens visuais do redesign completo (M5-B) baseado no Turno 2 do Claude Design. **Estende** e progressivamente substitui a base do [08-design-tokens.md](./08-design-tokens.md) — os tokens M5 continuam válidos até que cada tela seja migrada.
+Este documento é a fonte única dos tokens visuais do redesign completo (M5-B) baseado no Turno 2 do Claude Design. **Estende** e progressivamente substitui a base do [08-design-tokens.md](./08-design-tokens.md): os tokens M5 continuam válidos até que cada tela seja migrada.
 
 ## Tom
 
@@ -24,7 +24,7 @@ Vindos do design, mapeando aos usos concretos das mockups.
 | Token            | Hex       | Uso                                                                             |
 | ---------------- | --------- | ------------------------------------------------------------------------------- |
 | `label`          | `#6B7280` | Section labels (MENU, MÉTRICAS DE HOJE), metadados (data, contadores discretos) |
-| `body-secondary` | `#4B5563` | Texto secundário — descrições curtas embaixo de headings                        |
+| `body-secondary` | `#4B5563` | Texto secundário, descrições curtas embaixo de headings                         |
 | `border-subtle`  | `#E5E7EB` | Borda de card, divisor fino                                                     |
 | `border-strong`  | `#D1D5DB` | Borda mais forte quando precisa contraste                                       |
 | `surface-subtle` | `#F3F4F6` | Fundo interno de área secundária (row hover, section bg)                        |
@@ -36,18 +36,18 @@ Vindos do design, mapeando aos usos concretos das mockups.
 | ----------- | --------- | --------------------------------------------------------- |
 | `tint-blue` | `#EAF3FB` | Fundo do container de ícone da métrica água (azul lavado) |
 
-Métricas usam o mesmo padrão de tint. Cada métrica ganha o seu no roadmap — não hardcode aqui além do exemplo água.
+Métricas usam o mesmo padrão de tint. Cada métrica ganha o seu no roadmap, então não hardcode aqui além do exemplo água.
 
 ## Tipografia
 
 Duas famílias, ambas via `expo-font` + `@expo-google-fonts/*` (OTA-safe, sem native change):
 
-- **Inter** (400/500/600) — corpo e headings
-- **JetBrains Mono** (400/500) — labels em uppercase (section headers, chips)
+- **Inter** (400/500/600): corpo e headings
+- **JetBrains Mono** (400/500): labels em uppercase (section headers, chips)
 
-⚠️ **O boot BLOQUEIA até as fontes carregarem** (`app/_layout.jsx` retorna `null` enquanto `useFonts` não resolve, com o splash nativo segurado pelo `expo-splash-screen`). A fatia 0 tinha feito o contrário — carregava em background pra "não introduzir splash extra" — e isso custou caro: no Android a UI montava com a fonte de fallback, o sistema media o texto com ela, e quando a Inter chegava o glifo real não cabia mais na caixa já dimensionada. A última letra cortava ("Depois" virava "Depoi"). Foi diagnosticado errado três vezes (#239, #249, #268) antes de achar a corrida. Não voltar a descartar o retorno do `useFonts`.
+⚠️ **O boot BLOQUEIA até as fontes carregarem** (`app/_layout.jsx` retorna `null` enquanto `useFonts` não resolve, com o splash nativo segurado pelo `expo-splash-screen`). A fatia 0 tinha feito o contrário, carregando em background pra "não introduzir splash extra", e isso custou caro: no Android a UI montava com a fonte de fallback, o sistema media o texto com ela, e quando a Inter chegava o glifo real não cabia mais na caixa já dimensionada. A última letra cortava ("Depois" virava "Depoi"). Foi diagnosticado errado três vezes (#239, #249, #268) antes de achar a corrida. Não voltar a descartar o retorno do `useFonts`.
 
-### Escala (px direto — sem rem, sem `62.5%`)
+### Escala (px direto, sem rem e sem `62.5%`)
 
 | Papel         | Size / Weight / Family            | Nota                                       |
 | ------------- | --------------------------------- | ------------------------------------------ |
@@ -60,7 +60,7 @@ Duas famílias, ambas via `expo-font` + `@expo-google-fonts/*` (OTA-safe, sem na
 | H1 tela       | 24px · 600 · Inter                | "Bom dia, Ana."                            |
 | H1 documento  | 32px · 600 · Inter                | headers de página fora do app (docs, mock) |
 
-Corpo em 14-15px é **menor** que o M5 baseline de 17px (iOS-aligned). Migração é gradual — telas velhas seguem no 17, telas novas nascem no 14. Convergem quando todas migrarem.
+Corpo em 14-15px é **menor** que o M5 baseline de 17px (iOS-aligned). Migração é gradual: telas velhas seguem no 17, telas novas nascem no 14. Convergem quando todas migrarem.
 
 ## Radius
 
@@ -108,6 +108,6 @@ Fatia 6: substituir os 4 assets do ícone (`icon.png`, `adaptive-icon.png`, `spl
 
 ## Ver também
 
-- [08-design-tokens.md](./08-design-tokens.md) — baseline M5 (ainda válido pras telas não migradas)
-- [04-roadmap-milestones.md](./04-roadmap-milestones.md) — item M5-B na milestone Design System
-- Arquivo `Back on Track - Icon Directions.html` no repo local (gitignored) — fonte visual do Claude Design
+- [08-design-tokens.md](./08-design-tokens.md): baseline M5 (ainda válido pras telas não migradas)
+- [04-roadmap-milestones.md](./04-roadmap-milestones.md): item M5-B na milestone Design System
+- Arquivo `Back on Track - Icon Directions.html` no repo local (gitignored): fonte visual do Claude Design

--- a/docs/10-canais-e-promocao.md
+++ b/docs/10-canais-e-promocao.md
@@ -8,11 +8,11 @@ Até aqui existia **um** canal (`preview`) apontando pra **uma** branch (`previe
 
 O histórico do projeto cobrou o preço disso:
 
-- **#126** — regressão introduzida ao corrigir o #108. Passou por CI verde e foi pra produção via OTA; só apareceu quando um humano testou.
-- **#218** — dep nativa nova sem bump de `version` deixou os testers em **crash loop**.
-- **#239 / #249** — quebras de renderização de fonte no Android. Passaram por CI **e** pelo preview da Vercel, porque só se manifestam no APK nativo.
+- **#126**: regressão introduzida ao corrigir o #108. Passou por CI verde e foi pra produção via OTA; só apareceu quando um humano testou.
+- **#218**: dep nativa nova sem bump de `version` deixou os testers em **crash loop**.
+- **#239 / #249**: quebras de renderização de fonte no Android. Passaram por CI **e** pelo preview da Vercel, porque só se manifestam no APK nativo.
 
-O ponto comum: nada disso é pegável por lint, teste ou preview web. Precisa rodar no APK — e antes disso, precisa existir um lugar onde rodar que não seja o celular do tester.
+O ponto comum: nada disso é pegável por lint, teste ou preview web. Precisa rodar no APK, e antes disso precisa existir um lugar onde rodar que não seja o celular do tester.
 
 ## Como funciona agora
 
@@ -38,13 +38,13 @@ Três branches, dois canais, dois apps no seu aparelho:
 Duas coisas fazem isso funcionar sem ninguém reinstalar nada:
 
 1. **O APK é assado com um _canal_, não com uma branch.** O canal aponta pra uma branch, e esse mapeamento vive no servidor. O APK 1.2.0 que os testers já têm segue no canal `preview`; mudamos só o que alimenta a branch `preview`.
-2. **`eas update:republish` copia um grupo de update entre branches.** Promover não é rebuildar nem republicar do zero — é apontar pro mesmo artefato já validado.
+2. **`eas update:republish` copia um grupo de update entre branches.** Promover é apontar pro mesmo artefato já validado, sem rebuildar nem republicar do zero.
 
 ### Por que `release` existe
 
-Validar no aparelho só vale **antes** do merge — os bugs que motivaram todo esse gate (quebra de fonte no Android, #239/#249) não aparecem no CI nem no preview da Vercel, só no APK. Validar depois do merge deixa a main carregando o bug até sair um segundo PR de correção, que foi exatamente o padrão do #239 → #249.
+Validar no aparelho só vale **antes** do merge, porque os bugs que motivaram todo esse gate (quebra de fonte no Android, #239/#249) não aparecem no CI nem no preview da Vercel, só no APK. Validar depois do merge deixa a main carregando o bug até sair um segundo PR de correção, que foi exatamente o padrão do #239 → #249.
 
-Mas isso torna `staging` uma fonte insegura pra promoção: se ela recebe PRs não-mergeados, promover de lá poderia mandar código não-mergeado pros testers. A `release`, alimentada só por push na main, é **barreira estrutural** contra isso — não depende de ninguém lembrar da regra na hora de promover.
+Mas isso torna `staging` uma fonte insegura pra promoção: se ela recebe PRs não-mergeados, promover de lá poderia mandar código não-mergeado pros testers. A `release`, alimentada só por push na main, é **barreira estrutural** contra isso, e não depende de ninguém lembrar da regra na hora de promover.
 
 ## O fluxo do dia a dia
 
@@ -52,7 +52,7 @@ Mas isso torna `staging` uma fonte insegura pra promoção: se ela recebe PRs n�
 
 ⚠️ **A bancada é um slot só.** Existe um canal `staging` e um app no aparelho, então o BoT staging mostra sempre **o push mais recente**, seja de qual PR for. Não dá pra ter dois PRs carregados ao mesmo tempo; o resumo de cada run diz o que ficou.
 
-**Merge na main NÃO toca a bancada.** Publicava antes, e o efeito era o merge sobrescrever em silêncio o PR que estava sendo validado — aconteceu três vezes, com PRs sendo reportados como "não funciona" quando o código deles nem estava no aparelho. Hoje a bancada é exclusiva de PR.
+**Merge na main NÃO toca a bancada.** Publicava antes, e o efeito era o merge sobrescrever em silêncio o PR que estava sendo validado. Aconteceu três vezes, com PRs sendo reportados como "não funciona" quando o código deles nem estava no aparelho. Hoje a bancada é exclusiva de PR.
 
 **Quem não publica:** PR em draft, PR com a label `skip-staging`, PR de fork (não recebe o `EXPO_TOKEN`) e mudança que só toca `docs/**`, `**/*.md` ou `.github/**` (não altera o bundle).
 
@@ -62,7 +62,7 @@ Pra forçar qualquer PR ignorando esses filtros: workflow **Test PR on Staging**
 
 **3. Promover** → rodar a workflow **Promote Update** (aba Actions). Ela pega o último grupo de `release` e republica em `preview`. Os testers recebem na próxima abertura do app.
 
-Merges se acumulam em `release` até você promover — dá pra soltar um lote coerente em vez de pingar mudança solta.
+Merges se acumulam em `release` até você promover, então dá pra soltar um lote coerente em vez de pingar mudança solta.
 
 ## Rollback
 
@@ -87,7 +87,7 @@ eas update:roll-back-to-embedded --branch preview --runtime-version 1.2.0 --plat
 
 ## O APK de staging
 
-Cortado sob demanda — só quando uma mudança **nativa** precisa de validação (dep nova, plugin, ícone, splash). Mudança só-JS não precisa: o OTA chega sozinho no BoT staging que você já tem instalado (seja de um PR com label, seja da main).
+Cortado sob demanda, só quando uma mudança **nativa** precisa de validação (dep nova, plugin, ícone, splash). Mudança só-JS não precisa: o OTA chega sozinho no BoT staging que você já tem instalado (seja de um PR com label, seja da main).
 
 ```bash
 eas build --platform android --profile staging
@@ -102,11 +102,11 @@ O profile `staging` do `eas.json` seta `APP_VARIANT=staging`, e o `app.config.js
 | scheme        | `backontrack://`                     | `backontrack-staging://` |
 | canal         | `preview`                            | `staging`                |
 
-O que **não** muda: `slug`, `projectId` do EAS e `updates.url`. É o mesmo projeto EAS batendo no mesmo servidor — o canal é que separa.
+O que **não** muda: `slug`, `projectId` do EAS e `updates.url`. É o mesmo projeto EAS batendo no mesmo servidor, e o canal é que separa.
 
 ### Por que o scheme também bifurca
 
-Com os dois apps instalados sob o mesmo `backontrack://`, o Android não sabe qual abrir no callback do magic link — o login cairia no app errado, ou num seletor.
+Com os dois apps instalados sob o mesmo `backontrack://`, o Android não sabe qual abrir no callback do magic link, e o login cairia no app errado, ou num seletor.
 
 **Passo manual necessário** (uma vez, no dashboard do Supabase → Authentication → URL Configuration → Additional Redirect URLs):
 
@@ -118,5 +118,5 @@ Sem isso, login **no BoT staging** cai no fallback da Site URL e mostra `otp_exp
 
 ## Ver também
 
-- [04-roadmap-milestones.md](./04-roadmap-milestones.md) — M6 (sync) e M8 (estabilização/loja)
+- [04-roadmap-milestones.md](./04-roadmap-milestones.md): M6 (sync) e M8 (estabilização/loja)
 - A regra de **bump de `version` quando entra dep nativa** continua valendo, e é independente disto: OTA não atravessa fronteira de módulo nativo. Um APK de staging valida a mudança, mas não dispensa o bump.

--- a/docs/11-modelo-de-niveis.md
+++ b/docs/11-modelo-de-niveis.md
@@ -1,8 +1,8 @@
-# Modelo de Níveis — Back on Track
+# Modelo de Níveis do Back on Track
 
 Documento de desenho, escrito **antes** de qualquer código. Fixa o modelo, o que é decisão fechada, o que ainda está aberto, e em que evidência cada peça se apoia.
 
-**Status:** em revisão. Tom decidido em §1.5 (reforço sóbrio). Design do Turno 4 (Claude Design, projeto `4565395c-…`) respondeu o briefing [12-briefing-home-niveis.md](./12-briefing-home-niveis.md) com 6 telas e fechou duas decisões — ver §11. Fechado: cumulativo, regressão em vez de ofensiva, portão por sinal e por comportamento, três regras de quebra (diária binária, diária quantitativa, semanal), graduação, ordem sugerida com skip qualificado. Aberto: ver §11.
+**Status:** em revisão. Tom decidido em §1.5 (reforço sóbrio). Design do Turno 4 (Claude Design, projeto `4565395c-…`) respondeu o briefing [12-briefing-home-niveis.md](./12-briefing-home-niveis.md) com 6 telas e fechou duas decisões, ver §11. Fechado: cumulativo, regressão em vez de ofensiva, portão por sinal e por comportamento, três regras de quebra (diária binária, diária quantitativa, semanal), graduação, ordem sugerida com skip qualificado. Aberto: ver §11.
 
 Referência declarada: **Fabulous** (habit tracker científico, modelo de jornada). O que se rejeita nele: não engaja, e a premissa lúdica polui. Queremos a jornada, sem a fantasia.
 
@@ -12,7 +12,7 @@ Este documento **não** altera o `04-roadmap-milestones.md`. O roadmap só muda 
 
 ## 1. A ideia em uma frase
 
-O app deixa de tratar 5 métricas como iguais e passa a conduzir uma **jornada**: um hábito por vez, conquistado até ficar estável, acumulando — e quem quebra o fluxo **volta um nível** em vez de perder tudo.
+O app deixa de tratar 5 métricas como iguais e passa a conduzir uma **jornada**: um hábito por vez, conquistado até ficar estável, acumulando, e quem quebra o fluxo **volta um nível** em vez de perder tudo.
 
 ```
 lvl 1   sono
@@ -27,30 +27,30 @@ lvl 3   sono + água + <próximo>
 
 ## 1.5. O tom: reforço sóbrio
 
-**Decidido em 14/08/2026.** Antes disto o tom era _herdado_, não decidido: o `09-design-v2.md` (M5-B, #233) diz "retomada, não conquista — sem streaks, sem badges, sem exclamação", e o briefing de design transformou isso numa proibição dura de qualquer recompensa visível. Ninguém tinha ratificado essa extensão.
+**Decidido em 14/08/2026.** Antes disto o tom era _herdado_, não decidido: o `09-design-v2.md` (M5-B, #233) diz "retomada, não conquista: sem streaks, sem badges, sem exclamação", e o briefing de design transformou isso numa proibição dura de qualquer recompensa visível. Ninguém tinha ratificado essa extensão.
 
 ⚠️ **E ela escondia uma contradição: nós ESTAMOS gamificando.** Nível, progressão, portão e regressão são mecânica de jogo, e das fortes. O que se rejeita é o **registro visual** do jogo, não a mecânica. Dizer "sem gamificação" era impreciso.
 
-**A posição é reforço sóbrio:** subir de nível e graduar **são momentos** — reconhecidos, visíveis, com peso. Mas sem vocabulário nem estética de jogo: nada de medalha, XP, confete, mascote, "você desbloqueou!". Reconhecimento, não premiação.
+**A posição é reforço sóbrio:** subir de nível e graduar **são momentos**, reconhecidos, visíveis, com peso. Mas sem vocabulário nem estética de jogo: nada de medalha, XP, confete, mascote, "você desbloqueou!". Reconhecimento, não premiação.
 
-O que isso preserva: loss aversion e reconhecimento visível são parte do que faz ofensiva funcionar — o Duolingo não cresceu com números discretos em cinza. Remover **todo** reforço visível arriscava jogar fora o motor junto com o barulho. A queixa contra o Fabulous é excesso de fantasia, não a existência de recompensa.
+O que isso preserva: loss aversion e reconhecimento visível são parte do que faz ofensiva funcionar. O Duolingo não cresceu com números discretos em cinza. Remover **todo** reforço visível arriscava jogar fora o motor junto com o barulho. A queixa contra o Fabulous é excesso de fantasia, não a existência de recompensa.
 
-**Onde isso NÃO se aplica:** superfícies de diagnóstico, como o bloco de sinais em Ajustes → Avançado (#285). Ali o tom frio é correto — é instrumento de calibração, não superfície de reforço. Se parecesse placar, viraria o barulho que se quer evitar.
+**Onde isso NÃO se aplica:** superfícies de diagnóstico, como o bloco de sinais em Ajustes → Avançado (#285). Ali o tom frio é correto: é instrumento de calibração, e não superfície de reforço. Se parecesse placar, viraria o barulho que se quer evitar.
 
-**Ideia futura, fora de escopo:** dar ao usuário a escolha do registro — sóbrio, reforço sóbrio, ou lúdico assumido. Engajamento é pessoal: assim como o dono do projeto não engaja com o lúdico do Fabulous, muita gente não engaja com o sóbrio. Mudança grande, depende de investimento, registrada como direção — não como plano.
+**Ideia futura, fora de escopo:** dar ao usuário a escolha do registro: sóbrio, reforço sóbrio, ou lúdico assumido. Engajamento é pessoal: assim como o dono do projeto não engaja com o lúdico do Fabulous, muita gente não engaja com o sóbrio. Mudança grande, depende de investimento, registrada como direção, e não como plano.
 
 ---
 
 ## 2. Por que regressão em vez de ofensiva zerada
 
-A objeção natural é que punir contradiz a voz do app — que fala "sem pressa", "sem cobrança", e reserva `danger` só pro destrutivo (ver `08-design-tokens.md`).
+A objeção natural é que punir contradiz a voz do app, que fala "sem pressa", "sem cobrança", e reserva `danger` só pro destrutivo (ver `08-design-tokens.md`).
 
-**O argumento se inverte quando se olha a alternativa.** Ofensiva é que é brutal: 45 dias viram zero por uma noite. Perder um nível preserva quase todo o progresso e devolve a pessoa a um hábito que ela **já provou** que consegue — reconquistar é mais fácil que da primeira vez. É decaimento gradual em vez de penhasco.
+**O argumento se inverte quando se olha a alternativa.** Ofensiva é que é brutal: 45 dias viram zero por uma noite. Perder um nível preserva quase todo o progresso e devolve a pessoa a um hábito que ela **já provou** que consegue, e reconquistar é mais fácil que da primeira vez. É decaimento gradual em vez de penhasco.
 
 A evidência é desfavorável à ofensiva pura:
 
-- Ofensiva zerada produz **quit moment, não restart moment** — vergonha e abandono, não motivação renovada.
-- O mecanismo tem nome desde os anos 70: **what-the-hell effect** (Polivy & Herman). Depois de um deslize, a pessoa não volta ao plano; abandona de vez, porque o custo de quebrar mais caiu a zero. Mesma família do _abstinence violation effect_ — quem mira perfeição desiste mais depois de um único escorregão.
+- Ofensiva zerada produz **quit moment, não restart moment**: vergonha e abandono, não motivação renovada.
+- O mecanismo tem nome desde os anos 70: **what-the-hell effect** (Polivy & Herman). Depois de um deslize, a pessoa não volta ao plano; abandona de vez, porque o custo de quebrar mais caiu a zero. Mesma família do _abstinence violation effect_: quem mira perfeição desiste mais depois de um único escorregão.
 - O próprio **Duolingo**, que popularizou a ofensiva, recuou: o **Streak Freeze cortou churn em 21%** entre usuários em risco, e o achado deles foi que **facilitar a manutenção aumentou engajamento _e_ resultado de aprendizado**.
 
 A regressão também é coerente com o que o app já faz: o estado de retomada (#242) não cobra quem sumiu por 3 dias, convida. A regressão é esse mesmo gesto, mecanizado.
@@ -62,9 +62,9 @@ A regressão também é coerente com o que o app já faz: o estado de retomada (
 A proposta inicial era subir de nível após 1–2 semanas sustentadas. **A pesquisa contradiz isso.**
 
 - Lally et al. (UCL, 2010), n=96: mediana de **66 dias** até o comportamento virar automático, faixa de **18 a 254**.
-- A literatura converge em **1–2 hábitos novos por vez** como teto — acima disso a tendência é falharem todos, porque na fase ativa cada um ainda consome esforço consciente.
+- A literatura converge em **1–2 hábitos novos por vez** como teto, porque acima disso a tendência é falharem todos, porque na fase ativa cada um ainda consome esforço consciente.
 
-Cruzando com o cumulativo: subir em 2 semanas empilha o segundo hábito enquanto o primeiro ainda está a ~50 dias de ser automático. É exatamente o modo de falha documentado — cumulativo com escada rápida vira castelo de cartas, e a regressão deixa de ser gentil: vira inevitável.
+Cruzando com o cumulativo: subir em 2 semanas empilha o segundo hábito enquanto o primeiro ainda está a ~50 dias de ser automático. É exatamente o modo de falha documentado: cumulativo com escada rápida vira castelo de cartas, e a regressão deixa de ser gentil: vira inevitável.
 
 **Portanto o portão é sinal, não calendário.** Sobe de nível quando o hábito anterior dá sinais de estar perto de automático. A faixa de 18 a 254 dias é justamente o argumento contra prazo fixo: as pessoas diferem demais.
 
@@ -72,7 +72,7 @@ Cruzando com o cumulativo: subir em 2 semanas empilha o segundo hábito enquanto
 
 ## 4. O portão é comportamento, nunca desfecho
 
-**Não se habitua um resultado.** Ninguém decide dormir 7h30 — decide-se deitar às 23h30. A duração é consequência de ansiedade, cafeína, barulho, criança acordando.
+**Não se habitua um resultado.** Ninguém decide dormir 7h30. Decide-se deitar às 23h30. A duração é consequência de ansiedade, cafeína, barulho, criança acordando.
 
 Das cinco métricas, o sono é a única em que o número registrado **não é um comportamento**:
 
@@ -86,7 +86,7 @@ Das cinco métricas, o sono é a única em que o número registrado **não é um
 
 Se o portão do nível fosse duração de sono, o app rebaixaria alguém por algo fora do seu controle. Isso é pior que ofensiva zerada: é punição por azar.
 
-**Regra:** o portão de nível é sempre um comportamento. No sono, é a consistência do horário de deitar. A duração segue registrada e exibida — é o que importa pra pessoa — mas não decide nível.
+**Regra:** o portão de nível é sempre um comportamento. No sono, é a consistência do horário de deitar. A duração segue registrada e exibida, porque é o que importa pra pessoa, mas não decide nível.
 
 Isso reaproveita o sinal de regularidade da §5: `bed` já é o dado, e é comportamento e proxy de automaticidade ao mesmo tempo.
 
@@ -106,7 +106,7 @@ O que temos é `records` com `createdAt`, `quantity` e `type`. Dá pra montar um
 | **regularidade** | dispersão do horário do registro     | comportamento automático é disparado por contexto e acontece em horário estável; variabilidade cai conforme o hábito assenta |
 | **resiliência**  | falhou e voltou no dia seguinte?     | hábito automático se recupera sozinho; hábito frágil vira duas faltas                                                        |
 
-**A regularidade é o sinal mais interessante e o menos óbvio** — e é de graça, porque todo registro já tem timestamp. Sono ainda tem `bed`/`wake`, que dá o sinal direto sem depender da hora em que a pessoa abriu o app.
+**A regularidade é o sinal mais interessante e o menos óbvio**, e é de graça, porque todo registro já tem timestamp. Sono ainda tem `bed`/`wake`, que dá o sinal direto sem depender da hora em que a pessoa abriu o app.
 
 ⚠️ **Isto é proxy, não medida.** Não estamos medindo automaticidade; estamos inferindo de comportamento observável. Os limiares abaixo são **ponto de partida pra calibrar com dado real**, não verdades:
 
@@ -114,7 +114,7 @@ O que temos é `records` com `createdAt`, `quantity` e `type`. Dá pra montar um
 - desvio do horário habitual estável ou em queda
 - nenhuma falta dupla na janela
 
-O primeiro usuário com dado suficiente pra calibrar é o próprio dono do projeto — há registros desde julho.
+O primeiro usuário com dado suficiente pra calibrar é o próprio dono do projeto, com registros desde julho.
 
 ---
 
@@ -128,13 +128,13 @@ As métricas não são todas do mesmo tipo, e tratá-las igual seria erro:
 | **quantitativo diário** | horário de deitar              | "foi suficiente?"  | **média móvel de 7 dias abaixo do alvo** |
 | **frequência semanal**  | exercício, estudo              | "manteve o ritmo?" | **duas semanas seguidas abaixo do alvo** |
 
-**Por que duas faltas no binário:** Lally mostra que perder **um** dia custa menos de meio ponto de automaticidade e recupera rápido. A segunda falta consecutiva é onde o laço quebra — "falhar uma vez é acidente, falhar duas é o começo de um hábito novo". Simples de explicar e alinhado com o dado.
+**Por que duas faltas no binário:** Lally mostra que perder **um** dia custa menos de meio ponto de automaticidade e recupera rápido. A segunda falta consecutiva é onde o laço quebra: "falhar uma vez é acidente, falhar duas é o começo de um hábito novo". Simples de explicar e alinhado com o dado.
 
 **Por que média móvel no quantitativo:** a pergunta não é binária. Uma noite de 5h no meio de uma semana boa não é quebra; sete noites de 6h são. Média móvel perdoa o acidente e pega o padrão.
 
-**Por que semanal em exercício e estudo:** eles não são hábitos diários — costumam ser 3–5×/semana. Aplicar "duas faltas consecutivas" rebaixaria alguém por não treinar sábado e domingo, ou seja, **por descansar**. A unidade certa é a semana, e a lógica é a mesma do binário: uma semana ruim é acidente, duas seguidas são padrão.
+**Por que semanal em exercício e estudo:** eles não são hábitos diários, e costumam ser 3–5×/semana. Aplicar "duas faltas consecutivas" rebaixaria alguém por não treinar sábado e domingo, ou seja, **por descansar**. A unidade certa é a semana, e a lógica é a mesma do binário: uma semana ruim é acidente, duas seguidas são padrão.
 
-A semana é **calendário (seg–dom)**, não janela móvel: é como as pessoas planejam ("essa semana treinei 3×"), é legível na UI, e o app já tem a tela Semana. Janela móvel seria mais contínua e menos compreensível — o nível cairia numa terça sem que nada tivesse mudado naquele dia.
+A semana é **calendário (seg–dom)**, não janela móvel: é como as pessoas planejam ("essa semana treinei 3×"), é legível na UI, e o app já tem a tela Semana. Janela móvel seria mais contínua e menos compreensível: o nível cairia numa terça sem que nada tivesse mudado naquele dia.
 
 ---
 
@@ -150,7 +150,7 @@ A saída não é afrouxar a regra: é reconhecer que **hábito automático não 
 
 A primeira versão deste documento definia graduação como "N semanas além do portão". **Isso contradizia a §3.**
 
-A §3 estabelece que o portão de nível é sinal e não calendário, justamente porque a faixa de automaticidade vai de 18 a 254 dias e prazo fixo seria arbitrário. Definir graduação por semanas fixas reintroduz exatamente o calendário que acabamos de rejeitar — se prazo fixo é ruim pra subir de nível, é ruim pra graduar pelo mesmo motivo.
+A §3 estabelece que o portão de nível é sinal e não calendário, justamente porque a faixa de automaticidade vai de 18 a 254 dias e prazo fixo seria arbitrário. Definir graduação por semanas fixas reintroduz exatamente o calendário que acabamos de rejeitar: se prazo fixo é ruim pra subir de nível, é ruim pra graduar pelo mesmo motivo.
 
 Então a régua é a mesma da §5, com barra diferente:
 
@@ -161,21 +161,21 @@ Então a régua é a mesma da §5, com barra diferente:
 | regularidade | estável ou em queda   | estável, faixa estreita             |
 | resiliência  | sem falta dupla       | recupera sozinho após falha isolada |
 
-Mesma família de medida, barra mais exigente. `N` deixa de existir como decisão; o que resta a calibrar são limiares — que a §5 já ia calibrar de qualquer forma.
+Mesma família de medida, barra mais exigente. `N` deixa de existir como decisão; o que resta a calibrar são limiares, que a §5 já ia calibrar de qualquer forma.
 
 ---
 
 ## 8. A ordem dos níveis
 
-### Por que sono primeiro — e não pelo motivo popular
+### Por que sono primeiro, e não pelo motivo popular
 
-A justificativa usual ("hábito-chave: conserta o sono e o resto vem junto") **não se sustenta**: a literatura indica que hábitos-chave raramente cascateiam — uma mudança quase nunca dispara outras.
+A justificativa usual ("hábito-chave: conserta o sono e o resto vem junto") **não se sustenta**: a literatura indica que hábitos-chave raramente cascateiam, e uma mudança quase nunca dispara outras.
 
 O sono vem primeiro por outro motivo, esse com evidência direta: **dormir mal sabota ativamente os outros níveis.** Restrição de sono aumenta ingestão calórica e desloca a escolha de comida pra sabor em vez de saúde. Não é alavanca primeiro; é **sabotador primeiro**.
 
 ### O piso: lvl 0
 
-Regredir do lvl 1 não teria pra onde ir, e é justamente no primeiro nível que a pessoa mais tende a bater — sem progresso acumulado pra amortecer.
+Regredir do lvl 1 não teria pra onde ir, e é justamente no primeiro nível que a pessoa mais tende a bater, sem progresso acumulado pra amortecer.
 
 **lvl 0 = registrar qualquer coisa, todo dia.** É o laço central do app, trivialmente alcançável, dá a primeira experiência de domínio, e ninguém cai abaixo dele. Também é o que o app já é hoje: um agregador.
 
@@ -190,7 +190,7 @@ Regredir do lvl 1 não teria pra onde ir, e é justamente no primeiro nível que
 | 4     | exercício               | frequência semanal                |
 | 5     | estudo                  | frequência semanal                |
 
-Água em 2 por ser o mais controlável dos restantes — vitória fácil logo depois do nível difícil. Exercício e estudo por último porque exigem bloco de tempo e agenda, que é o que mais falha.
+Água em 2 por ser o mais controlável dos restantes, com vitória fácil logo depois do nível difícil. Exercício e estudo por último porque exigem bloco de tempo e agenda, que é o que mais falha.
 
 ---
 
@@ -198,7 +198,7 @@ Regredir do lvl 1 não teria pra onde ir, e é justamente no primeiro nível que
 
 A ordem é **sugerida, não imposta**. Obrigar quem já dorme bem a "conquistar" sono é irritante e destrói a credibilidade da jornada.
 
-**O critério pra pular é o mesmo critério pra passar.** Não se pula o portão — entra-se nele já qualificado:
+**O critério pra pular é o mesmo critério pra passar.** Não se pula o portão. Entra-se nele já qualificado:
 
 1. A pessoa indica que aquele hábito já está resolvido.
 2. O app avalia o **histórico** dela na mesma janela de 28 dias que usaria pra qualquer um (§5).
@@ -207,19 +207,19 @@ A ordem é **sugerida, não imposta**. Obrigar quem já dorme bem a "conquistar"
 
 **Não há o que burlar**, porque a exigência de evidência é idêntica à do caminho normal. O app não acredita nem desacredita a pessoa: ele olha o dado. Pular deixa de ser atalho e vira **reconhecimento**.
 
-Hábito pulado entra graduado porque, se satisfaz o portão sem esforço do app, já é automático por definição. Se depois degradar, o app **sugere revisitar** — não rebaixa. Rebaixar por um hábito que a pessoa nunca construiu pela jornada seria punir por algo que nunca foi promessa.
+Hábito pulado entra graduado porque, se satisfaz o portão sem esforço do app, já é automático por definição. Se depois degradar, o app **sugere revisitar**, sem rebaixar. Rebaixar por um hábito que a pessoa nunca construiu pela jornada seria punir por algo que nunca foi promessa.
 
 ---
 
 ## 10. Estado que o modelo precisa
 
-Hoje **metas não existem como dado** — as de `app/ajustes.jsx` são texto fixo, display-only. O que existe é registro com timestamp/quantidade, mais `computeDaysSinceLast` e `totalRecords` em `app/index.jsx`.
+Hoje **metas não existem como dado**: as de `app/ajustes.jsx` são texto fixo, display-only. O que existe é registro com timestamp/quantidade, mais `computeDaysSinceLast` e `totalRecords` em `app/index.jsx`.
 
 O modelo exige três coisas novas:
 
-1. **Alvo por métrica e por pessoa.** Sem isso não há portão. "8h pra todo mundo" é mentira — tem gente que precisa de 7. Isto promove "metas personalizadas" de item de QoL a **fundação**.
+1. **Alvo por métrica e por pessoa.** Sem isso não há portão. "8h pra todo mundo" é mentira, porque tem gente que precisa de 7. Isto promove "metas personalizadas" de item de QoL a **fundação**.
 2. **Estado de jornada:** nível atual, quais hábitos estão ativos, quais graduaram, e quando cada um entrou.
-3. **Avaliação diária:** o veredito por hábito (no alvo / falhou), derivado dos registros — não digitado.
+3. **Avaliação diária:** o veredito por hábito (no alvo / falhou), derivado dos registros, e não digitado.
 
 Tudo isso é puro-JS e cabe no `MergeableStore` que já existe. Nada aqui exige dep nativa; sincroniza junto com o resto de graça.
 
@@ -229,15 +229,15 @@ Tudo isso é puro-JS e cabe no `MergeableStore` que já existe. Nada aqui exige 
 
 ~~**O app segue servindo quem não quer jornada?**~~ **Resolvido pelo design (Turno 4).** A resposta é **hierarquia, não exclusão**: o hábito do nível ganha um bloco maior no topo, com número grande e botões de registro rápido; o resto vira uma segunda zona ("resto do dia") com linhas compactas, metade da altura, ainda tapáveis. Nada some. Rodapé explícito: "Tudo continua registrável. A ordem é sugerida."
 
-**Os limiares de §5 e §7 ainda não têm dado que os sustente.** Ver §12 — a calibração tem caminho definido, mas ainda não foi feita.
+**Os limiares de §5 e §7 ainda não têm dado que os sustente.** Ver §12: a calibração tem caminho definido, mas ainda não foi feita.
 
 ~~**O que acontece com o histórico ao regredir.**~~ **Resolvido pelo design (Turno 4, tela 4a·2).** Aviso suave no topo, sem vermelho e sem "você falhou":
 
-- o título é **"voltamos pra água"** — primeira pessoa do plural, o app voltou junto, não é a pessoa que falhou sozinha;
+- o título é **"voltamos pra água"**, primeira pessoa do plural, o app voltou junto, não é a pessoa que falhou sozinha;
 - o hábito perdido fica **"em pausa"**, nunca "perdido";
 - linha explícita: "Nada do que você já registrou foi perdido. Você continua podendo registrar tudo";
 - botão **"Ver histórico"** ao lado de "Entendi", pra provar em vez de afirmar;
-- a copy do foco vira "Recomeço curto" — dimensiona o esforço de volta.
+- a copy do foco vira "Recomeço curto", que dimensiona o esforço de volta.
 
 ---
 
@@ -247,16 +247,16 @@ Os limiares da §5 e da §7 precisam de dado real. **Hoje esse dado não existe.
 
 Levantamento do histórico do dono do projeto em 14/08/2026 (sala autenticada no server de sync):
 
-|                         |                             |
-| ----------------------- | --------------------------- |
-| registros totais        | 35                          |
-| faixa                   | 04/08 → 14/08 — **10 dias** |
-| dias com algum registro | 7 de 10                     |
-| água                    | 23                          |
-| sono                    | 6                           |
-| alimentação             | 4                           |
-| estudo                  | 2                           |
-| exercício               | 0                           |
+|                         |                            |
+| ----------------------- | -------------------------- |
+| registros totais        | 35                         |
+| faixa                   | 04/08 → 14/08, **10 dias** |
+| dias com algum registro | 7 de 10                    |
+| água                    | 23                         |
+| sono                    | 6                          |
+| alimentação             | 4                          |
+| estudo                  | 2                          |
+| exercício               | 0                          |
 
 Com 6 registros de sono em 10 dias não se fecha nem a janela de 28 dias do portão, muito menos se observa uma curva de formação. Qualquer limiar derivado daqui seria chute com aparência de análise.
 
@@ -267,14 +267,14 @@ Com 6 registros de sono em 10 dias não se fecha nem a janela de 28 dias do port
 Três opções foram consideradas:
 
 1. **Derivar da literatura** (Lally: mediana 66 dias; com portão de 28, graduação por volta de 5–6 semanas depois). Defensável, mas fixa um calendário contra o qual a §3 e a §7 argumentam.
-2. **Esperar acumular uso.** Honesto e lento — e o uso hoje não é consistente o bastante pra gerar o dado.
+2. **Esperar acumular uso.** Honesto e lento, e o uso hoje não é consistente o bastante pra gerar o dado.
 3. **Instrumentar já, com limiares configuráveis, sem consequência.** ✅
 
 O app passa a computar consistência, regularidade e resiliência por métrica **desde já, sem nenhum nível pendurado nisso**. Em algumas semanas há curva real, e aí os limiares se fixam com dado.
 
 **Efeito colateral desejável:** obriga a construir a parte analítica antes da gamificação, que é a ordem certa de risco. O cálculo pode estar errado sem machucar ninguém enquanto não houver nível dependendo dele.
 
-**Consequência pro roadmap:** a primeira fatia de implementação não é nível nenhum — é medição silenciosa.
+**Consequência pro roadmap:** a primeira fatia de implementação é medição silenciosa, sem nível nenhum.
 
 ---
 
@@ -282,25 +282,25 @@ O app passa a computar consistência, regularidade e resiliência por métrica *
 
 Duas ressalvas, pra este documento não ser lido como mais sólido do que é:
 
-**Ego depletion — base teórica do "1–2 hábitos por vez" — está no centro da crise de replicação da psicologia.** Não apoiar nada só nisso. A perna forte é a curva de automaticidade de Lally, que é medição direta e não teoria de recurso.
+**Ego depletion, a base teórica do "1–2 hábitos por vez", está no centro da crise de replicação da psicologia.** Não apoiar nada só nisso. A perna forte é a curva de automaticidade de Lally, que é medição direta e não teoria de recurso.
 
-**Lally é n=96, autorrelato, 84 dias.** É o melhor que existe nesse desenho e ainda assim é um estudo, não uma lei. A faixa de 18 a 254 dias é enorme — o que reforça portão por sinal em vez de prazo.
+**Lally é n=96, autorrelato, 84 dias.** É o melhor que existe nesse desenho e ainda assim é um estudo, não uma lei. A faixa de 18 a 254 dias é enorme, o que reforça portão por sinal em vez de prazo.
 
 O material sobre _recovery-first design_ é majoritariamente teórico e anedótico; o único número duro encontrado foi o **21% do Duolingo**.
 
 ### Fontes
 
-- Lally et al. 2010, _How are habits formed_ — https://onlinelibrary.wiley.com/doi/abs/10.1002/ejsp.674
-- BPS Research Digest, _How to form a habit_ — https://www.bps.org.uk/research-digest/how-form-habit
-- The Behavioral Scientist, _How long to form a habit_ — https://www.thebehavioralscientist.com/articles/how-long-to-form-a-habit
-- Apptitude, _How Duolingo's streak mechanic actually works_ — https://apptitude.io/blog/how-duolingos-streak-mechanic-actually-works/
-- The Decision Lab, _Streak Creep_ — https://thedecisionlab.com/insights/consumer-insights/streak-creep-the-perils-of-too-much-gamification
-- Yu-kai Chou, _Recovery-First Streak Design_ — https://yukaichou.com/gamification-analysis/recovery-first-streak-design/
-- UX Magazine, _Psychology of Hot Streak Game Design_ — https://uxmag.com/articles/the-psychology-of-hot-streak-game-design-how-to-keep-players-coming-back-every-day-without-shame
-- HabitDex, _Never Miss Twice_ — https://habitdex.com/methods/never-miss-twice
-- medRxiv, _The dark side of streaking_ — https://www.medrxiv.org/content/10.1101/2024.12.26.24319676.full.pdf
-- Scientific Reports, _Insufficient sleep and dietary choices_ — https://www.nature.com/articles/s41598-025-08289-4
-- PMC, _Sleep–diet interactions in lifestyle interventions_ — https://www.ncbi.nlm.nih.gov/pmc/articles/PMC9340846/
-- _Why keystone habits rarely trigger other changes_ — https://www.aypexmove.com/post/why-keystone-habits-rarely-trigger-other-changes
-- PMC, _Self-efficacy in habit building_ — https://pmc.ncbi.nlm.nih.gov/articles/PMC8137900/
-- Stanford ASCEND, _Tiny Habits_ (Fogg) — https://med.stanford.edu/content/dam/sm/ascend/documents/Introduction_%20Tiny%20Habits%20for%20Self%20Compassion,%20Getting%20Started.pdf
+- Lally et al. 2010, _How are habits formed_: https://onlinelibrary.wiley.com/doi/abs/10.1002/ejsp.674
+- BPS Research Digest, _How to form a habit_: https://www.bps.org.uk/research-digest/how-form-habit
+- The Behavioral Scientist, _How long to form a habit_: https://www.thebehavioralscientist.com/articles/how-long-to-form-a-habit
+- Apptitude, _How Duolingo's streak mechanic actually works_: https://apptitude.io/blog/how-duolingos-streak-mechanic-actually-works/
+- The Decision Lab, _Streak Creep_: https://thedecisionlab.com/insights/consumer-insights/streak-creep-the-perils-of-too-much-gamification
+- Yu-kai Chou, _Recovery-First Streak Design_: https://yukaichou.com/gamification-analysis/recovery-first-streak-design/
+- UX Magazine, _Psychology of Hot Streak Game Design_: https://uxmag.com/articles/the-psychology-of-hot-streak-game-design-how-to-keep-players-coming-back-every-day-without-shame
+- HabitDex, _Never Miss Twice_: https://habitdex.com/methods/never-miss-twice
+- medRxiv, _The dark side of streaking_: https://www.medrxiv.org/content/10.1101/2024.12.26.24319676.full.pdf
+- Scientific Reports, _Insufficient sleep and dietary choices_: https://www.nature.com/articles/s41598-025-08289-4
+- PMC, _Sleep–diet interactions in lifestyle interventions_: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC9340846/
+- _Why keystone habits rarely trigger other changes_: https://www.aypexmove.com/post/why-keystone-habits-rarely-trigger-other-changes
+- PMC, _Self-efficacy in habit building_: https://pmc.ncbi.nlm.nih.gov/articles/PMC8137900/
+- Stanford ASCEND, _Tiny Habits_ (Fogg): https://med.stanford.edu/content/dam/sm/ascend/documents/Introduction_%20Tiny%20Habits%20for%20Self%20Compassion,%20Getting%20Started.pdf

--- a/docs/12-briefing-home-niveis.md
+++ b/docs/12-briefing-home-niveis.md
@@ -1,4 +1,4 @@
-# Briefing para o Claude Design — Home com níveis
+# Briefing para o Claude Design: Home com níveis
 
 Instrução pronta pra ser passada ao Claude Design. Contexto, restrições e o que se espera de volta.
 
@@ -8,7 +8,7 @@ Fontes que este briefing pressupõe: [11-modelo-de-niveis.md](./11-modelo-de-niv
 
 ## O produto
 
-**Back on Track** é um acompanhador de métricas basais — sono, água, alimentação, exercício, estudo. Roda em Android (React Native) e web. Uso real, diário, por 6 pessoas.
+**Back on Track** é um acompanhador de métricas basais: sono, água, alimentação, exercício, estudo. Roda em Android (React Native) e web. Uso real, diário, por 6 pessoas.
 
 Hoje a Home mostra as 5 métricas como cards iguais, e o app é um agregador: você abre, registra, sai.
 
@@ -17,7 +17,7 @@ Hoje a Home mostra as 5 métricas como cards iguais, e o app é um agregador: vo
 O app passa a conduzir uma **jornada por níveis**. Um hábito por vez, conquistado até ficar estável, acumulando:
 
 ```
-lvl 0   registrar algo todo dia          (piso — não se perde)
+lvl 0   registrar algo todo dia          (piso, não se perde)
 lvl 1   sono                             (consistência do horário de deitar)
 lvl 2   + água
 lvl 3   + alimentação
@@ -28,13 +28,13 @@ lvl 5   + estudo
 Regras que a interface precisa comunicar:
 
 - **Cumulativo.** No lvl 2 o sono continua valendo.
-- **Quem quebra o fluxo volta um nível** — não perde tudo, não zera.
+- **Quem quebra o fluxo volta um nível**: não perde tudo, não zera.
 - **Hábito maduro gradua** e deixa de poder derrubar, mas continua sendo exibido.
 - **A ordem é sugerida.** Quem já tem um hábito resolvido pode pular, se o histórico comprovar.
 
 ## ⚠️ A restrição que manda em tudo
 
-O tom canônico do app, já em produção, é **"retomada, não conquista"**: sem streaks, sem badges, sem exclamação, sem confete. Copy calma — "3 registros hoje. Sem pressa." em vez de "🎉 Parabéns!".
+O tom canônico do app, já em produção, é **"retomada, não conquista"**: sem streaks, sem badges, sem exclamação, sem confete. Copy calma, como "3 registros hoje. Sem pressa." em vez de "🎉 Parabéns!".
 
 **A jornada não pode trair isso.** A referência declarada é o Fabulous, e o que se rejeita nele é exatamente a premissa lúdica poluindo a tela. Queremos a estrutura da jornada **sem a fantasia**.
 
@@ -48,20 +48,20 @@ Concretamente, o que **não** queremos:
 
 O nível é **contexto**, não prêmio. Ele diz "é isto que estamos construindo agora", não "olha o que você ganhou".
 
-> **Atualização de 14/08:** o tom foi decidido como **reforço sóbrio** (ver `11-modelo-de-niveis.md` §1.5). Subir de nível e graduar **são momentos** — reconhecidos e visíveis, com peso. A proibição acima continua valendo pra estética e vocabulário de jogo; ela não proíbe reconhecimento. A versão original deste briefing era mais restritiva do que o decidido, e o design do Turno 4 já acertou o alvo.
+> **Atualização de 14/08:** o tom foi decidido como **reforço sóbrio** (ver `11-modelo-de-niveis.md` §1.5). Subir de nível e graduar **são momentos**, reconhecidos e visíveis, com peso. A proibição acima continua valendo pra estética e vocabulário de jogo; ela não proíbe reconhecimento. A versão original deste briefing era mais restritiva do que o decidido, e o design do Turno 4 já acertou o alvo.
 
 ## O problema de design central
 
 **A Home precisa servir duas coisas ao mesmo tempo, e elas puxam em direções opostas.**
 
-1. **Jornada** — dar foco ao hábito do nível atual. Se tudo aparece igual, não há jornada.
-2. **Agregador** — o dono do app usa as 5 métricas diariamente, hoje. Se o lvl 1 mostrar só sono, o app piora pra quem já o usa.
+1. **Jornada**: dar foco ao hábito do nível atual. Se tudo aparece igual, não há jornada.
+2. **Agregador**: o dono do app usa as 5 métricas diariamente, hoje. Se o lvl 1 mostrar só sono, o app piora pra quem já o usa.
 
 **Esta é a pergunta que queremos que o design responda**, e é onde queremos variantes. Não decidimos internamente de propósito.
 
 Algumas direções possíveis (não exaustivas, não prescritivas):
 
-- hierarquia em vez de exclusão — o hábito do nível em destaque, os outros presentes e menores
+- hierarquia em vez de exclusão: o hábito do nível em destaque, os outros presentes e menores
 - o nível organiza a ordem, mas nada some
 - duas zonas: "o que estamos construindo" e "o resto do dia"
 - registro rápido de qualquer métrica sempre a um toque, independentemente do nível
@@ -73,20 +73,20 @@ Prioridade em ordem. Se não der pra fazer todas, as três primeiras são as que
 1. **Home no lvl 2, dia normal.** O caso comum: um hábito em construção (água), um já conquistado (sono), três ainda não abertos. Precisa resolver o problema central acima.
 2. **A regressão.** A tela mais difícil e a mais importante. Alguém acabou de voltar do lvl 3 pro lvl 2. Tem que ficar claro que (a) nada de registro foi perdido, (b) não é punição, (c) o caminho de volta é curto. Se essa tela der vontade de fechar o app, o modelo inteiro falha.
 3. **Home no lvl 0/1.** O começo, quando quase nada foi conquistado. Risco de parecer vazio ou de parecer que o app foi capado.
-4. **Subir de nível.** O momento da conquista, dentro do tom — reconhecimento, não celebração.
+4. **Subir de nível.** O momento da conquista, dentro do tom, com reconhecimento em vez de celebração.
 5. **Hábito graduado.** Como mostrar algo que virou automático e não pode mais te derrubar, sem sumir da tela.
 6. **Pular um nível.** A pessoa diz que já dorme bem; o app confere o histórico e reconhece (ou diz que vai observar).
 
 ## Restrições técnicas
 
-- **Tokens e tipografia já existem** — usar os de [09-design-v2.md](./09-design-v2.md). Inter (400/500/600) pro corpo, JetBrains Mono (400/500) pra labels em uppercase. Paleta: `brand-blue #2E5A88`, `brand-green #4CAF50`, `bg-canvas #F8F9FA`, `ink #0F1419`, mais os grays semânticos. **Não introduzir cor nova** sem necessidade forte e explicada.
+- **Tokens e tipografia já existem**: usar os de [09-design-v2.md](./09-design-v2.md). Inter (400/500/600) pro corpo, JetBrains Mono (400/500) pra labels em uppercase. Paleta: `brand-blue #2E5A88`, `brand-green #4CAF50`, `bg-canvas #F8F9FA`, `ink #0F1419`, mais os grays semânticos. **Não introduzir cor nova** sem necessidade forte e explicada.
 - **Claro e escuro.** O app tem dark mode real, escolhido pelo usuário e persistido.
 - **Android primeiro**, largura de celular. O web existe mas é secundário.
-- Nada aqui deve exigir biblioteca de animação ou dependência nativa nova — o app se atualiza por OTA, e dep nativa obriga reinstalação.
+- Nada aqui deve exigir biblioteca de animação ou dependência nativa nova, porque o app se atualiza por OTA, e dep nativa obriga reinstalação.
 - Ícones existentes: cada métrica já tem o seu, em SVG traço.
 
 ## O que ajuda mais na entrega
 
 - Copy real nas telas, não _lorem ipsum_. O tom da copy **é** metade do design aqui.
 - Quando houver decisão não óbvia, uma linha dizendo por quê.
-- Se a resposta ao problema central for "não dá pra servir os dois, escolha", dizer isso — é uma resposta legítima e útil.
+- Se a resposta ao problema central for "não dá pra servir os dois, escolha", dizer isso, que é uma resposta legítima e útil.


### PR DESCRIPTION
Closes #308. Fecha a parte de documentação da #302.

**357 ocorrências em 11 arquivos.** Nenhum deles entra no bundle, então não há risco de runtime nesta fatia. O risco é só de texto ruim, e a revisão acontece no diff.

## Método, em duas passadas

**Mecânica (64 linhas).** Itens de lista do tipo `- **Termo** — descrição`, onde dois-pontos é a pontuação correta e ainda melhora a leitura. Regex restrito a linha de lista cujo travessão separa um termo em negrito ou `code` da descrição.

**Por leitura (293).** Uma a uma, com script de substituição exata que aborta se qualquer trecho não casar. Isso pegou dois enganos meus durante o trabalho, em vez de aplicar silenciosamente no lugar errado.

Os critérios que apareceram:

- **ponto final** quando as duas orações se sustentam sozinhas
- **vírgula** quando a segunda depende da primeira
- **dois-pontos** quando a segunda explica ou lista a primeira

Títulos de ADR (`## ADR-004 — Armazenamento`) e de seção viraram dois-pontos. A lista bibliográfica do `11-modelo-de-niveis.md` (14 linhas `- Autor, _Título_ — https://`) saiu por regex própria.

Um título pediu reestruturação: `## ADR-007 — Modelagem da store TinyBase: uma tabela, não seis` produziria dois `:` na mesma linha, e virou `## ADR-007: Modelagem da store TinyBase (uma tabela, não seis)`.

## Preservado

O **glifo `—` de célula vazia** em `02-escopo-mvp.md:42`, que marca ausência de dado igual ao do código, e as **setas** `→` de transição. O script protege a célula de tabela explicitamente.

## Antítese

Entraram as duas que sobravam em doc:

- `03-decisoes-tecnicas.md`: "TinyBase não é uma pendência a corrigir, é uma escolha tecnicamente boa" virou "TinyBase é uma escolha tecnicamente boa pra esse caso, e não uma pendência a corrigir"
- `07-auditoria-ui.md`: "pode não estar acontecendo, e sim empilhando" virou "pode estar empilhando e fluindo como texto normal em vez de alinhar"

## Verificação

- `grep " — " docs/*.md` volta **apenas** a célula de tabela preservada
- **270 testes** verdes, incluindo os 11 do parser de roadmap
- prettier limpo (ele realinhou tabelas depois das trocas)
- **cada arquivo fecha com `+N -N` igual**, ou seja, nenhuma linha foi perdida no processo

## Como validar

Nada aqui chega à tela, então não há o que conferir no aparelho. A revisão é no diff, e o que vale procurar é frase que perdeu sentido ou informação que sumiu na reescrita.