### PR TITLE
fix(histórico): listar do mais recente pro mais antigo

### DIFF
--- a/components/MyHistory.jsx
+++ b/components/MyHistory.jsx
@@ -11,6 +11,7 @@ import { get, getByMonth, remove } from "@/infra/database";
 import { confirmAction } from "@/constants/dialogs";
 import { minutesToHHMM } from "@/constants/duration";
 import { router } from "expo-router";
+import { maisRecentesPrimeiro } from "@/constants/recordOrder";
 //#endregion
 
 function formatDate(date) {
@@ -221,7 +222,7 @@ function HistoryList({
 }) {
   return (
     <MyView safe={false} className="w-full items-center gap-3">
-      {Object.values(data).map((obj) => (
+      {maisRecentesPrimeiro(Object.values(data)).map((obj) => (
         <HistoryCard
           key={obj.id}
           obj={obj}

--- a/constants/recordOrder.js
+++ b/constants/recordOrder.js
@@ -1,0 +1,59 @@
+// @ts-nocheck -- helper puro; tipos vêm quando constants/ for tipado (ADR-002)
+
+// Ordem de exibição do histórico (#314).
+//
+// O histórico mostrava o registro mais antigo primeiro, porque nenhuma lista
+// ordenava: a ordem que aparecia era a de iteração da tabela do TinyBase, que
+// na prática é ordem de inserção. Quem abria uma métrica via o registro mais
+// velho no topo e precisava rolar até o fim pra achar o de hoje.
+//
+// ## Por que `date` e não `createdAt`
+//
+// `date` é a data do **evento**, e é ela que a pessoa reconhece. `createdAt` é
+// quando a linha foi gravada, que coincide na maioria dos casos mas não é a
+// mesma coisa. Os dois são estáveis na edição, porque o `update` usa
+// `setPartialRow` e não toca em nenhum dos dois, então editar um registro
+// antigo não o joga pro topo.
+//
+// `createdAt` entra como desempate, pra ordenar dois registros do mesmo
+// instante de `date` na ordem inversa de entrada.
+
+/**
+ * Instante de um registro, em ms, pra fins de ordenação.
+ *
+ * `buildRow` guarda `date: ""` quando a tela não manda data, e aí o parse
+ * falha. Nesse caso vale o `createdAt`, que sempre existe.
+ *
+ * @param {{date?: string, createdAt?: number}} registro
+ * @returns {number}
+ */
+function instante(registro) {
+  const t = Date.parse(registro?.date ?? "");
+  return Number.isFinite(t) ? t : Number(registro?.createdAt) || 0;
+}
+
+/**
+ * Comparador: mais recente primeiro.
+ *
+ * @param {object} a
+ * @param {object} b
+ * @returns {number}
+ */
+export function porMaisRecente(a, b) {
+  const diff = instante(b) - instante(a);
+  if (diff !== 0) return diff;
+  return (Number(b?.createdAt) || 0) - (Number(a?.createdAt) || 0);
+}
+
+/**
+ * Cópia da lista, do mais recente pro mais antigo.
+ *
+ * Copia de propósito: os chamadores passam o resultado de `Object.values` ou
+ * um array vindo do store, e ordenar no lugar esconderia efeito colateral.
+ *
+ * @param {Array<object>} registros
+ * @returns {Array<object>}
+ */
+export function maisRecentesPrimeiro(registros) {
+  return [...(registros ?? [])].sort(porMaisRecente);
+}

--- a/infra/database.js
+++ b/infra/database.js
@@ -2,6 +2,7 @@
 import { createMergeableStore } from "tinybase";
 
 import { DEFAULT_GOALS } from "@/constants/goals";
+import { maisRecentesPrimeiro } from "@/constants/recordOrder";
 
 const TABLE = "records";
 const TESTERS = "testers";
@@ -181,6 +182,12 @@ export function getByDate(isoDate) {
       if (!porTipo[linha.type]) porTipo[linha.type] = [];
       porTipo[linha.type].push(hidratar(id, linha));
     }
+  }
+  // Mais recente primeiro (#314). A ordem natural aqui é a de iteração da
+  // tabela, que na prática é ordem de inserção, e a tela de histórico mostrava
+  // o registro mais velho do dia no topo.
+  for (const tipo of Object.keys(porTipo)) {
+    porTipo[tipo] = maisRecentesPrimeiro(porTipo[tipo]);
   }
   return porTipo;
 }

--- a/tests/database.test.js
+++ b/tests/database.test.js
@@ -28,7 +28,10 @@ describe("registros", () => {
     const today = getToday();
     expect(today.water).toHaveLength(2);
     expect(today.sleep).toHaveLength(1);
-    expect(today.water[0].quantity).toBe(500);
+    // Mais recente primeiro (#314): o 300 entrou depois do 500, então vem
+    // antes. Este teste afirmava o contrário, porque a ordem era a de
+    // inserção da tabela e ninguém tinha decidido nada sobre ela.
+    expect(today.water.map((r) => r.quantity)).toEqual([300, 500]);
   });
 
   test("getByDate isola o dia (não mistura com hoje)", () => {

--- a/tests/record-order.test.js
+++ b/tests/record-order.test.js
@@ -1,0 +1,89 @@
+// @ts-nocheck -- teste; globals do jest não são tipados (ADR-002)
+
+// Ordem do histórico (#314). O bug era ausência de ordenação: a lista saía na
+// ordem de inserção da tabela, com o registro mais antigo no topo.
+
+import { maisRecentesPrimeiro, porMaisRecente } from "../constants/recordOrder";
+
+const reg = (date, createdAt) => ({ date, createdAt });
+
+describe("maisRecentesPrimeiro", () => {
+  it("põe o registro mais recente no topo", () => {
+    const lista = [
+      reg("2026-08-10T09:00:00.000Z", 100),
+      reg("2026-08-17T09:00:00.000Z", 300),
+      reg("2026-08-14T09:00:00.000Z", 200),
+    ];
+    expect(maisRecentesPrimeiro(lista).map((r) => r.date)).toEqual([
+      "2026-08-17T09:00:00.000Z",
+      "2026-08-14T09:00:00.000Z",
+      "2026-08-10T09:00:00.000Z",
+    ]);
+  });
+
+  it("ordena por hora dentro do mesmo dia", () => {
+    // As telas gravam toISOString() completo, então o horário separa registros
+    // do mesmo dia sem precisar do desempate.
+    const lista = [
+      reg("2026-08-17T08:00:00.000Z", 1),
+      reg("2026-08-17T21:00:00.000Z", 2),
+      reg("2026-08-17T13:00:00.000Z", 3),
+    ];
+    expect(maisRecentesPrimeiro(lista).map((r) => r.date)).toEqual([
+      "2026-08-17T21:00:00.000Z",
+      "2026-08-17T13:00:00.000Z",
+      "2026-08-17T08:00:00.000Z",
+    ]);
+  });
+
+  it("desempata pelo createdAt quando a data é idêntica", () => {
+    const lista = [
+      reg("2026-08-17T08:00:00.000Z", 10),
+      reg("2026-08-17T08:00:00.000Z", 30),
+      reg("2026-08-17T08:00:00.000Z", 20),
+    ];
+    expect(maisRecentesPrimeiro(lista).map((r) => r.createdAt)).toEqual([
+      30, 20, 10,
+    ]);
+  });
+
+  it("cai no createdAt quando date não parseia", () => {
+    // buildRow grava `date: ""` quando a tela não manda data.
+    const lista = [reg("", 100), reg("", 300), reg("", 200)];
+    expect(maisRecentesPrimeiro(lista).map((r) => r.createdAt)).toEqual([
+      300, 200, 100,
+    ]);
+  });
+
+  it("não ordena no lugar", () => {
+    const lista = [
+      reg("2026-08-10T00:00:00.000Z", 1),
+      reg("2026-08-17T00:00:00.000Z", 2),
+    ];
+    const copia = [...lista];
+    maisRecentesPrimeiro(lista);
+    expect(lista).toEqual(copia);
+  });
+
+  it("tolera lista vazia e ausente", () => {
+    expect(maisRecentesPrimeiro([])).toEqual([]);
+    expect(maisRecentesPrimeiro(undefined)).toEqual([]);
+  });
+});
+
+describe("porMaisRecente", () => {
+  it("editar um registro antigo não muda a posição dele", () => {
+    // O `update` usa setPartialRow e não toca em date nem createdAt. Este
+    // teste trava esse contrato: se algum dia a edição passar a regravar um
+    // dos dois, o registro editado pularia pro topo do histórico.
+    const antigo = reg("2026-08-01T10:00:00.000Z", 100);
+    const novo = reg("2026-08-17T10:00:00.000Z", 200);
+    const antes = [novo, antigo].sort(porMaisRecente);
+
+    const antigoEditado = { ...antigo, quantity: 999 };
+    const depois = [novo, antigoEditado].sort(porMaisRecente);
+
+    expect(depois.map((r) => r.date)).toEqual(antes.map((r) => r.date));
+    expect(depois[1].quantity).toBe(999);
+  });
+});


### PR DESCRIPTION
Closes #314.

O histórico abria no registro mais antigo, e era preciso rolar até o fim pra achar o de hoje.

## A causa

Nenhuma das listas ordenava. O que aparecia era a ordem de iteração da tabela do TinyBase, que na prática é ordem de inserção. Ninguém tinha decidido isso, era só o que sobrava.

## Dois pontos cobrem tudo

- **`HistoryList`** em `components/MyHistory.jsx`, por onde passam as três variantes (`MyHistory`, `MyMonthHistory`, `MyExerciseHistory`) que as telas de métrica usam
- **`getByDate`** em `infra/database.js`, que alimenta `app/history.jsx` e o `getToday`

## Por qual campo

Por **`date`**, que é a data do evento e é a que a pessoa reconhece, com **`createdAt`** de desempate. As telas gravam `toISOString()` completo, então o horário já separa registros do mesmo dia, e o desempate só age quando o instante é idêntico.

Quando `date` não parseia, e o `buildRow` grava `""` se a tela não mandar data, vale o `createdAt`, que sempre existe.

## O detalhe que me fez escolher esses campos

Os dois são **estáveis na edição**: o `update` usa `setPartialRow` e não toca em `date` nem em `createdAt`. Se eu tivesse ordenado por um campo regravado na edição, corrigir a quantidade de um registro de duas semanas atrás o jogaria pro topo do histórico.

Tem teste travando esse contrato, pra que uma mudança futura no `update` quebre o CI em vez de virar um bug estranho de ordenação.

## Um teste que afirmava o contrário

`tests/database.test.js` verificava `today.water[0].quantity === 500`, que era o **primeiro inserido**. Em vez de só trocar o número esperado, troquei por uma asserção sobre a lista inteira, que declara a ordem nova de propósito.

## Nenhum outro consumidor depende da ordem

Conferi os demais usos de `getToday` e `getByMonth`: `WaterQuickAdd`, `FeedingBespoke` e `app/index.jsx` só fazem `reduce` e `length`.

292 testes verdes, 7 deles novos.

## Como validar

No BoT Staging:

1. Abrir qualquer métrica com histórico e ver o registro de hoje **no topo**
2. A tela de histórico por dia, com o mesmo comportamento dentro do dia
3. **Editar um registro antigo** e confirmar que ele fica onde estava, em vez de subir