### PR TITLE
chore(texto): tirar o travessão de constants, infra, server e scripts (fatia 3a da #302)

### DIFF
--- a/constants/Colors.js
+++ b/constants/Colors.js
@@ -1,7 +1,7 @@
 export const Colors = {
   primary: "#2E5A88",
   secondary: "#4CAF50",
-  // Ação destrutiva e erro visível — Material red-500, combina com o
+  // Ação destrutiva e erro visível: Material red-500, combina com o
   // secondary que é Material green-500. Ver docs/08-design-tokens.md.
   danger: "#F44336",
   light: {

--- a/constants/distribution.js
+++ b/constants/distribution.js
@@ -4,7 +4,7 @@
 // "Obter o app" usa, porque o Chrome do Android BLOQUEIA o download direto de
 // APK de URL pública (o Safe Browsing baixa 100% e descarta o arquivo); a
 // página do EAS instala mesmo no Chrome (testado deslogado, em aba anônima).
-// É POR BUILD — trocar a cada build NATIVO novo (raro: o OTA cobre mudanças de
+// É POR BUILD: trocar a cada build NATIVO novo (raro: o OTA cobre mudanças de
 // JS). Ver issue #90.
 //
 // APK_URL: download direto do APK via GitHub Releases (/latest/, estável).

--- a/constants/environment.js
+++ b/constants/environment.js
@@ -2,7 +2,7 @@
 //
 // Antes daqui o único campo era `Platform.OS + Platform.Version`, que produzia
 // "android 36" ou "web 0.0.0". A informação existia, mas exigia saber que
-// `web` = navegador e `android` = app nativo — quem tria a issue não sabe. E no
+// `web` = navegador e `android` = app nativo, e quem tria a issue não sabe. E no
 // navegador o "web 0.0.0" não dizia NADA: nem qual browser, nem qual OS, justo
 // no caso mais difícil de reproduzir.
 //
@@ -28,7 +28,7 @@ function describeEnvironment() {
  */
 function describeBundle() {
   try {
-    // Em dev/web esses campos vêm nulos — degrada sem quebrar.
+    // Em dev/web esses campos vêm nulos, então degrada sem quebrar.
     const { updateId, channel, isEmbeddedLaunch } = Updates;
     if (!updateId) return isEmbeddedLaunch ? "embutido no app" : "";
     const curto = String(updateId).slice(0, 8);
@@ -45,7 +45,7 @@ function describeBundle() {
  * capacidade de validar no BoT Staging.
  *
  * ⚠️ **`__DEV__` sozinho não serve.** O BoT Staging é build de produção
- * (`--environment preview`), então `__DEV__` é `false` lá — e apagaria os
+ * (`--environment preview`), então `__DEV__` é `false` lá, e apagaria os
  * controles justamente no lugar onde a validação acontece, que é a regra do
  * projeto.
  *

--- a/constants/feedback.js
+++ b/constants/feedback.js
@@ -4,7 +4,7 @@
 // FEEDBACK_ENDPOINT: função serverless na Vercel, mesma origem do web export
 // (ver package.json "homepage"). É ela que guarda o PAT e abre a issue.
 // FEEDBACK_KEY: segredo compartilhado semi-público (EXPO_PUBLIC_*, embutido no
-// bundle) só pra deter abuso casual — o token real fica só na Vercel. Se vazio,
+// bundle) só pra deter abuso casual. O token real fica só na Vercel. Se vazio,
 // o endpoint aceita sem header (liga-se o segredo depois definindo a env dos
 // dois lados).
 

--- a/constants/goals.js
+++ b/constants/goals.js
@@ -2,19 +2,19 @@
 
 // Metas por métrica (#285, fatia 0 do modelo de níveis).
 //
-// Antes disto as metas eram texto fixo em `app/ajustes.jsx` — display-only,
+// Antes disto as metas eram texto fixo em `app/ajustes.jsx`: display-only,
 // sem existir como dado. O modelo de níveis não fecha sem elas: o portão de
 // nível compara comportamento contra um alvo, e "8h pra todo mundo" é mentira
 // (tem gente que precisa de 7). Ver `docs/11-modelo-de-niveis.md` §10.
 //
 // Esta fatia só transforma em dado, com os mesmos valores de hoje. Edição
-// pelo usuário é fatia própria — o que importa agora é a forma, pra os sinais
+// pelo usuário é fatia própria, e o que importa agora é a forma, pra os sinais
 // de automaticidade terem contra o que medir.
 
 /** Unidades vêm do `CATEGORY_MAP`; aqui só o alvo diário. */
 export const DEFAULT_GOALS = {
-  water: 2000, // ml — "2,0 L" no Ajustes de hoje
-  sleep: 480, // min — 8h
+  water: 2000, // ml, "2,0 L" no Ajustes de hoje
+  sleep: 480, // min, 8h
   exercise: 30, // min
   feeding: 3, // refeições
   study: 30, // min
@@ -25,11 +25,11 @@ export const DEFAULT_GOALS = {
  * (`docs/11-modelo-de-niveis.md` §6) e, mais pra frente, como o portão lê o
  * hábito.
  *
- * - `sum` — soma do dia contra o alvo (água, exercício, estudo, refeições).
- * - `presence` — houve registro? (a quantidade não decide nada)
+ * - `sum`: soma do dia contra o alvo (água, exercício, estudo, refeições).
+ * - `presence`: houve registro? (a quantidade não decide nada)
  *
  * **Sono é `presence` de propósito.** A §4 do modelo é explícita: o portão é
- * comportamento, nunca desfecho. Ninguém decide dormir 8h — decide deitar às
+ * comportamento, nunca desfecho. Ninguém decide dormir 8h. Decide deitar às
  * 23h30. Somar duração e comparar com 480 min gatearia nível por uma coisa
  * fora do controle da pessoa. A duração segue registrada e exibida; quem
  * avalia o hábito é a regularidade do horário (ver `regularity` em
@@ -44,7 +44,7 @@ export const GOAL_KIND = {
 };
 
 /**
- * Cadência esperada do hábito — define a unidade da regra de quebra (§6).
+ * Cadência esperada do hábito: define a unidade da regra de quebra (§6).
  *
  * Exercício e estudo não são diários (3–5×/semana é o normal). Tratá-los como
  * diários rebaixaria alguém por descansar no fim de semana.
@@ -77,7 +77,7 @@ export function goalFor(goals, metric) {
  * Meta formatada pra exibição, na unidade que a pessoa lê.
  *
  * O alvo é guardado na unidade canônica da métrica (ml, minutos, refeições),
- * mas ninguém lê "2000 ml" nem "480 min" — lê "2,0 L" e "8h". Este é o
+ * mas ninguém lê "2000 ml" nem "480 min". Lê "2,0 L" e "8h". Este é o
  * mesmo texto que estava chumbado em `app/ajustes.jsx` antes da #285.
  *
  * @param {string} metric

--- a/constants/greeting.js
+++ b/constants/greeting.js
@@ -8,7 +8,7 @@
 /**
  * Só o PRIMEIRO nome: corta no primeiro caractere não-alfabético.
  *
- * `\p{L}` (com flag `u`) é letra Unicode, então acento passa — "João da
+ * `\p{L}` (com flag `u`) é letra Unicode, então acento passa, e "João da
  * Silva" vira "João", não "Jo". Cobre de uma vez os separadores que aparecem
  * de verdade: espaço ("Matheus Henrique"), ponto do email
  * ("matheus.mhddn") e dígito.
@@ -52,7 +52,7 @@ export function pickName(user, displayName) {
   const localpart = String(email).split("@")[0] || "";
   const derivado = firstName(localpart);
   if (!derivado) return "";
-  // Aqui o lowercase vale: localpart é derivado, não escolhido — normaliza
+  // Aqui o lowercase vale: localpart é derivado, não escolhido, então normaliza
   // "MATHEUS.MHDDN@..." pra "Matheus".
   return derivado.charAt(0).toUpperCase() + derivado.slice(1).toLowerCase();
 }

--- a/constants/habitSignals.js
+++ b/constants/habitSignals.js
@@ -3,13 +3,13 @@
 // Sinais de automaticidade (#285, fatia 0 do modelo de níveis).
 //
 // Lally et al. mediram automaticidade com questionário (SRHI). Não temos isso
-// e não queremos — questionário é fricção, e o app inteiro é construído em
+// e não queremos: questionário é fricção, e o app inteiro é construído em
 // cima de registro rápido. O que temos é registro com timestamp e quantidade.
 //
 // Daqui sai um **proxy comportamental**, não uma medida. Ver
 // `docs/11-modelo-de-niveis.md` §5.
 //
-// ⚠️ Nesta fatia nada consome estes números — nenhum limiar, nenhum nível.
+// ⚠️ Nesta fatia nada consome estes números: nenhum limiar, nenhum nível.
 // São medição silenciosa, pra calibrar os limiares com dado real antes de
 // pendurar consequência neles (§12). O cálculo pode estar errado sem machucar
 // ninguém enquanto isso for verdade.
@@ -18,7 +18,7 @@ import { GOAL_KIND } from "./goals";
 
 const MS_DIA = 86_400_000;
 
-/** Chave de dia-calendário local (não UTC — o dia do usuário é o local). */
+/** Chave de dia-calendário local (não UTC, porque o dia do usuário é o local). */
 function diaLocal(ms) {
   const d = new Date(ms);
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
@@ -39,7 +39,7 @@ function minutoDoDia(ms) {
  * @param {number} days Tamanho da janela.
  * @param {number} [now] Epoch ms; injetável pra teste.
  * @returns {Array<{dia: string, total: number, hit: boolean}>} Sempre com
- *   `days` posições — dia sem registro entra como `total: 0, hit: false`.
+ *   `days` posições: dia sem registro entra como `total: 0, hit: false`.
  */
 export function dailyVerdicts(records, metric, target, days, now = Date.now()) {
   const kind = GOAL_KIND[metric] ?? "sum";
@@ -65,7 +65,7 @@ export function dailyVerdicts(records, metric, target, days, now = Date.now()) {
     const info = porDia.get(k);
     const total = info?.total ?? 0;
     const n = info?.n ?? 0;
-    // `presence`: houve registro basta. A quantidade não decide (§4 — sono é
+    // `presence`: houve registro basta. A quantidade não decide (§4, sono é
     // desfecho, não comportamento).
     const hit = kind === "presence" ? n > 0 : total >= target;
     out.push({ dia: k, total, hit });
@@ -90,11 +90,11 @@ export function consistency(verdicts) {
  *
  * Comportamento automático é disparado por contexto e acontece em horário
  * parecido; a dispersão cai conforme o hábito assenta. É o sinal menos óbvio
- * dos três e sai de graça — todo registro já tem `createdAt`.
+ * dos três e sai de graça, porque todo registro já tem `createdAt`.
  *
  * ⚠️ **Horário é circular, e desvio-padrão comum erra feio nele.** 23h50 e
  * 00h10 distam 20 minutos, não 23h40. Um `stddev` sobre "minutos desde a
- * meia-noite" trataria essas duas noites como caos absoluto — e o caso que
+ * meia-noite" trataria essas duas noites como caos absoluto, e o caso que
  * mais importa, o horário de deitar, vive exatamente em cima da meia-noite.
  *
  * Por isso a estatística é circular: cada horário vira um ângulo no relógio de
@@ -132,7 +132,7 @@ export function regularity(records, metric, days, now = Date.now()) {
   const resultant = Math.sqrt(sx * sx + sy * sy) / n;
 
   // R=0 seria dispersão total; o log divergiria. Trava num piso pra devolver
-  // número em vez de Infinity — quem lê quer "muito irregular", não NaN.
+  // número em vez de Infinity: quem lê quer "muito irregular", não NaN.
   const R = Math.max(resultant, 1e-6);
   const sdRad = Math.sqrt(-2 * Math.log(R));
   const sdMinutes = (sdRad * 1440) / (2 * Math.PI);
@@ -143,11 +143,11 @@ export function regularity(records, metric, days, now = Date.now()) {
 /**
  * Resiliência: depois de uma falha isolada, voltou no dia seguinte?
  *
- * Hábito automático se recupera sozinho; hábito frágil vira duas faltas — e a
+ * Hábito automático se recupera sozinho; hábito frágil vira duas faltas, e a
  * segunda falta consecutiva é onde o laço quebra (§6). Este sinal mede
  * exatamente a diferença entre um tropeço e o começo de um hábito novo.
  *
- * ⚠️ **Oportunidade é só a falha ISOLADA** — a primeira de uma sequência, a
+ * ⚠️ **Oportunidade é só a falha ISOLADA**: a primeira de uma sequência, a
  * que vem logo depois de um dia no alvo. Contar toda falha faria uma recaída
  * longa pontuar como recuperação quando enfim acabasse: numa sequência
  * `alvo, falha, falha, alvo`, o segundo dia de queda "recuperou" no papel. O
@@ -159,11 +159,11 @@ export function regularity(records, metric, days, now = Date.now()) {
  * Só conta oportunidades em que havia dia seguinte dentro da janela.
  *
  * `doubleMisses` é medida à parte e conta **todo** par de falhas consecutivas
- * — é a regra de quebra da §6, não a de recuperação.
+ * porque essa é a regra de quebra da §6, não a de recuperação.
  *
  * @param {Array<{hit: boolean}>} verdicts Cronológico (saída de `dailyVerdicts`).
  * @returns {{rate: number|null, recovered: number, opportunities: number, doubleMisses: number}}
- *   `rate` é `null` quando não houve falha isolada — não dá pra afirmar nada
+ *   `rate` é `null` quando não houve falha isolada, porque não dá pra afirmar nada
  *   sobre recuperação de quem nunca caiu.
  */
 export function resilience(verdicts) {

--- a/constants/journey.js
+++ b/constants/journey.js
@@ -3,7 +3,7 @@
 // Estado da jornada por níveis (#289, fatia 1).
 //
 // Deriva de `records` + metas: em que nível a pessoa está e qual o status de
-// cada hábito. **Nada aqui muda o uso do app ainda** — o resultado só aparece
+// cada hábito. **Nada aqui muda o uso do app ainda**: o resultado só aparece
 // no bloco de diagnóstico em Ajustes → Avançado.
 //
 // Modelo completo em `docs/11-modelo-de-niveis.md`.
@@ -17,7 +17,7 @@ import {
 } from "./habitSignals";
 
 /**
- * ⚠️ LIMIARES PROVISÓRIOS — nenhum destes números tem dado que o sustente.
+ * ⚠️ LIMIARES PROVISÓRIOS: nenhum destes números tem dado que o sustente.
  *
  * A #285 rodou os sinais sobre o histórico real e achou 10 dias de registro:
  * não fecha nem a janela de 28 dias do portão, muito menos uma curva de
@@ -38,7 +38,7 @@ export const THRESHOLDS = {
      * Piso de amostra pra regularidade significar alguma coisa.
      *
      * Achado da #285: estudo marcou R=0,99 sobre **2 registros**. Duas
-     * amostras sempre parecem concentradas — sem piso, o sinal reporta
+     * amostras sempre parecem concentradas, e sem piso o sinal reporta
      * perfeição espúria e abriria o portão pra quem registrou duas vezes.
      */
     regularityMinSamples: 8,
@@ -64,7 +64,7 @@ export const PAUSED = "paused";
 /**
  * O hábito passou do portão? (perto de automático)
  *
- * Regularidade só conta com amostra suficiente — ver `regularityMinSamples`.
+ * Regularidade só conta com amostra suficiente, ver `regularityMinSamples`.
  * Sem amostra o hábito **não** passa: portão aberto por falta de evidência é
  * pior que portão fechado, porque empilha o próximo hábito em cima de nada.
  */
@@ -74,14 +74,14 @@ export function passesGate(signals, limiares = THRESHOLDS) {
   if (signals.regularity.n < gate.regularityMinSamples) return false;
   if (signals.regularity.sdMinutes == null) return false;
   if (signals.regularity.sdMinutes > gate.regularityMaxSd) return false;
-  // Falta dupla na janela é o sinal de laço quebrado (§6) — não é "perto de
+  // Falta dupla na janela é o sinal de laço quebrado (§6), e não "perto de
   // automático" quem ainda desaba dois dias seguidos.
   if (signals.resilience.doubleMisses > 0) return false;
   return true;
 }
 
 /**
- * O hábito graduou? (automático — deixa de poder causar regressão)
+ * O hábito graduou? (automático, deixa de poder causar regressão)
  *
  * Mesma régua do portão com barra mais alta, nunca "N semanas": prazo fixo
  * contradiz o argumento do próprio portão (§7).
@@ -93,7 +93,7 @@ export function passesGraduation(signals, limiares = THRESHOLDS) {
   if (signals.regularity.n < graduation.regularityMinSamples) return false;
   if (signals.regularity.sdMinutes > graduation.regularityMaxSd) return false;
   // Quem nunca falhou não tem taxa de recuperação (`null`). Isso NÃO impede
-  // graduação — é ausência de queda, não ausência de resiliência.
+  // graduação: é ausência de queda, não ausência de resiliência.
   if (
     signals.resilience.rate != null &&
     signals.resilience.rate < graduation.resilience
@@ -104,7 +104,7 @@ export function passesGraduation(signals, limiares = THRESHOLDS) {
 }
 
 /**
- * O hábito quebrou, conforme a cadência dele? (§6 — três regras, não uma)
+ * O hábito quebrou, conforme a cadência dele? (§6, três regras em vez de uma)
  *
  * - **diário** → duas faltas consecutivas. Perder um dia custa menos de meio
  *   ponto de automaticidade e recupera rápido (Lally); a segunda falta é onde
@@ -146,13 +146,13 @@ export function isBroken(verdicts, cadence, porSemana = 3) {
  * ## Por que precisa de `previousLevel`
  *
  * O nível é **derivado dos sinais**: sobe quando o hábito do topo passa o
- * portão. Nesse desenho, "quebrar" já é deixar de passar — a queda é
+ * portão. Nesse desenho, "quebrar" já é deixar de passar, e a queda é
  * implícita, e olhando só o presente é **impossível distinguir "caiu do lvl 3"
  * de "nunca passou do lvl 2"**.
  *
  * Regressão exige memória. `previousLevel` é o maior nível já alcançado,
  * persistido no store; é a comparação com ele que transforma uma queda em
- * evento — o que a tela 4a·2 do design precisa pra dizer "voltamos pra água".
+ * evento, o que a tela 4a·2 do design precisa pra dizer "voltamos pra água".
  *
  * Sem `previousLevel` a função continua correta, só não afirma regressão —
  * é o caso do primeiro uso, onde não há passado pra comparar.
@@ -162,7 +162,7 @@ export function isBroken(verdicts, cadence, porSemana = 3) {
  * Decisão da #289. Se no lvl 3 a água quebra (mais antiga, não graduada),
  * pausar a água deixaria a alimentação órfã no topo sem base. Pausando o
  * topo, larga-se a carga mais nova e o foco volta pro hábito que está
- * sofrendo — que é a copy do design ("o foco volta pra água por um tempo").
+ * sofrendo, que é a copy do design ("o foco volta pra água por um tempo").
  *
  * @param {{records: Array, goals?: object, now?: number, previousLevel?: number|null, granted?: string[], thresholds?: object}} args
  * @returns {{level: number, habits: object, focus: string|null, regressed: boolean}}
@@ -188,13 +188,13 @@ export function deriveJourney({
       regularity: regularity(lista, metric, janela, now),
       resilience: resilience(verdicts),
     };
-    // `broken` é INFORMATIVO — serve pra explicar por que caiu, não pra
+    // `broken` é INFORMATIVO: serve pra explicar por que caiu, não pra
     // derrubar. Quem derruba é o portão. E hábito sem nenhum acerto na janela
     // não está quebrado: não começou.
     const comecou = signals.consistency.hits > 0;
     // Concessão por conferência (#295): o hábito entra graduado sem esperar a
     // barra alta. A evidência exigida foi a do portão, avaliada sobre o mesmo
-    // histórico — não é atalho, é reconhecimento antecipado.
+    // histórico: é reconhecimento antecipado, e não atalho.
     const concedido = (granted ?? []).includes(metric);
     porMetrica[metric] = {
       signals,
@@ -206,7 +206,7 @@ export function deriveJourney({
   }
 
   // 2. Nível = quantos hábitos, em ordem, passam o portão AGORA. O primeiro
-  //    que não passa interrompe a escada — e é o que está sendo construído.
+  //    que não passa interrompe a escada, e é o que está sendo construído.
   let gateLevel = 0;
   for (const metric of JOURNEY_ORDER) {
     if (porMetrica[metric].gated) gateLevel += 1;
@@ -233,7 +233,7 @@ export function deriveJourney({
     habits[metric] = { status, ...info };
   });
 
-  // Foco = o hábito em construção — o card grande da Home (fatia 2).
+  // Foco = o hábito em construção, o card grande da Home (fatia 2).
   const focus =
     JOURNEY_ORDER.slice(0, level)
       .filter((m) => habits[m].status === BUILDING)

--- a/constants/journeyHome.js
+++ b/constants/journeyHome.js
@@ -4,7 +4,7 @@
 //
 // Ficam fora do componente pelo mesmo motivo do `bannerPriority.js`: importar
 // a Home no jest puxa a cadeia toda até AsyncStorage. Aqui mora o que tem
-// risco de bug — qual ação rápida, qual copy, o que vai pra cada zona.
+// risco de bug: qual ação rápida, qual copy, o que vai pra cada zona.
 //
 // Telas 4a·1 e 4a·3 do Turno 4 do Claude Design.
 
@@ -25,7 +25,7 @@ export const METRIC_TINT = {
  * Ações rápidas do card de foco, por métrica.
  *
  * ⚠️ **Sono não tem incremento, e isso não é omissão.** O design mostra
- * `+200ml / +300ml / +500ml`, que serve pra água — mas sono se registra por
+ * `+200ml / +300ml / +500ml`, que serve pra água, mas sono se registra por
  * horário de deitar e acordar, não por quantidade acumulada. E sono é o
  * **primeiro** foco da jornada: o card do lvl 1, o primeiro que qualquer
  * pessoa vê, é justamente o que não tem incremento sensato.
@@ -62,7 +62,7 @@ export function quickAddLabel(metric, valor) {
 /**
  * Chip de contexto do header: `lvl N · <hábito>`.
  *
- * O nível é **contexto, não pontuação** — por isso vive num chip discreto e
+ * O nível é **contexto, não pontuação**, e por isso vive num chip discreto e
  * nunca como número grande (docs/11-modelo-de-niveis.md §1.5).
  */
 export function levelChip(level, focus) {
@@ -83,7 +83,7 @@ export function headerCopy(journey) {
   const { focus, habits, regressed } = journey ?? {};
 
   if (!focus) {
-    // lvl 0 — nada conquistado ainda. Convite, não vazio.
+    // lvl 0: nada conquistado ainda. Convite, não vazio.
     return {
       title: "Só registrar hoje.",
       subtitle: "Qualquer coisa. O que aparecer.",
@@ -107,7 +107,7 @@ export function headerCopy(journey) {
   if (estaveis.length === 0) {
     return { title, subtitle: "Sem pressa. Um de cada vez." };
   }
-  // "já é seu" reconhece sem premiar — reforço sóbrio.
+  // "já é seu" reconhece sem premiar: reforço sóbrio.
   const lista =
     estaveis.length === 1
       ? `${estaveis[0]} já é seu`
@@ -121,7 +121,7 @@ export function headerCopy(journey) {
 /**
  * Divide as métricas entre a zona de foco e a de "resto do dia".
  *
- * **Nada some** — é a decisão central do design (hierarquia, não exclusão).
+ * **Nada some**: é a decisão central do design (hierarquia, não exclusão).
  * Métrica trancada continua na lista, só sem valor a mostrar. Por isso o
  * rodapé promete "tudo continua registrável", e a promessa precisa ser
  * verdadeira.

--- a/constants/journeyMoments.js
+++ b/constants/journeyMoments.js
@@ -1,13 +1,13 @@
 // @ts-nocheck -- helper puro; tipos vêm quando constants/ for tipado (ADR-002)
 
-// Momentos da jornada (#293, fatia 3a) — telas 4a·2 e 4a·4 do Turno 4.
+// Momentos da jornada (#293, fatia 3a): telas 4a·2 e 4a·4 do Turno 4.
 //
 // Um momento aparece UMA VEZ e some. Quem garante isso é o `journeyAckLevel`
 // no store: o nível que a pessoa já viu. Sem ele o aviso de regressão
 // reapareceria em toda abertura do app.
 //
 // Tom: reforço sóbrio (docs/11-modelo-de-niveis.md §1.5). Subir de nível é
-// reconhecimento em prosa, não celebração — sem confete, sem verde de vitória,
+// reconhecimento em prosa, não celebração: sem confete, sem verde de vitória,
 // sem "🎉". E a regressão não tem vermelho nem palavra de culpa.
 
 import { CATEGORY_MAP } from "@/components/categoryUtils";
@@ -37,7 +37,7 @@ export function pendingMoment(level, ackLevel) {
  * Qual hábito foi conquistado ao chegar neste nível.
  *
  * ⚠️ **`null` abaixo do lvl 2, e isso não é detalhe.** No lvl 1 o primeiro
- * hábito está sendo CONSTRUÍDO, não conquistado — nada virou seu ainda.
+ * hábito está sendo CONSTRUÍDO, não conquistado, e nada virou seu ainda.
  * Sem esta guarda o sheet diria "Sono virou seu" tendo "Sono" também como
  * próximo foco: o mesmo hábito nos dois papéis, na primeira subida que a
  * pessoa veria.
@@ -57,9 +57,9 @@ const capitalizar = (s) => `${s.charAt(0).toUpperCase()}${s.slice(1)}`;
  * Copy do sheet de subir de nível (4a·4).
  *
  * Três movimentos, nessa ordem:
- * 1. **nomeia o que virou seu** — "Sono virou seu" é reconhecimento em prosa;
- * 2. **explica o que muda** — para de cobrar atenção;
- * 3. **antecipa a queda** — "sem drama". Tirar peso do futuro antes que ele
+ * 1. **nomeia o que virou seu**: "Sono virou seu" é reconhecimento em prosa;
+ * 2. **explica o que muda**: para de cobrar atenção;
+ * 3. **antecipa a queda**: "sem drama". Tirar peso do futuro antes que ele
  *    chegue é o que impede o reconhecimento de virar dívida.
  *
  * @param {{from: number, to: number, achieved: string, next: string|null}} args
@@ -85,7 +85,7 @@ export function levelUpCopy({ from, to, achieved, next }) {
 /**
  * Copy do aviso de regressão (4a·2).
  *
- * ⚠️ **"voltamos", primeira pessoa do plural.** O app voltou junto — não é a
+ * ⚠️ **"voltamos", primeira pessoa do plural.** O app voltou junto, e não é a
  * pessoa que falhou sozinha. E o hábito fica **"em pausa"**, nunca "perdido".
  *
  * A promessa de que nada sumiu vem acompanhada de um botão pro histórico:

--- a/constants/journeySkip.js
+++ b/constants/journeySkip.js
@@ -1,6 +1,6 @@
 // @ts-nocheck -- helper puro; tipos vêm quando constants/ for tipado (ADR-002)
 
-// Pular nível com conferência do histórico (#295) — tela 4a·6 do Turno 4.
+// Pular nível com conferência do histórico (#295): tela 4a·6 do Turno 4.
 //
 // ⚠️ **O critério pra pular é o MESMO critério do portão.** Não se pula o
 // portão: entra-se nele já qualificado, com evidência avaliada sobre a mesma
@@ -13,8 +13,8 @@
 //
 // Duas coisas da tela que não são decoração:
 //
-// - **números concretos, não veredito.** O app mostra o que viu — dias com
-//   registro, dispersão do horário — em vez de dar uma nota.
+// - **números concretos, não veredito.** O app mostra o que viu: dias com
+//   registro, dispersão do horário, em vez de dar uma nota.
 // - **antecipa o caso oposto.** Dizer de antemão o que acontece se não bater
 //   é o que impede a tela de virar interrogatório: não confia cego, mas
 //   também não desconfia hostil.
@@ -43,7 +43,7 @@ export function skipQualifies(signals, thresholds) {
  * Os números que o app viu, prontos pra exibir.
  *
  * Cada linha é um fato observável, não uma avaliação. `—` quando não há
- * amostra pra afirmar nada — dizer "0 min de variação" com dois registros
+ * amostra pra afirmar nada: dizer "0 min de variação" com dois registros
  * seria inventar precisão.
  *
  * @param {object} signals

--- a/constants/navigation.js
+++ b/constants/navigation.js
@@ -9,7 +9,7 @@
 //   - deep link direto (`backontrack://admin`, magic link do auth);
 //   - Fast Refresh no dev.
 //
-// Nesses casos o botão "Voltar" ficava morto — o usuário via o controle,
+// Nesses casos o botão "Voltar" ficava morto, e o usuário via o controle,
 // tocava, e nada acontecia. Aqui a Home vira o destino de fallback: sempre
 // existe pra onde voltar.
 

--- a/constants/stableHabit.js
+++ b/constants/stableHabit.js
@@ -1,6 +1,6 @@
 // @ts-nocheck -- helper puro; tipos vêm quando constants/ for tipado (ADR-002)
 
-// Tela do hábito estável (#297) — tela 4a·5 do Turno 4.
+// Tela do hábito estável (#297): tela 4a·5 do Turno 4.
 //
 // O que esta tela precisa dizer, e que nenhuma outra diz: o app **parou de
 // usar este hábito pra medir a pessoa**. Não é elogio nem prêmio; é uma
@@ -13,7 +13,7 @@ const MS_DIA = 86_400_000;
 /**
  * Há quantos dias o hábito está estável.
  *
- * `null` quando não há data — o hábito pode estar estável agora sem que a
+ * `null` quando não há data, porque o hábito pode estar estável agora sem que a
  * data tenha sido registrada ainda (primeira abertura depois de graduar).
  * Nesse caso a tela omite o "há N dias" em vez de inventar zero.
  *
@@ -30,7 +30,7 @@ export function stableForDays(desde, agora = Date.now()) {
 /**
  * Rótulo do chip de status.
  *
- * ⚠️ **Cinza, nunca verde** — quem chama isso decide a cor, mas o texto já
+ * ⚠️ **Cinza, nunca verde**: quem chama isso decide a cor, mas o texto já
  * evita vocabulário de prêmio: "estável", não "conquistado" nem "dominado".
  * É status, não medalha.
  */
@@ -46,17 +46,17 @@ export function stableChip(dias) {
  *
  * Três movimentos, nesta ordem, e a ordem importa:
  *
- * 1. **o que mudou pra pessoa** — "não precisa mais do seu esforço ativo".
+ * 1. **o que mudou pra pessoa**: "não precisa mais do seu esforço ativo".
  *    Acerta o mecanismo do modelo: hábito automático deixa de disputar o
  *    recurso de autorregulação (§7). É o benefício real, e vem primeiro.
- * 2. **por que ainda vale registrar** — "manter os dados apurados". Sem isso
+ * 2. **por que ainda vale registrar**: "manter os dados apurados". Sem isso
  *    o registro vira permissão sem propósito, e a pessoa para.
- * 3. **o que deixou de acontecer** — "não pode mais derrubar seu nível".
+ * 3. **o que deixou de acontecer**: "não pode mais derrubar seu nível".
  *
  * A versão anterior abria pelo negativo e dizia que o app parou de "medir
  * você". Era honesta e ficou fria: transformava a pessoa em objeto do app, e
  * a primeira informação era sobre uma punição que sumiu, não sobre o que ela
- * ganhou. Continua sem elogio — reforço sóbrio, não celebração.
+ * ganhou. Continua sem elogio: reforço sóbrio, não celebração.
  */
 export function stableExplanation(metric) {
   const nome = CATEGORY_MAP[metric]?.displayName ?? metric;

--- a/constants/sync.js
+++ b/constants/sync.js
@@ -2,7 +2,7 @@
 // Configuração do sync WebSocket (M6 fatia 3, #202).
 //
 // SYNC_URL: server TinyBase WS no homeserver (ADR-009). Endpoint por-sala é
-// `${SYNC_URL}/${roomId}` — o server cria/reabre o arquivo JSON da sala sob
+// `${SYNC_URL}/${roomId}`: o server cria/reabre o arquivo JSON da sala sob
 // demanda. Ver server/README.md pra deploy/rotação de subdomínio.
 //
 // Definir EXPO_PUBLIC_SYNC_URL="" desliga o sync (persistência local segue

--- a/constants/themeTokens.js
+++ b/constants/themeTokens.js
@@ -7,7 +7,7 @@
 // NativeWind pra respeitar o toggle manual + o `prefers-color-scheme` do OS.
 //
 // Para classes utilitárias (`bg-*`, `text-*`, `border-*`), continue usando
-// `className="... dark:..."` — este helper existe SÓ pros callsites que não
+// `className="... dark:..."`. Este helper existe SÓ pros callsites que não
 // aceitam className.
 
 import { useColorScheme } from "nativewind";

--- a/infra/database.js
+++ b/infra/database.js
@@ -32,7 +32,7 @@ export const store = createMergeableStore()
     },
     // Metas por métrica (#285, fatia 0 do modelo de níveis). rowId = a
     // métrica ("water", "sleep", …). Antes disto as metas eram texto fixo em
-    // Ajustes — não existiam como dado, e o portão de nível não fecha sem
+    // Ajustes: não existiam como dado, e o portão de nível não fecha sem
     // elas. Ver docs/11-modelo-de-niveis.md §10.
     [GOALS]: {
       target: { type: "number" },
@@ -44,19 +44,19 @@ export const store = createMergeableStore()
     // (ver infra/persistence.js). Default vazio = sync ainda não inicializado.
     syncRoomId: { type: "string", default: "" },
     // Como o usuário quer ser chamado no cumprimento da Home. Preferido em
-    // relação à derivação do email — que quando presente cai no primeiro nome
+    // relação à derivação do email, que quando presente cai no primeiro nome
     // (antes do primeiro ponto). Editável em Ajustes.
     displayName: { type: "string", default: "" },
     // Maior nível já alcançado na jornada (#289). É a MEMÓRIA que torna
     // regressão detectável: o nível atual é derivado dos sinais, e olhando só
     // o presente não dá pra distinguir "caiu do lvl 3" de "nunca passou do 2".
-    // Só sobe — cair é justamente o que se quer poder detectar.
+    // Só sobe, porque cair é justamente o que se quer poder detectar.
     journeyPeakLevel: { type: "number", default: 0 },
     // Nível que o usuário já VIU e reconheceu (#293). Diferente do peak:
     // o peak dirige o estado (o que aparece "em pausa" na Home, de forma
     // persistente), o ack dirige o momento (aparece uma vez e some). Se o ack
     // governasse o estado, hábito pausado viraria trancado no instante em que
-    // a pessoa tocasse "Entendi" — e o design mostra "em pausa" DEPOIS disso.
+    // a pessoa tocasse "Entendi", e o design mostra "em pausa" DEPOIS disso.
     // -1 = nunca reconheceu nada, pra distinguir de "reconheceu o lvl 0".
     journeyAckLevel: { type: "number", default: -1 },
     // Nível forçado pra PREVISUALIZAR telas (#293). -1 = desligado.
@@ -67,16 +67,16 @@ export const store = createMergeableStore()
     // mesmo portão. Forçar o nível testa a TELA; o modelo continua sendo
     // testado por `tests/journey.test.js`, com dado sintético.
     //
-    // Enquanto ligado, o peak NÃO sobe — senão sair do demo deixaria o app
+    // Enquanto ligado, o peak NÃO sobe, senão sair do demo deixaria o app
     // permanentemente "regredido".
     journeyDemoLevel: { type: "number", default: -1 },
     // Hábitos graduados por CONFERÊNCIA do histórico (#295), separados por
     // vírgula. Graduar normalmente exige a barra alta e semanas de observação;
-    // pular concede com a evidência do portão — mesma exigência, sem espera.
+    // pular concede com a evidência do portão: mesma exigência, sem espera.
     // Persistido porque a derivação olha só a janela atual e esqueceria.
     journeyGranted: { type: "string", default: "" },
     // Quando cada hábito ficou estável (#297), como `metric:epoch` separado
-    // por vírgula. A graduação é DERIVADA dos sinais — o app sabe que o hábito
+    // por vírgula. A graduação é DERIVADA dos sinais, e o app sabe que o hábito
     // é estável, não desde quando. Sem esta data não dá pra dizer "estável há
     // 24 dias". Some quando o hábito deixa de ser estável, pra recomeçar a
     // contagem se ele for reconquistado.
@@ -166,7 +166,7 @@ export function getByMonth(type, month) {
 
 // Todos os registros de um dia, agrupados por type. Uma passada única na tabela
 // (a "uma query só" da tela hoje), reusando hidratar. Compara ano/mês/dia local
-// de `date` (ISO string) — mesma convenção de getByMonth.
+// de `date` (ISO string), mesma convenção de getByMonth.
 export function getByDate(isoDate) {
   const alvo = new Date(isoDate);
   const linhas = store.getTable(TABLE);
@@ -197,7 +197,7 @@ export function getToday() {
 }
 
 export function clearAll() {
-  // Só os registros — a lista de testers (admin) sobrevive ao "limpar dados".
+  // Só os registros: a lista de testers (admin) sobrevive ao "limpar dados".
   store.delTable(TABLE);
 }
 
@@ -224,7 +224,7 @@ function generateRoomId() {
 
 /**
  * Garante que o store tem um `syncRoomId`. Chamar DEPOIS do startAutoLoad do
- * persister local — senão pode gerar um room, ser sobrescrito pelo load, e o
+ * persister local, senão pode gerar um room, ser sobrescrito pelo load, e o
  * sync tenta se conectar num room que muda no meio do caminho.
  * @returns {string} o roomId (novo ou existente).
  */
@@ -246,7 +246,7 @@ export function ensureSyncRoomId() {
  * semear ANTES do `startAutoLoad` terminar, o load sobrescreve o que acabou
  * de ser escrito. Manter como último passo se alguém mexer na ordem.
  *
- * Não sobrescreve meta existente — o usuário poderá editar em fatia futura, e
+ * Não sobrescreve meta existente, porque o usuário poderá editar em fatia futura, e
  * seed não pode desfazer escolha de ninguém.
  */
 export function ensureGoals() {
@@ -269,7 +269,7 @@ export function getGoals() {
 /**
  * Eleva o pico de nível, se o atual for maior. Nunca abaixa.
  *
- * Chamar de efeito, nunca durante render — é escrita no store.
+ * Chamar de efeito, nunca durante render, porque é escrita no store.
  */
 export function raiseJourneyPeak(level) {
   if (!Number.isFinite(level)) return;
@@ -281,7 +281,7 @@ export function raiseJourneyPeak(level) {
  * Concede/revoga estabilidade a um hábito pra PREVISUALIZAR a tela dele.
  *
  * Reusa `journeyGranted`, que é o mesmo caminho da conferência de histórico
- * (#295) — a tela de detalhe não sabe (nem precisa saber) se a estabilidade
+ * (#295): a tela de detalhe não sabe (nem precisa saber) se a estabilidade
  * veio de mérito ou de previsualização. Revogar limpa a data junto, senão
  * sobraria um "estável há N dias" de um hábito que não é mais estável.
  */
@@ -352,7 +352,7 @@ export function getGraduatedAt() {
  * Sincroniza as datas com quem está estável agora.
  *
  * Marca a data na PRIMEIRA vez que o hábito aparece estável, e apaga quando
- * ele deixa de estar — assim reconquistar recomeça a contagem, em vez de
+ * ele deixa de estar, e assim reconquistar recomeça a contagem, em vez de
  * herdar um "estável há 90 dias" que não é verdade.
  *
  * Chamar de efeito, nunca em render.

--- a/infra/persistence.js
+++ b/infra/persistence.js
@@ -13,7 +13,7 @@ const db = openDatabaseSync("back_on_track.db");
  * Chame este hook uma vez, perto da raiz do app (ex: app/_layout.jsx),
  * pra carregar os dados salvos ao abrir o app e manter tudo persistido
  * automaticamente a cada mudança. Sem isso, a store do TinyBase vive só
- * na memória e some a cada reload — é o motivo mais provável do app
+ * na memória e some a cada reload, e é o motivo mais provável do app
  * hoje parecer "só visual".
  *
  * Nota: o persister de Expo SQLite ainda é experimental (a própria

--- a/infra/persistence.web.js
+++ b/infra/persistence.web.js
@@ -8,7 +8,7 @@ import { ensureGoals, ensureSyncRoomId, store } from "./database";
  * O Metro resolve este arquivo (.web.js) no bundle web e usa
  * persistence.js (Expo SQLite) apenas no native. Isso é necessário
  * porque o expo-sqlite depende de um WASM que não é suportado no
- * `expo export` web — arrastá-lo pro bundle quebra o build da Vercel.
+ * `expo export` web, e arrastá-lo pro bundle quebra o build da Vercel.
  *
  * Aqui a persistência usa localStorage via createLocalPersister do
  * TinyBase, mantendo o mesmo comportamento: os dados sobrevivem ao

--- a/infra/session.js
+++ b/infra/session.js
@@ -18,7 +18,7 @@ const SessionContext = createContext({
 
 export function SessionProvider({ children }) {
   const [session, setSession] = useState(null);
-  // ready só vira true depois da 1ª leitura da sessão persistida — evita
+  // ready só vira true depois da 1ª leitura da sessão persistida, o que evita
   // flash de "deslogado" na abertura pra quem já estava logado.
   const [ready, setReady] = useState(!AUTH_ENABLED);
 
@@ -50,7 +50,7 @@ export function SessionProvider({ children }) {
   // `autoRefreshToken: true` sozinho não basta aqui: o timer de refresh do
   // supabase-js é um `setInterval` do runtime JS, e no RN o runtime dorme com
   // o app em background. O token vence enquanto ninguém está olhando, e ao
-  // voltar o app reconecta o sync com o token velho — foram 8 rejeições
+  // voltar o app reconecta o sync com o token velho. Foram 8 rejeições
   // `invalid token: expired` no server entre 06/08 e 12/08.
   //
   // A Supabase documenta o wiring manual por AppState pra native. No web não

--- a/infra/supabase.js
+++ b/infra/supabase.js
@@ -6,7 +6,7 @@ import { Platform } from "react-native";
 
 // Cliente Supabase pra auth (M6 auth fatia A, #207, ADR-010).
 //
-// URL/ANON KEY vêm do dashboard do Supabase — a anon key é public por design
+// URL/ANON KEY vêm do dashboard do Supabase, e a anon key é public por design
 // (vive no bundle do app), então EXPO_PUBLIC_* é ok. JWT Secret NÃO entra
 // aqui (fica no server WS na fatia B).
 //
@@ -20,12 +20,12 @@ export const SUPABASE_ANON_KEY =
 export const AUTH_ENABLED = Boolean(SUPABASE_URL && SUPABASE_ANON_KEY);
 
 // Guarda o erro de init pra caso o cliente precise mostrar diagnóstico.
-// Non-null sse `createClient` lançou (ex.: URL inválida — aconteceu no
+// Non-null sse `createClient` lançou (ex.: URL inválida, aconteceu no
 // rollout do M6 quando as env vars EAS vieram com control char SYN).
 export let supabaseInitError = null;
 
 // Envelope createClient em try/catch pra crash de validação (ex.: URL
-// inválido) NÃO derrubar o app inteiro. Retorna null e loga — app abre
+// inválido) NÃO derrubar o app inteiro. Retorna null e loga, então o app abre
 // com auth desligada em vez de crash na abertura.
 function safeCreateClient() {
   if (!AUTH_ENABLED) return null;
@@ -41,7 +41,7 @@ function safeCreateClient() {
         detectSessionInUrl: Platform.OS === "web",
         // Força PKCE em todas as plataformas. Sem isso, o supabase-js pode
         // gerar magic link em hash-flow (#access_token=...) que só funciona
-        // com detectSessionInUrl=true — quebra no native, onde o callback
+        // com detectSessionInUrl=true, que quebra no native, onde o callback
         // precisa do ?code= pra chamar exchangeCodeForSession.
         flowType: "pkce",
       },

--- a/infra/sync-retry.js
+++ b/infra/sync-retry.js
@@ -10,7 +10,7 @@
  * **Por que jitter:** quando o server reinicia, todos os clientes caem no
  * mesmo instante. Sem jitter eles voltam juntos no mesmo milissegundo e
  * derrubam de novo (thundering herd). Full jitter espalha cada cliente por
- * uma janela aleatória — sorteia em `[delay/2, delay]` em vez de sempre usar
+ * uma janela aleatória: sorteia em `[delay/2, delay]` em vez de sempre usar
  * o teto.
  */
 

--- a/infra/sync-session.js
+++ b/infra/sync-session.js
@@ -10,8 +10,8 @@
  * As duas funções aqui existem porque o sync errava ao tratar "ainda não sei"
  * como se fosse uma resposta:
  *
- * - `resolveRoomId` — sessão carregando não é "deslogado".
- * - `isTokenExpired` — token vencido na mão não é motivo pra tentar conectar.
+ * - `resolveRoomId`: sessão carregando não é "deslogado".
+ * - `isTokenExpired`: token vencido na mão não é motivo pra tentar conectar.
  */
 
 /**
@@ -19,14 +19,14 @@
  *
  * `getSession()` do Supabase é assíncrono: no 1º render do app o `session` é
  * `null` mesmo pra quem está logado. Ler `user?.id ?? anonRoomId` nesse
- * instante devolve a sala **anônima** — e o `startSync()` que vem logo atrás
+ * instante devolve a sala **anônima**, e o `startSync()` que vem logo atrás
  * empurra a store inteira pra lá antes da sessão resolver.
  *
  * Com `AUTH_MODE=optional` isso vira uma cópia completa dos dados
  * autenticados numa sala que conecta sem token. Depois do flip pra `required`
  * viraria falha garantida em toda abertura.
  *
- * Por isso o gate em `ready`: sem sessão resolvida, não há sala — o caller
+ * Por isso o gate em `ready`: sem sessão resolvida, não há sala, e o caller
  * trata `null` como "espera", não como "desligado".
  *
  * @param {boolean} ready Sessão já resolvida (`SessionProvider.ready`).
@@ -45,7 +45,7 @@ export function resolveRoomId(ready, user, anonRoomId) {
  * Voltar do background reconecta na hora (`AppState` → `active`), mas o token
  * que está no state do React pode ter vencido enquanto o app dormia. Tentar
  * com ele produz `rejecting: invalid token: expired` no server e uma
- * piscada de "offline" — foram 8 dessas no log entre 06/08 e 12/08.
+ * piscada de "offline". Foram 8 dessas no log entre 06/08 e 12/08.
  *
  * Quando isto devolve `true`, o caller **não** reconecta: o
  * `startAutoRefresh` (ligado no `SessionProvider`) renova, o
@@ -54,12 +54,12 @@ export function resolveRoomId(ready, user, anonRoomId) {
  *
  * `expires_at` do Supabase vem em **segundos** epoch, não milissegundos.
  *
- * Sessão anônima (sem token) nunca está vencida — não há o que renovar.
+ * Sessão anônima (sem token) nunca está vencida, porque não há o que renovar.
  *
  * @param {{ expires_at?: number, access_token?: string } | null | undefined} session
  * @param {number} [now] Epoch em ms; injetável pra teste.
  * @param {number} [skewMs] Margem pra contar como vencido um token prestes a
- *   vencer — o round-trip até o server leva algum tempo. Default 5s.
+ *   vencer, porque o round-trip até o server leva algum tempo. Default 5s.
  * @returns {boolean}
  */
 export function isTokenExpired(session, now = Date.now(), skewMs = 5_000) {
@@ -70,13 +70,13 @@ export function isTokenExpired(session, now = Date.now(), skewMs = 5_000) {
 }
 
 /**
- * A conexão caiu porque falta login — e não porque a rede caiu? (#278)
+ * A conexão caiu porque falta login, em vez de porque a rede caiu? (#278)
  *
  * Só é verdade quando as duas coisas valem: o client não tem token **e** o
  * server declarou `authMode: "required"` no `/healthz`. Nesse par a recusa é
  * determinística: anônimo nunca vai entrar, por mais que tente.
  *
- * Fora disso, `false` — inclusive quando o modo é desconhecido (o `/healthz`
+ * Fora disso, `false`, inclusive quando o modo é desconhecido (o `/healthz`
  * não respondeu). Server inalcançável **é** problema de rede, então cair no
  * caminho de "sem conexão" está certo ali.
  *

--- a/infra/sync-url.js
+++ b/infra/sync-url.js
@@ -4,11 +4,11 @@
  * Monta a URL WS pro server de sync (M6, fatia C, #211).
  *
  * Isolado num arquivo próprio pra ser testável sem puxar `infra/sync.js`
- * inteiro — que importa Supabase/AsyncStorage e não roda no jest (RN
+ * inteiro, que importa Supabase/AsyncStorage e não roda no jest (RN
  * native module).
  *
  * Retorna `null` se algum insumo essencial faltar (baseUrl vazio, roomId
- * ainda não carregado do disco) — o caller trata como "sync desligado" e
+ * ainda não carregado do disco): o caller trata como "sync desligado" e
  * não tenta abrir WebSocket.
  *
  * `token` é opcional. Quando presente, o server valida HS256 no
@@ -32,7 +32,7 @@ export function buildSyncUrl(baseUrl, roomId, token) {
  * a rede está de pé e a recusa foi política; se nem ele responde, é rede
  * mesmo. Não precisa de heurística.
  *
- * `wss://` vira `https://` e `ws://` vira `http://` — mesmo host, mesma porta.
+ * `wss://` vira `https://` e `ws://` vira `http://`, com mesmo host e mesma porta.
  *
  * @param {string} baseUrl Mesma base do `buildSyncUrl` (ex.: `wss://host`).
  * @returns {string | null} `null` se a base estiver vazia (sync desligado).

--- a/infra/sync.js
+++ b/infra/sync.js
@@ -36,7 +36,7 @@ export const SYNC_NEEDS_AUTH = "needs-auth";
  *
  * Serve a dois propósitos de uma vez: se responde, a rede está de pé e a
  * recusa do WS foi política; se não responde, é rede mesmo. Por isso o
- * `catch` devolve `null` em vez de propagar — "não sei" é uma resposta útil
+ * `catch` devolve `null` em vez de propagar, porque "não sei" é uma resposta útil
  * aqui, e o caller trata como offline.
  *
  * @param {string | null} healthzUrl
@@ -77,7 +77,7 @@ async function fetchAuthMode(healthzUrl, timeoutMs = 4000) {
  *
  * `getSession()` é assíncrono: no 1º render, quem está logado ainda aparece
  * como `user: null`. Conectar aí resolvia pra sala **anônima**, e o
- * `startSync()` logo atrás empurrava a store inteira pra lá — com
+ * `startSync()` logo atrás empurrava a store inteira pra lá, com
  * `AUTH_MODE=optional`, uma cópia completa dos dados autenticados numa sala
  * que conecta sem token (#275). Por isso `resolveRoomId` devolve `null`
  * enquanto a sessão não resolveu, e `null` aqui significa "espera", não
@@ -85,7 +85,7 @@ async function fetchAuthMode(healthzUrl, timeoutMs = 4000) {
  *
  * ## Por que a reconexão precisa observar o socket na mão
  *
- * `createWsSynchronizer` **resolve mesmo quando a conexão falha** — ele
+ * `createWsSynchronizer` **resolve mesmo quando a conexão falha**: ele
  * escuta `open` E `error` e resolve nos dois casos (ver
  * `synchronizers/synchronizer-ws-client`). Então um 401 do server produz um
  * synchronizer "válido" envolvendo um socket morto, e nenhum `catch` dispara.
@@ -98,17 +98,17 @@ async function fetchAuthMode(healthzUrl, timeoutMs = 4000) {
  * ## Como a reconexão funciona
  *
  * Ao cair, agenda nova tentativa com backoff exponencial + jitter
- * (`sync-retry.js`). Cada tentativa recria o synchronizer inteiro — bumpar
+ * (`sync-retry.js`). Cada tentativa recria o synchronizer inteiro, e bumpar
  * `generation` muda as deps do `useCreateSynchronizer`, que derruba o antigo
  * e monta um novo. Voltar pro foreground (`AppState` → `active`) reconecta
  * na hora, sem esperar o backoff: o SO costuma matar o socket em background
  * e o usuário que reabre o app quer sync imediato.
  *
- * Depende do `useRegistrosPersistencia` já ter rodado — é ele quem carrega o
+ * Depende do `useRegistrosPersistencia` já ter rodado, porque é ele quem carrega o
  * `syncRoomId` do disco (ou gera no 1º launch).
  *
  * Chamado uma única vez, pelo `SyncStatusProvider`. Telas leem o resultado
- * via `useSyncStatus()` — montar o hook duas vezes abriria dois sockets.
+ * via `useSyncStatus()`, porque montar o hook duas vezes abriria dois sockets.
  *
  * @returns {{ status: "off"|"connecting"|"online"|"offline", reconnect: () => void }}
  */
@@ -117,7 +117,7 @@ export function useRegistrosSync() {
   const anonRoomId = useValue("syncRoomId", store);
 
   // roomId: user.id se logado; senão o UUID anônimo. `null` enquanto a sessão
-  // não resolveu — ver `resolveRoomId`, e o porquê logo abaixo em `waiting`.
+  // não resolveu. Ver `resolveRoomId`, e o porquê logo abaixo em `waiting`.
   // token: JWT se logado; senão null (server em optional-mode aceita anônimo).
   const roomId = resolveRoomId(ready, user, anonRoomId);
   const token = session?.access_token ?? null;
@@ -139,7 +139,7 @@ export function useRegistrosSync() {
   const retryExpRef = useRef(0);
   const retryTimerRef = useRef(null);
   // Socket da tentativa corrente. Usado pra ignorar `close` de conexões
-  // obsoletas — na troca de deps o create do novo roda ANTES do destroy do
+  // obsoletas: na troca de deps o create do novo roda ANTES do destroy do
   // antigo, então o close do antigo chegaria depois e agendaria retry à toa.
   const currentWsRef = useRef(null);
   const mountedRef = useRef(true);
@@ -171,18 +171,18 @@ export function useRegistrosSync() {
     };
   }, [clearRetry]);
 
-  // Voltar pro foreground reconecta na hora se estiver caído — não espera o
+  // Voltar pro foreground reconecta na hora se estiver caído, sem esperar o
   // backoff, que pode estar no teto de 30s.
   useEffect(() => {
     // No web o AppState devolve `undefined` quando não há `document`
-    // (prerender do `expo export`) — sem a guarda, o cleanup quebraria o
+    // (prerender do `expo export`): sem a guarda, o cleanup quebraria o
     // build. Native sempre devolve subscription.
     const sub = AppState.addEventListener?.("change", (next) => {
       if (next !== "active") return;
       // Token vencido enquanto o app dormia: reconectar agora seria rejeitado
       // pelo server e só geraria ruído. O `startAutoRefresh` (session.js)
       // renova, o `onAuthStateChange` publica a sessão nova, a `url` muda e o
-      // synchronizer é recriado sozinho — com token que presta.
+      // synchronizer é recriado sozinho, com token que presta.
       if (isTokenExpired(session)) return;
       const ws = currentWsRef.current;
       // readyState 1 = OPEN. Qualquer outra coisa = reconectar.
@@ -211,7 +211,7 @@ export function useRegistrosSync() {
 
         // Caiu sem token: pode não ser rede. Sob `AUTH_MODE=required` o
         // server recusa anônimo por política, e o 401 do handshake não chega
-        // até aqui — a API WebSocket não expõe status de upgrade recusado.
+        // até aqui, porque a API WebSocket não expõe status de upgrade recusado.
         // Perguntar o modo é o que separa "preciso entrar" de "estou sem
         // sinal"; sem isso o app diz "sem conexão" e oferece um "Tentar de
         // novo" que nunca vai funcionar (#278).
@@ -265,7 +265,7 @@ export function useRegistrosSync() {
     },
     // Reconecta em troca de URL (login/logout/token refresh) e a cada
     // tentativa agendada pelo backoff. `waiting` entra porque com SYNC_URL
-    // vazio a URL é null antes e depois da sessão resolver — sem ele o
+    // vazio a URL é null antes e depois da sessão resolver, e sem ele o
     // callback não rodaria de novo e o status ficaria preso em `connecting`.
     [url, generation, waiting],
   );
@@ -288,7 +288,7 @@ const SyncStatusContext = createContext({
  *
  * Precisa ficar DENTRO do `SessionProvider`: `useRegistrosSync` chama
  * `useSession` por baixo, e acima do provider ele devolveria o default do
- * contexto (`user: null`) — o sync ficaria eternamente anônimo mesmo logado.
+ * contexto (`user: null`), e o sync ficaria eternamente anônimo mesmo logado.
  * Foi exatamente o bug do #217.
  *
  * @param {{ children: any }} props
@@ -303,7 +303,7 @@ export function SyncStatusProvider({ children }) {
 }
 
 /**
- * Estado do sync pra telas. Não abre conexão — só lê o que o provider publica.
+ * Estado do sync pra telas. Não abre conexão: só lê o que o provider publica.
  * @returns {{ status: "off"|"connecting"|"online"|"offline", reconnect: () => void }}
  */
 export function useSyncStatus() {

--- a/infra/theme.js
+++ b/infra/theme.js
@@ -8,7 +8,7 @@
 // vai pro AsyncStorage e é restaurada no boot.
 //
 // **Por que AsyncStorage e não o TinyBase store**: o store SINCRONIZA entre
-// devices (M6). Tema é preferência POR APARELHO — o celular pode estar no
+// devices (M6). Tema é preferência POR APARELHO, porque o celular pode estar no
 // escuro à noite enquanto o tablet segue claro. Guardar no store faria uma
 // escolha vazar pra outro device. AsyncStorage é local por definição.
 //
@@ -24,7 +24,7 @@ import { useColorScheme } from "nativewind";
 const THEME_KEY = "backontrack.colorScheme";
 
 /**
- * Salva a escolha explícita do usuário. Erro de escrita não quebra a UI — o
+ * Salva a escolha explícita do usuário. Erro de escrita não quebra a UI, e o
  * tema já mudou em memória; só a persistência falha (e o próximo boot volta
  * pro sistema, que é degradação aceitável).
  * @param {"light" | "dark"} scheme
@@ -66,7 +66,7 @@ export function useRestoreThemePreference() {
       cancelled = true;
     };
     // setColorScheme é estável entre renders (vem do NativeWind); rodar só no
-    // mount é o desejado — restauração acontece uma vez por sessão.
+    // mount é o desejado, porque a restauração acontece uma vez por sessão.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 }

--- a/infra/useJourney.js
+++ b/infra/useJourney.js
@@ -10,24 +10,24 @@ import { getGoals, getGrantedHabits, store } from "./database";
 // ⚠️ **Existe por causa de um bug que aconteceu duas vezes.**
 //
 // A derivação vive numa função pura bem testada, mas ela precisa receber
-// vários pedaços do store — metas, pico, concessões. Quando cada tela montava
+// vários pedaços do store: metas, pico, concessões. Quando cada tela montava
 // esses argumentos por conta própria, era questão de tempo até uma esquecer
 // um: a Home ficou sem passar `granted`, e por isso a conferência de
 // histórico (#295) e a previsualização de estabilidade não tinham **nenhum**
 // efeito na tela principal. Os 269 testes seguiram verdes, porque testam a
-// função — não quem a chama.
+// função, e não quem a chama.
 //
 // Com um hook só, existe um lugar pra ligar e um lugar pra errar. Se faltar
 // argumento, falta pra todo mundo ao mesmo tempo, o que é visível na hora.
 //
 // A lição mais geral: teste de função pura não pega "ninguém chamou". Só
-// rodar o app pega — foi o usuário quem viu.
+// rodar o app pega, e foi o usuário quem viu.
 
 /**
  * Estado da jornada, com todos os insumos do store já ligados.
  *
  * @param {{previousLevel?: number|null}} [opts] `previousLevel` explícito
- *   sobrescreve o pico — útil pra previsualização.
+ *   sobrescreve o pico, útil pra previsualização.
  * @returns {{level: number, habits: object, focus: string|null, regressed: boolean}}
  */
 export function useJourney(opts = {}) {

--- a/infra/week.js
+++ b/infra/week.js
@@ -8,7 +8,7 @@
 //
 // Range: últimos 7 dias incluindo hoje (rolling), pra HOJE aparecer sempre no
 // último slot. Header exibe o número da semana ISO da data de hoje pra dar
-// contexto — não é o range ISO Mon-Sun (que seria confuso quando o rolling
+// contexto, em vez do range ISO Mon-Sun (que seria confuso quando o rolling
 // atravessa duas semanas).
 
 import { store } from "@/infra/database";
@@ -30,7 +30,7 @@ const MONTH_ABBR = [
   "dez",
 ];
 
-// ISO 8601 week number. Cópia direta do algoritmo canônico — não vale trazer
+// ISO 8601 week number. Cópia direta do algoritmo canônico, porque não vale trazer
 // date-fns só pra isso.
 function isoWeek(d) {
   const t = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()));

--- a/scripts/notify-testers.mjs
+++ b/scripts/notify-testers.mjs
@@ -15,7 +15,7 @@
 //
 // O envio é opt-in porque manda mensagem real e irreversível pros testers. Não
 // existe lista de transmissão via API (a Evolution API não suporta: issue #2081),
-// então o disparo é um DM por tester, em loop e com delay — o que também é mais
+// então o disparo é um DM por tester, em loop e com delay, o que também é mais
 // privado (ninguém vê a lista) e menos chamativo pro antispam do WhatsApp.
 //
 // Env do modo --send:
@@ -25,7 +25,7 @@
 //   EVO_DELAY_MS  opcional, delay entre envios (default 4000)
 //
 // A lista sai da tela de admin do app ("Exportar lista") e vai em
-// scripts/testers.json — gitignored, porque é PII.
+// scripts/testers.json, gitignored, porque é PII.
 
 import { execFileSync } from "node:child_process";
 import { readFileSync, existsSync } from "node:fs";
@@ -72,9 +72,9 @@ function readLatestRelease() {
 
 /**
  * Monta a mensagem WhatsApp de aviso de nova APK. Tom comercial e enxuto: o
- * tester decide em segundos se instala agora ou depois — não é changelog de
+ * tester decide em segundos se instala agora ou depois. Não é changelog de
  * dev. As **notas da release** (`-f notes=` no workflow) viram o "o que
- * mudou" — escreva user-facing (features/fixes visíveis), não dev-facing
+ * mudou": escreva user-facing (features/fixes visíveis), não dev-facing
  * (SDK bumps, refactors internos). A versão fica no rodapé pra referência,
  * sem competir com a headline.
  *
@@ -207,7 +207,7 @@ async function sendText(cfg, phone, text) {
   });
   if (!res.ok) {
     const detalhe = await res.text();
-    throw new Error(`HTTP ${res.status} — ${detalhe.slice(0, 200)}`);
+    throw new Error(`HTTP ${res.status}: ${detalhe.slice(0, 200)}`);
   }
 }
 
@@ -221,7 +221,7 @@ async function runSend(message) {
   console.log(`Instância: ${cfg.instance} @ ${cfg.url}`);
   console.log(`Delay entre envios: ${cfg.delayMs}ms`);
   console.log(`Testers (${testers.length}):`);
-  for (const t of testers) console.log(`  • ${t.name} — ${t.phone}`);
+  for (const t of testers) console.log(`  • ${t.name}: ${t.phone}`);
 
   if (!process.argv.includes("--yes") && !(await confirmSend(testers.length))) {
     console.log("Cancelado. Nada foi enviado.");
@@ -238,7 +238,7 @@ async function runSend(message) {
       console.log(`✓ ${t.name} (${t.phone})`);
     } catch (e) {
       falhas.push(`${t.name} (${t.phone}): ${e.message}`);
-      console.error(`✖ ${t.name} (${t.phone}) — ${e.message}`);
+      console.error(`✖ ${t.name} (${t.phone}): ${e.message}`);
     }
     // Delay entre envios: baixa a chance de o WhatsApp tratar como spam.
     if (i < testers.length - 1) await sleep(cfg.delayMs);
@@ -261,7 +261,7 @@ function runPrint(message) {
   if (copied) {
     console.log(`✓ Copiado pro clipboard (${copied}). Cole na conversa.`);
   } else {
-    console.log("ℹ Clipboard indisponível — copie o texto acima manualmente.");
+    console.log("ℹ Clipboard indisponível, copie o texto acima manualmente.");
   }
 }
 
@@ -272,7 +272,7 @@ function runPrint(message) {
 function resolveMessage() {
   const i = process.argv.indexOf("--text-file");
   if (i === -1) {
-    // Só toca no `gh` no modo release — com --text-file nem precisa de release.
+    // Só toca no `gh` no modo release, porque com --text-file nem precisa de release.
     return buildMessage(readLatestRelease(), readHomepage());
   }
   const caminho = process.argv[i + 1];

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-# Backing image slim, sem toolchain — o server só precisa de node runtime.
+# Backing image slim, sem toolchain: o server só precisa de node runtime.
 FROM node:22-alpine
 
 WORKDIR /app
@@ -11,7 +11,7 @@ RUN npm install --omit=dev
 COPY server.js ./
 COPY smoke-client.js ./
 
-# Porta interna — o Traefik na frente mapeia via label, não via publish.
+# Porta interna. O Traefik na frente mapeia via label, não via publish.
 EXPOSE 8787
 
 # Volume onde ficam os JSONs por sala (bind mount no compose).

--- a/server/README.md
+++ b/server/README.md
@@ -1,4 +1,4 @@
-# Back on Track — Sync Server
+# Back on Track: Sync Server
 
 Server WebSocket do TinyBase pra sincronizar dados entre dispositivos do app Back on Track. Fatia 2 da implementação do M6 (#198), sobre a decisão da [ADR-009](../docs/03-decisoes-tecnicas.md#adr-009).
 
@@ -20,7 +20,7 @@ O `smoke` conecta, escreve uma célula, desconecta, reconecta e confirma que o v
 
 ## Deploy no homeserver
 
-O homeserver **já tem um `cloudflared` rodando como serviço systemd** (unit `/etc/systemd/system/cloudflared.service`), servindo o túnel `home server` da Cloudflare com outros subdomínios (`app`, `cloud`, `mc`). **Reusamos esse túnel** — não subimos um segundo `cloudflared` no compose (seria replica redundante da mesma tunnel).
+O homeserver **já tem um `cloudflared` rodando como serviço systemd** (unit `/etc/systemd/system/cloudflared.service`), servindo o túnel `home server` da Cloudflare com outros subdomínios (`app`, `cloud`, `mc`). **Reusamos esse túnel**, sem subir um segundo `cloudflared` no compose (seria replica redundante da mesma tunnel).
 
 Passos (uma vez):
 
@@ -32,7 +32,7 @@ Passos (uma vez):
    - **Service type:** **HTTP** (não HTTPS!)
    - **URL:** `127.0.0.1:8787`
 
-   O cloudflared do systemd puxa a nova rota automaticamente — sem restart, sem rebuild.
+   O cloudflared do systemd puxa a nova rota automaticamente, sem restart e sem rebuild.
 
 2. **Subir o container `sync`:**
 
@@ -42,7 +42,7 @@ Passos (uma vez):
    docker compose logs sync   # esperado: "[sync] listening on ws://0.0.0.0:8787 ..."
    ```
 
-   O container publica a porta 8787 **só em 127.0.0.1** (loopback do host — acessível pelo cloudflared do systemd, mas não pela LAN nem externamente).
+   O container publica a porta 8787 **só em 127.0.0.1** (loopback do host, acessível pelo cloudflared do systemd, mas não pela LAN nem externamente).
 
 3. **Smoke test remoto** (de qualquer máquina, sem VPN):
 
@@ -54,12 +54,12 @@ Passos (uma vez):
 
 ### Por que Cloudflare Tunnel
 
-- **Zero porta aberta no roteador** — o `cloudflared` faz outbound; ideal pra homeserver atrás de NAT ou CG-NAT.
-- **TLS gerenciado pela Cloudflare** — sem Let's Encrypt local, sem renovação, sem DNS challenge.
+- **Zero porta aberta no roteador**: o `cloudflared` faz outbound; ideal pra homeserver atrás de NAT ou CG-NAT.
+- **TLS gerenciado pela Cloudflare**: sem Let's Encrypt local, sem renovação, sem DNS challenge.
 - **DDoS + cache + firewall grátis** na frente, se um dia precisar.
-- **Um túnel serve N serviços** — o `home server` já servia `app`/`cloud`/`mc`; a rota `backontrack-sync` entra sem novo cloudflared.
+- **Um túnel serve N serviços**: o `home server` já servia `app`/`cloud`/`mc`; a rota `backontrack-sync` entra sem novo cloudflared.
 
-Trade-off honesto: **dependência da Cloudflare** — se o dashboard/rede deles cair, o tunel cai. Aceitável pra este uso.
+Trade-off honesto: **dependência da Cloudflare**. Se o dashboard/rede deles cair, o tunel cai. Aceitável pra este uso.
 
 ### Rotate do token (só se vazar)
 
@@ -69,7 +69,7 @@ O cloudflared do systemd usa `--token <JWT>` embutido na unit file. Se o token v
 2. No host, com `sudo` (o serviço roda como root):
 
    ```bash
-   sudo cloudflared tunnel login   # uma vez — só se ~/.cloudflared/cert.pem não existe
+   sudo cloudflared tunnel login   # uma vez, só se ~/.cloudflared/cert.pem não existe
    sudo bash -c '
      NEW=$(cloudflared tunnel token <TUNNEL_UUID>) && \
      [ ${#NEW} -ge 150 ] && [[ "$NEW" == eyJ* ]] && \
@@ -80,34 +80,34 @@ O cloudflared do systemd usa `--token <JWT>` embutido na unit file. Se o token v
    sudo systemctl daemon-reload && sudo systemctl restart cloudflared
    ```
 
-   O `cloudflared tunnel token <UUID>` imprime o token atual do túnel — pegamos direto via API em vez de depender do dashboard mostrar. Sem eco no shell.
+   O `cloudflared tunnel token <UUID>` imprime o token atual do túnel, e pegamos direto via API em vez de depender do dashboard mostrar. Sem eco no shell.
 
 ## Persistência
 
 Arquivo JSON por sala em `/data` (volume bind-mount `./data:/data`). Um `pathId` (ex.: `alice`) vira `alice.json`. Backup = copiar o diretório. Restore = colocar de volta antes do `up`.
 
-Se apertar (concorrência alta, integridade, queries futuras), trocar por SQLite via `createSqlite3Persister` — mesmo shape, muda 1 função no `server.js`. Adiar até ter demanda concreta.
+Se apertar (concorrência alta, integridade, queries futuras), trocar por SQLite via `createSqlite3Persister`: mesmo shape, muda 1 função no `server.js`. Adiar até ter demanda concreta.
 
 ## Autenticação (M6 fatia B, #211, ADR-010)
 
-O server valida JWT do Supabase se o cliente mandar `?token=<JWT>` na URL, com `crypto` nativo (zero dep). Enforça `jwt.sub === pathId` — quem sabe o path sem o token do dono não conecta (403).
+O server valida JWT do Supabase se o cliente mandar `?token=<JWT>` na URL, com `crypto` nativo (zero dep). Enforça `jwt.sub === pathId`, então quem sabe o path sem o token do dono não conecta (403).
 
 **Dois algoritmos são aceitos:**
 
-- **ES256** — o que o Supabase assina hoje. Chaves assimétricas ECC P-256, com `kid` no header. A chave pública vem do JWKS do projeto (`$SUPABASE_URL/auth/v1/.well-known/jwks.json`), cacheada em memória por `kid`. `kid` desconhecido dispara refetch (throttle de 60s pra token forjado não virar DoS contra o endpoint).
-- **HS256** — legado, secret simétrico compartilhado. Mantido pra compat e pros testes.
+- **ES256**: o que o Supabase assina hoje. Chaves assimétricas ECC P-256, com `kid` no header. A chave pública vem do JWKS do projeto (`$SUPABASE_URL/auth/v1/.well-known/jwks.json`), cacheada em memória por `kid`. `kid` desconhecido dispara refetch (throttle de 60s pra token forjado não virar DoS contra o endpoint).
+- **HS256**: legado, secret simétrico compartilhado. Mantido pra compat e pros testes.
 
 Envs que controlam o comportamento:
 
-| Env                   | Default    | Efeito                                                                                                             |
-| --------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------ |
-| `AUTH_MODE`           | `optional` | `optional`: aceita anônimo se sem token. `required`: rejeita sem token (401).                                      |
-| `SUPABASE_URL`        | vazio      | URL base do projeto (ex.: `https://abc.supabase.co`). Necessária pra validar **ES256** — dela sai o endpoint JWKS. |
-| `SUPABASE_JWT_SECRET` | vazio      | Secret **HS256** legado. Só necessária se o projeto ainda assina com HS256.                                        |
+| Env                   | Default    | Efeito                                                                                                                   |
+| --------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `AUTH_MODE`           | `optional` | `optional`: aceita anônimo se sem token. `required`: rejeita sem token (401).                                            |
+| `SUPABASE_URL`        | vazio      | URL base do projeto (ex.: `https://abc.supabase.co`). Necessária pra validar **ES256**, porque dela sai o endpoint JWKS. |
+| `SUPABASE_JWT_SECRET` | vazio      | Secret **HS256** legado. Só necessária se o projeto ainda assina com HS256.                                              |
 
 `AUTH_MODE=required` exige **pelo menos uma** das duas (`SUPABASE_URL` ou `SUPABASE_JWT_SECRET`); sem nenhuma o server aborta no boot. Com `AUTH_MODE=optional` e nenhuma das duas, um cliente que mandar `?token=` leva 500 (recusar é mais seguro que aceitar sem checar).
 
-> ⚠️ **Migração ES256 (agosto/2026).** O Supabase migrou pra chaves assimétricas e passou a assinar com ES256. O server só aceitava HS256, então rejeitava **todo** cliente logado com `401 unsupported alg: ES256` — sync silenciosamente morto em web e mobile (falha só aparecia no console do navegador). Se o seu `.env` só tem `SUPABASE_JWT_SECRET`, **adicione `SUPABASE_URL`** e recrie o container.
+> ⚠️ **Migração ES256 (agosto/2026).** O Supabase migrou pra chaves assimétricas e passou a assinar com ES256. O server só aceitava HS256, então rejeitava **todo** cliente logado com `401 unsupported alg: ES256`, com sync silenciosamente morto em web e mobile (falha só aparecia no console do navegador). Se o seu `.env` só tem `SUPABASE_JWT_SECRET`, **adicione `SUPABASE_URL`** e recrie o container.
 
 **Onde pegar cada uma:**
 
@@ -127,7 +127,7 @@ docker compose up -d --build
 Confere no log do boot qual verificador subiu:
 
 ```
-[sync] listening on ws://0.0.0.0:8787 — data dir: /data — auth: optional (ES256 via jwks)
+[sync] listening on ws://0.0.0.0:8787 | data dir: /data | auth: optional (ES256 via jwks)
 ```
 
 ### Matriz de comportamento
@@ -143,7 +143,7 @@ Confere no log do boot qual verificador subiu:
 | `?token=` ES256 com `kid` fora do JWKS | ❌ 401               | ❌ 401               |
 | `?token=` alg não suportado (RS256…)   | ❌ 401               | ❌ 401               |
 
-### `GET /healthz` — anúncio do modo (#278)
+### `GET /healthz`: anúncio do modo (#278)
 
 ```
 $ curl https://backontrack-sync.mhdn.com.br/healthz
@@ -152,23 +152,23 @@ $ curl https://backontrack-sync.mhdn.com.br/healthz
 
 Existe por um motivo específico: **o 401 do handshake não chega ao app.** A API
 WebSocket de browser e React Native não expõe o status HTTP de um upgrade
-recusado — o cliente vê só um `close` genérico, indistinguível de queda de
+recusado, e o cliente vê só um `close` genérico, indistinguível de queda de
 rede. Sem isto, o tester sem login veria "sem conexão" e um "Tentar de novo"
 que nunca funciona.
 
 O client consulta este endpoint **só quando** uma conexão sem token falha.
 A resposta resolve as duas perguntas de uma vez:
 
-| `/healthz` respondeu? | `authMode` | conclusão do client                                      |
-| --------------------- | ---------- | -------------------------------------------------------- |
-| sim                   | `required` | é política — mostra "precisa entrar", **para o backoff** |
-| sim                   | `optional` | é rede — mostra "sem conexão", segue tentando            |
-| não                   | —          | server inalcançável, é rede — mostra "sem conexão"       |
+| `/healthz` respondeu? | `authMode` | conclusão do client                                     |
+| --------------------- | ---------- | ------------------------------------------------------- |
+| sim                   | `required` | é política, mostra "precisa entrar", **para o backoff** |
+| sim                   | `optional` | é rede, mostra "sem conexão", segue tentando            |
+| não                   | —          | server inalcançável, é rede, mostra "sem conexão"       |
 
 Alternativas descartadas: inferir no client sem perguntar (mente em
 `optional`, onde a mesma falha é rede de verdade) e aceitar o upgrade pra
 fechar com close code 4001 (o `createWsServer` registraria a conexão e criaria
-o arquivo de sala — um por conexão rejeitada, o lixo da #277 automatizado).
+o arquivo de sala, um por conexão rejeitada, o lixo da #277 automatizado).
 
 Qualquer outra rota HTTP segue respondendo `426 Upgrade Required`.
 
@@ -176,15 +176,15 @@ Qualquer outra rota HTTP segue respondendo `426 Upgrade Required`.
 
 1. Deploy com `AUTH_MODE=optional`. Clientes anônimos (compat) continuam sincronizando.
 2. Merge da fatia C (cliente passa a mandar JWT + migração dos dados anônimos → sala do userId). OTA chega nos testers.
-3. Aviso via WhatsApp (Evolution API) pros testers logarem — [[evolution-api-testers-stack]].
-4. **Deploy do server com `/healthz`** (#278) — precisa vir ANTES do flip. Enquanto não estiver no ar, o client sonda, não recebe resposta, e cai no caminho de "sem conexão": mesma coisa que hoje, sem regressão. Mas se o flip acontecer antes deste deploy, o tester sem login volta a ver a mensagem errada.
+3. Aviso via WhatsApp (Evolution API) pros testers logarem, ver [[evolution-api-testers-stack]].
+4. **Deploy do server com `/healthz`** (#278): precisa vir ANTES do flip. Enquanto não estiver no ar, o client sonda, não recebe resposta, e cai no caminho de "sem conexão": mesma coisa que hoje, sem regressão. Mas se o flip acontecer antes deste deploy, o tester sem login volta a ver a mensagem errada.
 5. Dias depois, PR separado: flip `AUTH_MODE=required` no server. Anônimo passa a ser rejeitado.
 
-Cloudflare Tunnel na frente já garante TLS válido; o server em si só fala WS plano em `127.0.0.1:8787` do host (loopback, não LAN — só o cloudflared do systemd alcança).
+Cloudflare Tunnel na frente já garante TLS válido; o server em si só fala WS plano em `127.0.0.1:8787` do host (loopback, não LAN, e só o cloudflared do systemd alcança).
 
 ## O que NÃO está aqui
 
-- Cliente do app passando `?token=` — vem na fatia C junto com a migração dos dados anônimos.
+- Cliente do app passando `?token=`: vem na fatia C junto com a migração dos dados anônimos.
 - Migração de dados anônimos → sala do userId (fatia C).
-- Validação em cenários reais (offline→online, 2 devices, reinstall) — última fatia do M6.
+- Validação em cenários reais (offline→online, 2 devices, reinstall): última fatia do M6.
 - Migração de schema server-side (não temos, `MergeableStore` cuida da forma dos dados).

--- a/server/compose.yml
+++ b/server/compose.yml
@@ -1,4 +1,4 @@
-# Deploy do server WS. TLS público via Cloudflare Tunnel — mas o cloudflared já
+# Deploy do server WS. TLS público via Cloudflare Tunnel, mas o cloudflared já
 # roda como serviço systemd no host (servindo outros subdomínios do túnel `home
 # server`), então NÃO subimos um container cloudflared aqui: seria uma segunda
 # replica redundante do mesmo túnel.
@@ -10,7 +10,7 @@
 #        Public Hostname: backontrack-sync . mhdn.com.br
 #        Service:         HTTP  (não HTTPS)
 #        URL:             http://127.0.0.1:8787
-#      Nova rota é puxada automaticamente pelo cloudflared existente — sem
+#      Nova rota é puxada automaticamente pelo cloudflared existente, sem
 #      restart, sem rebuild.
 #
 # Subir:
@@ -25,7 +25,7 @@ services:
       PORT: "8787"
       DATA_DIR: "/data"
     # Carrega .env do lado do container (auth: SUPABASE_JWT_SECRET, AUTH_MODE).
-    # `.env` é gitignored — cada deploy tem o seu.
+    # `.env` é gitignored, e cada deploy tem o seu.
     env_file:
       - .env
     volumes:

--- a/server/server.js
+++ b/server/server.js
@@ -7,7 +7,7 @@
 //
 // Auth (M6 fatia B, #211, ADR-010): quando o cliente manda `?token=<JWT>` na
 // URL, o server valida a assinatura e enforça que o `sub` do JWT bate com o
-// pathId — quem sabe o path sem o token do dono não conecta.
+// pathId: quem sabe o path sem o token do dono não conecta.
 //
 // Dois algoritmos são aceitos:
 //   - **ES256** (padrão atual do Supabase): chaves assimétricas ECC P-256. A
@@ -47,7 +47,7 @@ const DATA_DIR = resolve(process.env.DATA_DIR ?? "./data");
 const AUTH_MODE = process.env.AUTH_MODE ?? "optional";
 const JWT_SECRET = process.env.SUPABASE_JWT_SECRET ?? "";
 // URL base do projeto Supabase (ex.: https://abc.supabase.co). Necessária pra
-// validar tokens ES256 — é dela que sai o endpoint JWKS.
+// validar tokens ES256, porque é dela que sai o endpoint JWKS.
 const SUPABASE_URL = (process.env.SUPABASE_URL ?? "").replace(/\/+$/, "");
 const JWKS_URL = SUPABASE_URL
   ? `${SUPABASE_URL}/auth/v1/.well-known/jwks.json`
@@ -96,7 +96,7 @@ async function fetchJwks() {
   if (!JWKS_URL) throw new Error("SUPABASE_URL not set, cannot verify ES256");
   const now = Date.now();
   if (now - jwksFetchedAt < JWKS_MIN_REFETCH_MS && jwksCache.size > 0) {
-    // Refetch recente demais — usa o cache atual (kid segue desconhecido).
+    // Refetch recente demais, então usa o cache atual (kid segue desconhecido).
     return;
   }
   jwksFetchedAt = now;
@@ -138,7 +138,7 @@ async function verifyJwt(token) {
 
   if (header.alg === "ES256") {
     const key = await getPublicKey(header.kid);
-    // Assinatura JWT ES256 é R||S cru (64 bytes), não DER — daí o
+    // Assinatura JWT ES256 é R||S cru (64 bytes), e não DER, daí o
     // dsaEncoding ieee-p1363, senão o Node rejeita tudo como inválido.
     const ok = verify(
       "sha256",
@@ -173,7 +173,7 @@ async function verifyJwt(token) {
 // Servidor HTTP na frente do WS, por um motivo só: anunciar o AUTH_MODE (#278).
 //
 // Quando o server recusa uma conexão sem token, ele responde 401 no handshake
-// — mas o 401 **não atravessa** até o cliente. A API WebSocket de browser e
+// Só que o 401 **não atravessa** até o cliente. A API WebSocket de browser e
 // React Native não expõe o status HTTP de um handshake que falhou; o app vê
 // só um `close` genérico, indistinguível de queda de rede. Sem isto, o tester
 // sem login veria "sem conexão" e um "Tentar de novo" que nunca funciona.
@@ -196,7 +196,7 @@ const httpServer = createServer((req, res) => {
       "content-type": "application/json",
       "content-length": Buffer.byteLength(corpo),
       // O app é servido de outra origem (e no native não há origem). Só
-      // devolve o modo de auth — nada aqui é segredo.
+      // devolve o modo de auth, e nada aqui é segredo.
       "access-control-allow-origin": "*",
       "cache-control": "no-store",
     });
@@ -224,7 +224,7 @@ const wss = new WebSocketServer({
         );
         return callback(false, 500, "server cannot verify tokens");
       }
-      // verifyJwt é async (JWKS pode precisar de fetch) — o callback do
+      // verifyJwt é async (JWKS pode precisar de fetch), e o callback do
       // verifyClient aceita resolução assíncrona.
       verifyJwt(token)
         .then((payload) => {
@@ -272,6 +272,6 @@ const verifiers = [
 // corrida em que o teste conecta num socket que ainda não existe.
 httpServer.listen(PORT, () => {
   console.log(
-    `[sync] listening on ws://0.0.0.0:${PORT} — data dir: ${DATA_DIR} — auth: ${AUTH_MODE}${verifiers ? ` (${verifiers})` : ""}`,
+    `[sync] listening on ws://0.0.0.0:${PORT} | data dir: ${DATA_DIR} | auth: ${AUTH_MODE}${verifiers ? ` (${verifiers})` : ""}`,
   );
 });

--- a/server/smoke-client.js
+++ b/server/smoke-client.js
@@ -7,7 +7,7 @@
 //   URL=ws://localhost:8787 node smoke-client.js
 //   URL=wss://<sub>.<seu-dominio> node smoke-client.js
 //
-// Não é teste unitário — é um "ping" que dá pra rodar contra dev local ou
+// Em vez de teste unitário, é um "ping" que dá pra rodar contra dev local ou
 // contra o server em produção. Sai 0 se OK, 1 se falhou.
 
 import { createMergeableStore } from "tinybase";

--- a/server/smoke-two-clients.js
+++ b/server/smoke-two-clients.js
@@ -4,7 +4,7 @@
 // Diferente do smoke-client.js (self round-trip: escreve → desconecta →
 // reconecta → lê próprio valor), aqui abrimos 2 clients SIMULTANEAMENTE no
 // mesmo room e provamos que um vê a escrita do outro via server. É o teste
-// que responde "sync funciona entre dois devices?" — sem depender do app RN.
+// que responde "sync funciona entre dois devices?", sem depender do app RN.
 //
 //   ROOM=<uuid-de-testes> URL=wss://backontrack-sync.mhdn.com.br node smoke-two-clients.js
 //


### PR DESCRIPTION
Closes #316. Primeira metade da fatia 3, com 191 ocorrências em 34 arquivos. A segunda (`components/`, `app/`, `tests/`) vem na 3b.

Diff fecha em **+188 -188**, ou seja, nenhuma linha a mais nem a menos.

## Quase tudo é comentário, com duas exceções

**O log de boot do server** tinha dois travessões separando campos:

```
[sync] listening on ws://0.0.0.0:8787 — data dir: /data — auth: optional
```

Virou pipe, que é separador de campo e não pontuação de prosa.

Este é o único ponto do PR com risco real, e por um motivo que não é óbvio: **o `tests/sync-server.test.js` usa esse log como sinal de "servidor pronto"**, casando em `[sync] listening on ws://`. O trecho casado vem antes do primeiro separador, então a troca é segura. Rodei os 20 testes que sobem o server de verdade em subprocesso, e passam.

O `server/README.md` tinha essa saída copiada como exemplo, e foi atualizado junto pra não mentir sobre o que o server imprime.

**A saída de CLI do `notify-testers.mjs`**, que o operador lê ao disparar aviso pros testers, passou a usar dois-pontos entre nome e valor.

## Preservado

O glifo de célula vazia na tabela do `server/README.md`, e o literal em `scripts/check-em-dash.js`, que já é isento por caminho na própria barreira.

## Verificação

- 292 testes verdes, incluindo os 20 do server em subprocesso
- eslint, prettier e tsc limpos
- a barreira da #310 passa no próprio diff

## Como validar

Nada muda na tela. O único comportamento observável é o log do server, que só aparece pra quem sobe o container.