### PR TITLE
fix(ci): fazer o roadmap chegar na bancada do staging

### DIFF
--- a/.github/workflows/test-pr-on-staging.yaml
+++ b/.github/workflows/test-pr-on-staging.yaml
@@ -18,8 +18,19 @@ name: Test PR on Staging
 # - **Draft** — trabalho em andamento não precisa ocupar a bancada.
 # - **Label `skip-staging`** — escape hatch manual.
 # - **PR de fork** — não recebe `EXPO_TOKEN`, falharia com erro confuso.
-# - **Mudança só de docs/workflow** — `paths-ignore` abaixo; não altera o
-#   bundle, publicar seria gasto de update à toa.
+# - **Mudança só de doc ou de workflow**, pelo filtro `paths` abaixo. Não
+#   altera o bundle, e publicar seria gasto de update à toa.
+#
+#   **Com uma exceção, e ela existe porque a regra acima já foi falsa.** O
+#   `docs/04-roadmap-milestones.md` É código: o `babel-plugin-inline-import`
+#   (ver `babel.config.js`) compila o markdown pra dentro do bundle como
+#   string literal, e `app/roadmap.jsx` o importa. Editar esse arquivo muda o
+#   app. Enquanto ele estava no filtro, duas mudanças reais de tela pularam a
+#   bancada **em silêncio**, sem falha e sem aviso, e foi preciso disparar o
+#   `workflow_dispatch` na mão nos dois casos (#300 e #307). Ver #301.
+#
+#   Se algum dia outro doc virar import, ele entra na lista de exceção junto.
+#   Hoje é o único: `grep -rn 'from \".*\.md\"' app/ components/ constants/`.
 #
 # ## O que garante que isto não vaze pros testers
 #
@@ -30,10 +41,16 @@ name: Test PR on Staging
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
-      - ".github/**"
+    # `paths` com negação em vez de `paths-ignore`, porque `paths-ignore` não
+    # sabe re-incluir. A ordem decide: cada padrão reavalia o caminho, e o
+    # último que casa manda. Por isso a exceção do roadmap vem por último, e
+    # precisa vencer DOIS padrões (`docs/**` e `**/*.md`).
+    paths:
+      - "**"
+      - "!docs/**"
+      - "!**/*.md"
+      - "!.github/**"
+      - "docs/04-roadmap-milestones.md"
   workflow_dispatch:
     inputs:
       pr:


### PR DESCRIPTION
Closes #301.

O `paths-ignore` do `test-pr-on-staging.yaml` pulava `docs/**`, com a justificativa escrita no próprio arquivo de que doc não altera o bundle. Pro `docs/04-roadmap-milestones.md` isso é **falso**: o `babel-plugin-inline-import` compila o markdown pra dentro do bundle como string literal, e o `app/roadmap.jsx` o importa.

O efeito era **silencioso**. O workflow não falhava, não avisava, simplesmente não rodava. Duas mudanças reais de tela pularam a bancada assim (#300 e #307), e nos dois casos precisei disparar o `workflow_dispatch` na mão depois de perceber.

## A correção

`paths-ignore` não sabe re-incluir, então virou `paths` com negação. A ordem decide, porque cada padrão reavalia o caminho e o último que casa manda. A exceção do roadmap vem por último de propósito: precisa vencer **dois** padrões, `docs/**` e `**/*.md`.

O comentário do cabeçalho também estava errado, e era ele que ia enganar a próxima pessoa. Reescrito com a exceção, o motivo dela, e o `grep` que confirma que hoje esse é o único doc importado pelo app.

## Verificação: o PR foi o próprio teste

A issue pedia pra confirmar a semântica da negação em vez de assumir. Foi o que fiz, nos dois sentidos:

**Re-inclusão funciona.** Subi primeiro com um commit temporário tocando o `docs/04`. O job `PR -> branch staging` **rodou e passou**, mesmo com todo o resto do diff caindo em `.github/**`, que é excluído. Sem a re-inclusão nenhum arquivo casaria e o workflow não teria disparado. Run: `32160487473`.

**Exclusão continua valendo.** Removi o commit de prova por force-push. O diff final toca **só** `.github/workflows/test-pr-on-staging.yaml`, e nenhum run novo de staging apareceu. O último segue sendo o mesmo `32160487473`.

Ou seja: a ordem dos padrões se comporta como documentado, e a exceção vence os dois padrões que a cobriam.

## Como validar

Não há nada pra ver no aparelho, e este é o raro caso em que **isso é o resultado esperado**: o PR toca só workflow, então ele não deve mesmo carregar a bancada.

A prova real já está no histórico de runs acima. A próxima confirmação em uso normal vem no próximo PR que editar o roadmap, que deve publicar sozinho, sem `workflow_dispatch` na mão.