### PR TITLE
chore(ci): barreira mecânica contra o travessão de prosa (fatia 4 da #302)

### DIFF
--- a/.claude/hooks/check-em-dash.sh
+++ b/.claude/hooks/check-em-dash.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# PreToolUse hook: bloqueia `git commit` quando o stage adiciona travessão de
+# prosa. A regra e as exceções vivem em scripts/check-em-dash.js, o mesmo
+# módulo que o job "Texto" do CI usa. Ver #302 e #310.
+#
+# Este hook só pega commits feitos pelo Claude. A barreira que vale pra todo
+# mundo é a do CI; esta existe pra dar o retorno antes de gastar um ciclo.
+#
+# Escape: SKIP_EM_DASH_CHECK=1 no env.
+#
+# Exit 0 = allow; exit 2 = block (stderr vai pro Claude).
+
+set -euo pipefail
+
+if [ "${SKIP_EM_DASH_CHECK:-}" = "1" ]; then
+  exit 0
+fi
+
+input=$(cat)
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""')
+
+# Só `git commit` como comando principal, ancorado no início. Evita disparar
+# quando outro comando cita a string "git commit" dentro de um argumento.
+if ! printf '%s' "$cmd" | grep -qE '^[[:space:]]*git[[:space:]]+commit\b'; then
+  exit 0
+fi
+
+if node scripts/check-em-dash.js; then
+  exit 0
+fi
+
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,6 +7,10 @@
           {
             "type": "command",
             "command": ".claude/hooks/check-commit-english.sh"
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/check-em-dash.sh"
           }
         ]
       }

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -59,6 +59,22 @@ jobs:
 
       - run: npm test
 
+  text:
+    name: Texto
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "lts/jod"
+
+      # Sem `npm ci`: o script não tem dependência além do node e do git.
+      - name: Travessão de prosa em linha adicionada
+        run: node scripts/check-em-dash.js --range ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }}
+
   commitlint:
     name: commitlint
     runs-on: ubuntu-latest

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -49,6 +49,16 @@ export default defineConfig([
     },
   },
   {
+    // Tooling de repo (scripts/) roda em Node CommonJS, fora do bundle do app.
+    // Mesmo caso do plugins/ acima: precisa dos globals de Node (require,
+    // module, process) que o bloco do app não tem.
+    files: ["scripts/**/*.js"],
+    languageOptions: {
+      sourceType: "commonjs",
+      globals: globals.node,
+    },
+  },
+  {
     // Funções serverless (Vercel) rodam em Node (ESM), não no app.
     files: ["api/**/*.js"],
     languageOptions: {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint:prettier:fix": "prettier --write .",
     "lint:eslint:check": "eslint .",
     "lint:types:check": "tsc --noEmit",
+    "lint:text:check": "node scripts/check-em-dash.js",
     "prepare": "husky",
     "commit": "cz",
     "test": "jest"

--- a/scripts/check-em-dash.js
+++ b/scripts/check-em-dash.js
@@ -1,3 +1,6 @@
+// @ts-nocheck -- tooling Node (CommonJS), fora do tsc do app (ADR-002).
+// O `exclude` do tsconfig não basta: o teste importa este módulo, e o tsc
+// segue o import pra dentro de pasta excluída.
 // Barreira mecânica contra o travessão de prosa (#310, fatia 4 da #302).
 //
 // O travessão espaçado (` — `) usado como aposto de propósito geral dá ao
@@ -73,7 +76,7 @@ function temTravessaoDeProsa(linha) {
  * Espera `--unified=0`, onde cada hunk header já dá a linha inicial exata e
  * não há contexto pra descontar.
  *
- * @param {string} diff Saída de `git diff --unified=0`.
+ * @param {string|null|undefined} diff Saída de `git diff --unified=0`.
  * @returns {Array<{file: string, line: number, text: string}>}
  */
 function linhasAdicionadas(diff) {
@@ -102,7 +105,7 @@ function linhasAdicionadas(diff) {
 /**
  * Achados de travessão de prosa nas linhas adicionadas de um diff.
  *
- * @param {string} diff
+ * @param {string|null|undefined} diff
  * @returns {Array<{file: string, line: number, text: string}>}
  */
 function achados(diff) {

--- a/scripts/check-em-dash.js
+++ b/scripts/check-em-dash.js
@@ -1,0 +1,167 @@
+// Barreira mecânica contra o travessão de prosa (#310, fatia 4 da #302).
+//
+// O travessão espaçado (` — `) usado como aposto de propósito geral dá ao
+// texto cara de coisa gerada por IA. A varredura da #302 tirou 520 deles do
+// repo; este script existe pra que não voltem.
+//
+// ## Por que só o diff
+//
+// O repo ainda tem travessão em comentário de código (fatia 3 pendente).
+// Checar a árvore inteira bloquearia todo commit. Checar só as **linhas
+// adicionadas** deixa o passado em paz e trava o que entra agora. Editar uma
+// linha que já tinha travessão e mantê-lo é pego de propósito: quem tocou na
+// linha arruma.
+//
+// ## O que NÃO é prosa
+//
+// Três usos do caractere são legítimos e ficam de fora:
+//
+// 1. **Glifo de valor vazio** (`"—"`), que marca ausência de dado em
+//    `formatGoal`, `CompactRow`, `ajustes` e `journeySkip`. Tem teste em cima.
+// 2. **Dentro de regex**, como o `[:\s—–-]` do `MILESTONE_RE`.
+// 3. **Célula vazia de tabela markdown** (`| — |`).
+//
+// Os dois primeiros caem fora sozinhos, porque nenhum deles tem espaço dos
+// dois lados do caractere. Só a célula de tabela precisa de tratamento
+// explícito, feito em `semCelulaVazia`.
+//
+// ## Auto-referência
+//
+// Este arquivo e o teste dele precisam do caractere literal pra existirem, e
+// seriam bloqueados pela própria regra. Ficam isentos por caminho, em
+// `EXENTOS`. A lista é curta de propósito: só os arquivos da barreira. Se ela
+// crescer, é sinal de que a regra está errada, não de que faltam exceções.
+//
+// Escape: SKIP_EM_DASH_CHECK=1 no ambiente.
+
+const { execFileSync } = require("node:child_process");
+
+const TRAVESSAO = " — ";
+
+/** Arquivos que definem a barreira, e por isso carregam o caractere literal. */
+const EXENTOS = new Set([
+  "scripts/check-em-dash.js",
+  "tests/em-dash-barrier.test.js",
+]);
+
+/**
+ * Remove as células vazias de tabela markdown (`| — |`) da linha.
+ *
+ * O lookahead preserva o pipe seguinte, senão duas células vazias adjacentes
+ * (`| — | — |`) se comeriam e a segunda escaparia da limpeza.
+ *
+ * @param {string} linha
+ * @returns {string}
+ */
+function semCelulaVazia(linha) {
+  return linha.replace(/\|\s*—\s*(?=\|)/g, "|");
+}
+
+/**
+ * Procura travessão de prosa numa linha.
+ *
+ * @param {string} linha
+ * @returns {boolean}
+ */
+function temTravessaoDeProsa(linha) {
+  return semCelulaVazia(linha).includes(TRAVESSAO);
+}
+
+/**
+ * Extrai as linhas adicionadas de um diff unificado, com arquivo e número.
+ *
+ * Espera `--unified=0`, onde cada hunk header já dá a linha inicial exata e
+ * não há contexto pra descontar.
+ *
+ * @param {string} diff Saída de `git diff --unified=0`.
+ * @returns {Array<{file: string, line: number, text: string}>}
+ */
+function linhasAdicionadas(diff) {
+  const out = [];
+  let file = null;
+  let linha = 0;
+  for (const l of String(diff ?? "").split("\n")) {
+    if (l.startsWith("+++ b/")) {
+      file = l.slice(6);
+      continue;
+    }
+    if (l.startsWith("+++ ") || l.startsWith("--- ")) continue;
+    const hunk = l.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+    if (hunk) {
+      linha = Number(hunk[1]);
+      continue;
+    }
+    if (l.startsWith("+") && file) {
+      out.push({ file, line: linha, text: l.slice(1) });
+      linha += 1;
+    }
+  }
+  return out;
+}
+
+/**
+ * Achados de travessão de prosa nas linhas adicionadas de um diff.
+ *
+ * @param {string} diff
+ * @returns {Array<{file: string, line: number, text: string}>}
+ */
+function achados(diff) {
+  return linhasAdicionadas(diff).filter(
+    (a) => !EXENTOS.has(a.file) && temTravessaoDeProsa(a.text),
+  );
+}
+
+function git(args) {
+  return execFileSync("git", args, {
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+}
+
+function main(argv) {
+  if (process.env.SKIP_EM_DASH_CHECK === "1") return 0;
+
+  const i = argv.indexOf("--range");
+  const diff =
+    i !== -1
+      ? git(["diff", "--unified=0", `${argv[i + 1]}..${argv[i + 2]}`])
+      : git(["diff", "--cached", "--unified=0"]);
+
+  const hits = achados(diff);
+  if (hits.length === 0) return 0;
+
+  const plural = hits.length === 1 ? "travessão" : "travessões";
+  process.stderr.write(
+    `\n${hits.length} ${plural} de prosa em linha adicionada:\n\n`,
+  );
+  for (const h of hits) {
+    const j = semCelulaVazia(h.text).indexOf(TRAVESSAO);
+    const trecho = h.text.slice(Math.max(0, j - 45), j + 45).trim();
+    process.stderr.write(`  ${h.file}:${h.line}\n    ...${trecho}...\n`);
+  }
+  process.stderr.write(
+    [
+      "",
+      "Reescreva a frase em vez de trocar o caractere. Ponto final quando as",
+      "duas orações se sustentam sozinhas, vírgula quando a segunda depende da",
+      "primeira, dois-pontos quando ela explica ou lista.",
+      "",
+      'Preservados de propósito: o glifo "—" de valor vazio, ocorrência dentro',
+      "de regex, e célula vazia de tabela markdown.",
+      "",
+      "Escape: SKIP_EM_DASH_CHECK=1 (use só se a barreira errou).",
+      "",
+    ].join("\n"),
+  );
+  return 1;
+}
+
+module.exports = {
+  achados,
+  linhasAdicionadas,
+  temTravessaoDeProsa,
+  semCelulaVazia,
+  EXENTOS,
+};
+
+if (require.main === module) process.exit(main(process.argv.slice(2)));

--- a/tests/em-dash-barrier.test.js
+++ b/tests/em-dash-barrier.test.js
@@ -1,3 +1,4 @@
+// @ts-nocheck -- teste; globals do jest não são tipados (ADR-002)
 // Testes da barreira contra o travessão de prosa (#310).
 //
 // O que importa aqui não é achar o travessão, que é trivial, e sim **não

--- a/tests/em-dash-barrier.test.js
+++ b/tests/em-dash-barrier.test.js
@@ -1,0 +1,145 @@
+// Testes da barreira contra o travessão de prosa (#310).
+//
+// O que importa aqui não é achar o travessão, que é trivial, e sim **não
+// disparar** nos três usos legítimos do caractere. Uma barreira que grita
+// errado ensina a ser ignorada, e aí não barra nada.
+
+import {
+  achados,
+  EXENTOS,
+  linhasAdicionadas,
+  semCelulaVazia,
+  temTravessaoDeProsa,
+} from "../scripts/check-em-dash";
+
+const diff = (linhas) =>
+  ["--- a/x.js", "+++ b/x.js", "@@ -1,0 +1,1 @@", ...linhas].join("\n");
+
+describe("temTravessaoDeProsa", () => {
+  it("pega o travessão espaçado", () => {
+    expect(temTravessaoDeProsa("o foco volta pra ele — sem drama")).toBe(true);
+  });
+
+  it("NÃO pega o glifo de valor vazio", () => {
+    expect(temTravessaoDeProsa('  if (!alvo) return "—";')).toBe(false);
+    expect(temTravessaoDeProsa('        {value ?? "—"}')).toBe(false);
+    expect(temTravessaoDeProsa('  [LOCKED]: "—",')).toBe(false);
+  });
+
+  it("NÃO pega travessão dentro de regex", () => {
+    expect(
+      temTravessaoDeProsa(
+        "const MILESTONE_RE = /^##\\s+(M\\d+)\\b[:\\s—–-]*(.*)$/;",
+      ),
+    ).toBe(false);
+    expect(
+      temTravessaoDeProsa(
+        "  const cut = s.search(/:\\s|\\s[—–]\\s|\\.\\s|\\.$/);",
+      ),
+    ).toBe(false);
+  });
+
+  it("NÃO pega célula vazia de tabela markdown", () => {
+    expect(temTravessaoDeProsa("| Água | ml | 250 (um copo) | — |")).toBe(
+      false,
+    );
+  });
+
+  it("pega células vazias adjacentes sem deixar a segunda escapar", () => {
+    // O lookahead do `semCelulaVazia` existe por causa deste caso: sem ele, a
+    // primeira substituição comeria o pipe que a segunda precisa pra casar, e
+    // a segunda célula escaparia da limpeza. O pipe preservado sobra na saída,
+    // o que não importa: ninguém lê o resultado, ele só alimenta a checagem.
+    expect(semCelulaVazia("| a | — | — | b |")).not.toContain("—");
+    expect(temTravessaoDeProsa("| a | — | — | b |")).toBe(false);
+  });
+
+  it("pega prosa na MESMA linha de uma célula vazia", () => {
+    expect(temTravessaoDeProsa("| — | isto sim — é prosa |")).toBe(true);
+  });
+
+  it("NÃO pega en-dash de intervalo nem seta", () => {
+    expect(temTravessaoDeProsa("faixa 18–254 dias")).toBe(false);
+    expect(temTravessaoDeProsa("Store → MergeableStore")).toBe(false);
+  });
+});
+
+describe("linhasAdicionadas", () => {
+  it("numera a partir do hunk header e ignora removidas", () => {
+    const d = [
+      "--- a/a.md",
+      "+++ b/a.md",
+      "@@ -10,1 +10,2 @@",
+      "-linha velha",
+      "+primeira",
+      "+segunda",
+    ].join("\n");
+    expect(linhasAdicionadas(d)).toEqual([
+      { file: "a.md", line: 10, text: "primeira" },
+      { file: "a.md", line: 11, text: "segunda" },
+    ]);
+  });
+
+  it("acompanha o arquivo em diff de múltiplos arquivos", () => {
+    const d = [
+      "--- a/a.js",
+      "+++ b/a.js",
+      "@@ -1,0 +1,1 @@",
+      "+um — dois",
+      "--- a/b.js",
+      "+++ b/b.js",
+      "@@ -5,0 +5,1 @@",
+      "+três — quatro",
+    ].join("\n");
+    expect(achados(d).map((h) => `${h.file}:${h.line}`)).toEqual([
+      "a.js:1",
+      "b.js:5",
+    ]);
+  });
+
+  it("não confunde o cabeçalho +++ com linha adicionada", () => {
+    expect(linhasAdicionadas(diff(["+ok"]))).toHaveLength(1);
+  });
+});
+
+describe("achados", () => {
+  it("volta vazio quando não há travessão de prosa", () => {
+    expect(achados(diff(['+return "—";', "+// tudo certo"]))).toEqual([]);
+  });
+
+  it("aponta arquivo, linha e texto", () => {
+    expect(achados(diff(["+algo — outra coisa"]))).toEqual([
+      { file: "x.js", line: 1, text: "algo — outra coisa" },
+    ]);
+  });
+
+  it("tolera diff vazio", () => {
+    expect(achados("")).toEqual([]);
+    expect(achados(null)).toEqual([]);
+  });
+});
+
+describe("auto-referência", () => {
+  it("isenta os arquivos da própria barreira", () => {
+    const d = [
+      "--- a/scripts/check-em-dash.js",
+      "+++ b/scripts/check-em-dash.js",
+      "@@ -1,0 +1,1 @@",
+      '+const TRAVESSAO = " — ";',
+      "--- a/app/index.jsx",
+      "+++ b/app/index.jsx",
+      "@@ -1,0 +1,1 @@",
+      "+// isto — não escapa",
+    ].join("\n");
+    expect(achados(d).map((h) => h.file)).toEqual(["app/index.jsx"]);
+  });
+
+  it("a lista de isentos cobre só os dois arquivos da barreira", () => {
+    // Guarda contra a lista virar depósito de exceção. Se ela crescer, a regra
+    // está errada, e o teste força a conversa em vez de deixar passar.
+    expect([...EXENTOS].sort()).toEqual([
+      "scripts/check-em-dash.js",
+      "tests/em-dash-barrier.test.js",
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #310. Última fatia da #302, e a que faz as outras três valerem a pena: sem barreira, o tique volta no próximo texto escrito.

## A regra, e por que ela é confiável

A classificação levantada na #302 separa bem os usos:

| forma | destino | por quê |
|---|---|---|
| ` — ` espaçado | **bloqueia** | é o tique |
| `"—"` glifo de valor vazio | passa | marca ausência de dado, tem teste em cima |
| `[:\s—–-]` em regex | passa | é sintaxe |
| `\| — \|` célula de tabela | passa | é célula vazia |

As duas primeiras exceções **caem fora sozinhas**, porque nenhuma delas tem espaço dos dois lados do caractere. Só a célula de tabela precisou de código, e ela rendeu o detalhe mais chato do PR: com um `replace` ingênuo, duas células vazias adjacentes (`| — | — |`) se comem, a primeira substituição consome o pipe que a segunda precisa pra casar, e a segunda escapa. O lookahead resolve, e tem teste dedicado.

## Só o diff, nunca a árvore

O repo ainda tem **372 travessões** em comentário de código, porque a fatia 3 está pendente. Checar a árvore bloquearia todo commit. Checar só linhas adicionadas deixa o passado em paz.

Efeito colateral desejado: editar uma linha que já tinha travessão e mantê-lo é pego, porque a linha aparece como adição. Tocou, arruma.

## Dois lugares, um módulo

1. **Job `Texto` no CI**, diffando `base.sha..head.sha` como o commitlint já faz. É a barreira que vale: pega qualquer commit, meu ou seu, e trava o merge. Não roda `npm ci`, porque o script não tem dependência além de node e git.
2. **Hook `PreToolUse`**, nos moldes do `check-commit-english.sh`. Só pega commits meus, mas evita gastar um ciclo de CI pra descobrir.

Também dá pra rodar à mão com `npm run lint:text:check`.

## O problema da auto-referência

O checador e o teste dele precisam do caractere literal pra existir, e seriam bloqueados pela própria regra. Ficam isentos por caminho, em `EXENTOS`.

Isso é um risco óbvio de virar depósito de exceção, então tem um teste afirmando que a lista contém **exatamente** os dois arquivos da barreira. Se alguém quiser adicionar um terceiro, o teste força a conversa em vez de deixar passar em silêncio.

## Antítese fica de fora, de propósito

Não automatizei a detecção de "não é X, é Y". Qualquer regex pra isso dispara em português legítimo, e uma barreira que grita errado ensina a ser ignorada, o que a torna pior que barreira nenhuma. Continua sendo questão de revisão.

## Verificação

Exercitei os três casos com stage de verdade, além dos 15 testes unitários:

- linha de prosa com travessão: **exit 1**, com arquivo, linha e trecho
- glifo, regex e célula de tabela: **exit 0**
- `SKIP_EM_DASH_CHECK=1`: **exit 0**
- modo `--range` contra o commit do M9, que sabidamente adicionou travessões: **18 achados**

285 testes verdes, eslint e prettier limpos.

## Um efeito colateral no eslint

`scripts/check-em-dash.js` é CommonJS de Node, e o bloco geral do eslint só tem os globals de browser, então `require`/`module`/`process` viravam `no-undef`. Adicionei um bloco pra `scripts/**/*.js` nos mesmos moldes do que já existe pra `plugins/`. O `notify-testers.mjs` não é afetado, porque `.mjs` não casa com o padrão de arquivos.

## Como validar

Não há nada visual. Se quiser ver a barreira agindo, o caminho mais rápido:

```bash
printf 'x // prosa — aqui\n' > t.js && git add t.js && npm run lint:text:check; git reset -q t.js && rm t.js
```