### PR TITLE
feat(roadmap): navegar todas as milestones com acordeão

### DIFF
--- a/app/roadmap.jsx
+++ b/app/roadmap.jsx
@@ -1,5 +1,6 @@
 // @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
 //#region imports
+import { useMemo, useState } from "react";
 import { Pressable, ScrollView, Text, View } from "react-native";
 import Svg, { Path } from "react-native-svg";
 
@@ -13,17 +14,22 @@ import roadmapMd from "../docs/04-roadmap-milestones.md";
 import { useThemeTokens } from "@/constants/themeTokens";
 //#endregion
 
-const digest = getDigest(parseRoadmap(roadmapMd));
+// Parseia uma vez, no módulo: o markdown é inlinado em tempo de build pelo
+// babel-plugin-inline-import, então o conteúdo não muda em runtime.
+const milestones = parseRoadmap(roadmapMd);
+const digest = getDigest(milestones);
 
 export default function Roadmap() {
   const t = useThemeTokens();
-  const {
-    milestonesDone,
-    milestonesTotal,
-    current,
-    currentProgress,
-    recentDone,
-  } = digest;
+  const { milestonesDone, milestonesTotal, current } = digest;
+
+  // A milestone em andamento já abre expandida: é a que a pessoa quer ver ao
+  // entrar. As outras ficam a um toque.
+  const [abertas, setAbertas] = useState(() => (current ? [current.id] : []));
+  const alterna = (id) =>
+    setAbertas((atual) =>
+      atual.includes(id) ? atual.filter((x) => x !== id) : [...atual, id],
+    );
   const pct = milestonesTotal
     ? Math.round((milestonesDone / milestonesTotal) * 100)
     : 0;
@@ -114,49 +120,112 @@ export default function Roadmap() {
           </Text>
         </View>
 
-        {/* Milestone atual */}
-        {current && (
-          <View className="rounded-2xl border border-border-subtle dark:border-border-subtle-dark bg-white dark:bg-card-dark p-5 gap-4">
-            <View className="gap-1">
-              <Text
-                className="text-xs uppercase tracking-wider text-label dark:text-label-dark"
-                style={{ fontFamily: "JetBrainsMono_500Medium" }}
-              >
-                Em andamento · {currentProgress.done}/{currentProgress.total}
-              </Text>
-              <Text
-                className="text-lg text-ink dark:text-ink-dark"
-                style={{ fontFamily: "Inter_600SemiBold" }}
-              >
-                {current.id} · {current.title}
-              </Text>
-            </View>
-            <View className="gap-2.5">
-              {current.items.map((item, i) => (
-                <ItemRow key={i} status={item.status} text={item.text} />
-              ))}
-            </View>
+        {/* Todas as milestones, na ordem do documento. Antes a tela só mostrava
+            a atual, e tudo que já foi entregue ou ainda vem ficava fora de
+            alcance (#303). */}
+        <View className="rounded-2xl border border-border-subtle dark:border-border-subtle-dark bg-white dark:bg-card-dark px-5 pt-4 pb-1">
+          <Text
+            className="text-xs uppercase tracking-wider text-label dark:text-label-dark"
+            style={{ fontFamily: "JetBrainsMono_500Medium" }}
+          >
+            Milestones
+          </Text>
+          <View className="mt-1">
+            {milestones.map((m, i) => (
+              <MilestoneRow
+                key={m.id}
+                milestone={m}
+                expanded={abertas.includes(m.id)}
+                atual={m.id === current?.id}
+                ultima={i === milestones.length - 1}
+                onToggle={() => alterna(m.id)}
+                chevronColor={t.label}
+              />
+            ))}
           </View>
-        )}
-
-        {/* Concluído recentemente */}
-        {recentDone.length > 0 && (
-          <View className="rounded-2xl border border-border-subtle dark:border-border-subtle-dark bg-white dark:bg-card-dark p-5 gap-3">
-            <Text
-              className="text-xs uppercase tracking-wider text-label dark:text-label-dark"
-              style={{ fontFamily: "JetBrainsMono_500Medium" }}
-            >
-              Concluído recentemente
-            </Text>
-            <View className="gap-2.5">
-              {recentDone.map((item, i) => (
-                <ItemRow key={i} status="done" text={item.text} />
-              ))}
-            </View>
-          </View>
-        )}
+        </View>
       </ScrollView>
     </MyView>
+  );
+}
+
+// Bolinha de status, compartilhada pela linha da milestone e pelo item.
+const DOT = {
+  done: "bg-secondary dark:bg-secondary-dark",
+  partial: "bg-primary dark:bg-primary-dark",
+  todo: "bg-border-strong dark:bg-border-strong-dark",
+};
+
+/**
+ * Uma milestone do acordeão: cabeçalho tocável e, quando aberta, os itens.
+ *
+ * O cabeçalho inteiro é UM `Pressable`, e os itens são `View` puras. Aninhar
+ * pressable dentro de pressable vira `<button>` dentro de `<button>` no
+ * react-native-web, e o React DOM recusa (foi o bug do #281).
+ */
+function MilestoneRow({
+  milestone,
+  expanded,
+  atual,
+  ultima,
+  onToggle,
+  chevronColor,
+}) {
+  const total = milestone.items.length;
+  const feitos = useMemo(
+    () => milestone.items.filter((i) => i.status === "done").length,
+    [milestone.items],
+  );
+
+  return (
+    <View
+      className={
+        ultima
+          ? ""
+          : "border-b border-border-subtle dark:border-border-subtle-dark"
+      }
+    >
+      <Pressable
+        accessibilityRole="button"
+        accessibilityState={{ expanded }}
+        accessibilityLabel={`${milestone.id}, ${milestone.title}, ${feitos} de ${total} itens, ${expanded ? "expandido" : "recolhido"}`}
+        onPress={onToggle}
+        className="flex-row items-center gap-3 py-3.5 active:opacity-70"
+      >
+        <View className={`h-2.5 w-2.5 rounded-full ${DOT[milestone.status]}`} />
+        <Text
+          className="flex-1 text-base text-ink dark:text-ink-dark"
+          style={{
+            fontFamily: atual ? "Inter_600SemiBold" : "Inter_400Regular",
+          }}
+        >
+          {milestone.id} · {milestone.title}
+        </Text>
+        <Text
+          className="text-xs text-label dark:text-label-dark"
+          style={{ fontFamily: "JetBrainsMono_400Regular" }}
+        >
+          {feitos}/{total}
+        </Text>
+        <Svg width={16} height={16} viewBox="0 0 24 24" fill="none">
+          <Path
+            d={expanded ? "M6 9l6 6 6-6" : "M9 6l6 6-6 6"}
+            stroke={chevronColor}
+            strokeWidth={2.2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </Svg>
+      </Pressable>
+
+      {expanded && total > 0 && (
+        <View className="gap-2.5 pb-4 pl-5">
+          {milestone.items.map((item, i) => (
+            <ItemRow key={i} status={item.status} text={item.text} />
+          ))}
+        </View>
+      )}
+    </View>
   );
 }
 
@@ -165,11 +234,7 @@ function ItemRow({ status, text }) {
   // Bolinha colorida em vez do emoji: done = accentToday, partial = primary,
   // todo = border-strong (vazio). Mais discreto e alinha melhor com o resto
   // do design v2 (WeekStrip usa a mesma paleta pra status de dia).
-  const color = {
-    done: "bg-secondary dark:bg-secondary-dark",
-    partial: "bg-primary dark:bg-primary-dark",
-    todo: "bg-border-strong dark:bg-border-strong-dark",
-  }[status];
+  const color = DOT[status];
   const textColor =
     status === "todo"
       ? "text-label dark:text-label-dark"

--- a/constants/roadmap.js
+++ b/constants/roadmap.js
@@ -112,7 +112,13 @@ export function parseRoadmap(md) {
 }
 
 /**
- * Seleciona o resumo para a Home a partir das milestones parseadas.
+ * Resumo do roadmap: contagem geral e qual milestone está em andamento.
+ *
+ * A tela lista todas as milestones (#303), então o digest ficou só com o que
+ * ela não consegue derivar sozinha. Saíram daqui `recentDone` e
+ * `currentProgress`: o primeiro existia pra compensar a falta de navegação, e
+ * o segundo virou o contador de cada linha do acordeão.
+ *
  * @param {Milestone[]} milestones
  */
 export function getDigest(milestones) {
@@ -128,24 +134,9 @@ export function getDigest(milestones) {
     return next !== -1 ? next : Math.max(0, milestones.length - 1);
   })();
 
-  const current = milestones[currentIndex] ?? null;
-  const currentItems = current?.items ?? [];
-  const currentDone = currentItems.filter((i) => i.status === "done").length;
-
-  // "Concluído recentemente": os ✅ da milestone atual; se poucos, completa
-  // com os da milestone anterior.
-  let recentDone = currentItems.filter((i) => i.status === "done");
-  if (recentDone.length < 3 && currentIndex > 0) {
-    const prev = milestones[currentIndex - 1]?.items ?? [];
-    recentDone = [...prev.filter((i) => i.status === "done"), ...recentDone];
-  }
-  recentDone = recentDone.slice(-4);
-
   return {
     milestonesDone: done,
     milestonesTotal: total,
-    current,
-    currentProgress: { done: currentDone, total: currentItems.length },
-    recentDone,
+    current: milestones[currentIndex] ?? null,
   };
 }

--- a/tests/roadmap.test.js
+++ b/tests/roadmap.test.js
@@ -78,7 +78,17 @@ describe("getDigest", () => {
     expect(d.milestonesDone).toBe(1);
     expect(d.milestonesTotal).toBe(2);
     expect(d.current.id).toBe("M1"); // primeira não-done
-    expect(d.currentProgress).toEqual({ done: 1, total: 3 });
+  });
+
+  test("devolve só o que a tela não deriva sozinha (#303)", () => {
+    // A tela lista todas as milestones e conta os itens de cada uma, então
+    // `recentDone` e `currentProgress` perderam consumidor. Este teste existe
+    // pra que voltar a adicioná-los seja uma decisão, e não um acidente.
+    expect(Object.keys(getDigest(parseRoadmap(MD))).sort()).toEqual([
+      "current",
+      "milestonesDone",
+      "milestonesTotal",
+    ]);
   });
 
   test("current pula milestones ⬜ do meio pra pegar a próxima na ordem (#147)", () => {
@@ -96,15 +106,5 @@ describe("getDigest", () => {
 - ⬜ d
 `;
     expect(getDigest(parseRoadmap(md)).current.id).toBe("M1");
-  });
-
-  test("recentDone completa com a milestone anterior quando há poucos", () => {
-    const d = getDigest(parseRoadmap(MD));
-    // M1 só tem 1 ✅; completa com os 2 ✅ do M0.
-    expect(d.recentDone.map((i) => i.text)).toEqual([
-      "Ambiente configurado",
-      "Navegação entre telas",
-      "Persistência integrada",
-    ]);
   });
 });


### PR DESCRIPTION
Closes #303.

A tela `/roadmap` desenhava três cards e **nunca mostrava milestone que não fosse a atual**. Como a atual é o M6, o M9, que descreve a jornada por níveis e portanto o app inteiro como ele está hoje, ficava inalcançável. O mesmo valia pra tudo que já foi entregue do M0 ao M5 e pro que ainda vem no M7 e M8.

O documento tem 10 milestones. A tela dava acesso a uma.

## O que muda

As 10 aparecem em lista, na ordem do documento, cada linha com bolinha de status, título e contador (`8/11`). Tocar expande os itens, com o mesmo `ItemRow` de antes.

A milestone em andamento **já abre expandida** e vem em semibold. É a que a pessoa quer ver ao entrar, e o comportamento antigo continua disponível sem nenhum toque.

O card de progresso geral fica como estava, no topo.

## O que saiu, e o que isso arrastou

O card **"Concluído recentemente"** foi removido. Ele existia pra compensar a falta de navegação, e a lista o torna redundante.

Com isso, `recentDone` e `currentProgress` ficaram sem nenhum consumidor. Os dois saíram do `getDigest`, junto com o teste do primeiro. O digest agora devolve só o que a tela não deriva sozinha: as contagens e qual é a atual.

Entrou um teste afirmando **exatamente quais chaves** o digest devolve. Deixar campo derivado sem consumidor já custou caro aqui duas vezes, e esse teste faz de voltar a adicionar um uma decisão consciente em vez de acidente.

## Acessibilidade

Cada cabeçalho é um controle de verdade: `accessibilityRole="button"`, `accessibilityState={{ expanded }}` e rótulo que diz o estado, no formato "M9, Jornada por Níveis, 8 de 11 itens, recolhido".

O cabeçalho inteiro é **um** `Pressable`, e os itens são `View` puras. Pressable dentro de Pressable vira `<button>` dentro de `<button>` no react-native-web, que o React DOM recusa. Foi exatamente o bug do #281, e evitei repetir.

O chevron troca de `d` em vez de rotacionar por transform, o que evita depender de animação e mantém o SVG legível nos dois estados.

## Como validar

No BoT Staging, abrir `/roadmap`:

1. As 10 milestones aparecem, do M0 ao M9
2. O M6 já vem aberto e em semibold, com os 4 itens dele
3. Tocar em qualquer outra expande e recolhe, e dá pra ter várias abertas ao mesmo tempo
4. O M9 é alcançável, com os 11 itens da jornada
5. O card de progresso segue em `6/10 · 60%`
6. Conferir claro e escuro, já que a linha tem borda e bolinha próprias

Vale um olhar no web também, onde o aninhamento de pressable apareceria como erro no console.