### PR TITLE
chore(texto): tirar o travessão de components, app, tests e config (fatia 3b da #302)

### DIFF
--- a/.claude/hooks/check-commit-english.sh
+++ b/.claude/hooks/check-commit-english.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# PreToolUse hook — bloqueia `git commit` quando o subject line (1ª linha da
+# PreToolUse hook: bloqueia `git commit` quando o subject line (1ª linha da
 # mensagem) parece português. Padrão do repo é inglês (CONTRIBUTING.md).
 # Configurado em .claude/settings.json.
 #
@@ -10,7 +10,7 @@
 
 set -euo pipefail
 
-# Escape valve — usuário pode desativar via env var pontualmente.
+# Escape valve: usuário pode desativar via env var pontualmente.
 if [ "${SKIP_COMMIT_LANG_CHECK:-}" = "1" ]; then
   exit 0
 fi
@@ -67,14 +67,14 @@ Commit subject em português detectado (acento '$found').
 
   Subject: "$subject"
 
-Padrão do repo é inglês — ver CONTRIBUTING.md. Reescreva o subject e tente de novo.
+Padrão do repo é inglês. Ver CONTRIBUTING.md. Reescreva o subject e tente de novo.
 (Escape emergencial: prefixe com SKIP_COMMIT_LANG_CHECK=1 se o hook errou.)
 MSG
   exit 2
 fi
 
 # --- Sinal 2: palavras PT-only comuns em commit messages ---
-# Lista conservadora — palavras que quase certamente indicam PT em contexto de
+# Lista conservadora: palavras que quase certamente indicam PT em contexto de
 # commit e não colidem com inglês. Match é word-boundary, case-insensitive.
 pt_words='trata|tratando|melhora|melhorando|melhoria|corrige|corrigindo|adiciona|adicionando|atualiza|atualizando|marca|marcando|entrega|entregue|entregando|ajusta|ajustando|deixa|deixando|evita|evitando|garante|garantindo|arruma|arrumando|renomeia|renomeando|reescreve|reescrevendo|separa|separando|junta|juntando|apaga|apagando|puxa|puxando|sobe|subindo|desce|descendo|acha|achando|coloca|colocando|tira|tirando|manda|mandando|fatia|arquivo|pasta|tela|escolha|mensagem|chave|senha|retorno|pacote|padrao|versao|sessao|conexao|estado|erro|erros|ponto|caminho|nome|nomes|tudo|nada|algum|alguma|apenas|somente|entao|senao|porque|quando|onde|com|sem|sobre|pelo|pela|pra|pro|para|dos|das'
 
@@ -85,7 +85,7 @@ Commit subject em português detectado (palavra: '$found').
 
   Subject: "$subject"
 
-Padrão do repo é inglês — ver CONTRIBUTING.md. Reescreva o subject e tente de novo.
+Padrão do repo é inglês. Ver CONTRIBUTING.md. Reescreva o subject e tente de novo.
 (Escape emergencial: prefixe com SKIP_COMMIT_LANG_CHECK=1 se o hook errou.)
 MSG
   exit 2

--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,6 @@ EXPO_PUBLIC_SUPABASE_ANON_KEY=
 # O PAT real da Vercel fica lá, não aqui.
 EXPO_PUBLIC_FEEDBACK_KEY=
 
-# --- Sync (M6 fatia 3, #202) — opcional ---
+# --- Sync (M6 fatia 3, #202), opcional ---
 # Padrão é wss://backontrack-sync.mhdn.com.br. String vazia desliga o sync.
 # EXPO_PUBLIC_SYNC_URL=

--- a/.github/workflows/promote-update.yaml
+++ b/.github/workflows/promote-update.yaml
@@ -1,6 +1,6 @@
 name: Promote Update
 
-# Promove o último OTA de `release` pra `preview` — libera pros 6 testers.
+# Promove o último OTA de `release` pra `preview`, liberando pros 6 testers.
 #
 # ## Por que a fonte é `release` e não `staging`
 #
@@ -9,14 +9,14 @@ name: Promote Update
 # merge. Promover de lá poderia mandar código não-mergeado pros testers.
 #
 # `release` só é alimentada por push na main. Promover de lá é barreira
-# ESTRUTURAL contra isso — não depende de ninguém lembrar da regra.
+# ESTRUTURAL contra isso, e não depende de ninguém lembrar da regra.
 #
 # Roda só sob demanda (`workflow_dispatch`) de propósito: o gate existe pra
 # VOCÊ escolher o momento e o lote. Merges na main se acumulam em release até
 # alguém rodar isto aqui.
 #
 # Mecanismo: `eas update:republish` copia um grupo de update de uma branch pra
-# outra. O APK dos testers não muda — ele é assado com o CANAL `preview`, e o
+# outra. O APK dos testers não muda: ele é assado com o CANAL `preview`, e o
 # canal aponta pra branch `preview`. Ninguém reinstala nada.
 #
 # Ver docs/10-canais-e-promocao.md.
@@ -57,7 +57,7 @@ jobs:
           GROUP=$(echo "$JSON" | jq -r '.currentPage[0].group // empty')
           DESC=$(echo "$JSON" | jq -r '.currentPage[0].message // "(sem mensagem)"')
           if [ -z "$GROUP" ]; then
-            echo "Nenhum update na branch release — nada a promover." >&2
+            echo "Nenhum update na branch release, nada a promover." >&2
             exit 1
           fi
           echo "group=$GROUP" >> "$GITHUB_OUTPUT"
@@ -94,5 +94,5 @@ jobs:
             echo "${DESC}"
             echo '```'
             echo ""
-            echo "Os 6 testers recebem na próxima abertura do app. Se algo der errado, rode esta workflow de novo apontando pro grupo bom anterior — ou use \`eas update:roll-back-to-embedded\`."
+            echo "Os 6 testers recebem na próxima abertura do app. Se algo der errado, rode esta workflow de novo apontando pro grupo bom anterior, ou use \`eas update:roll-back-to-embedded\`."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-update.yaml
+++ b/.github/workflows/publish-update.yaml
@@ -1,27 +1,27 @@
 name: Publish Update
 
-# Todo merge na main publica OTA na branch `release` — e SÓ nela.
+# Todo merge na main publica OTA na branch `release`, e SÓ nela.
 #
-#   release  — linhagem só-main. Única fonte da promoção pros testers.
-#   staging  — bancada de validação, alimentada SÓ por PR. Não é tocada aqui.
+#   release  = linhagem só-main. Única fonte da promoção pros testers.
+#   staging  = bancada de validação, alimentada SÓ por PR. Não é tocada aqui.
 #
 # ## Por que a main não publica mais em staging
 #
 # Publicava, com a ideia de manter o BoT staging refletindo a main quando não
 # havia PR em teste. O efeito prático foi outro: como `staging` é um slot só,
 # todo merge SOBRESCREVIA em silêncio o PR que estava sendo validado no
-# aparelho. Aconteceu três vezes seguidas — o #268 e o #270 foram reportados
+# aparelho. Aconteceu três vezes seguidas: o #268 e o #270 foram reportados
 # como "não funciona" quando o código deles nem estava no aparelho.
 #
 # Agora a bancada é exclusiva de PR: um merge nunca rouba o teste em curso.
 # Pra ver a main no aparelho, é só rodar `Test PR on Staging` sem PR aberto
-# ou esperar o próximo PR — o custo é bem menor que o da confusão.
+# ou esperar o próximo PR, e o custo é bem menor que o da confusão.
 #
 # A `release` segue sendo a única fonte da promoção, o que impede código
 # não-mergeado de chegar nos 6 testers. Barreira estrutural, não disciplina.
 #
 # `--environment preview` é o conjunto de env vars do EAS (Supabase etc.), não
-# o canal — todos os ambientes compartilham o mesmo backend de propósito.
+# o canal, e todos os ambientes compartilham o mesmo backend de propósito.
 #
 # Ver docs/10-canais-e-promocao.md.
 
@@ -57,7 +57,7 @@ jobs:
           {
             echo "## OTA publicada em \`release\`"
             echo ""
-            echo "Os testers **não** recebem ainda — a branch \`preview\` só muda por promoção manual."
+            echo "Os testers **não** recebem ainda: a branch \`preview\` só muda por promoção manual."
             echo ""
             echo "O **BoT staging** não foi tocado: a bancada é exclusiva de PR, pra um merge nunca sobrescrever o que você está testando."
             echo ""

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,7 +58,7 @@ jobs:
       # (banner NATIVE_OUTDATED do UpdateBanner) pro build recém-criado. Não
       # commita na main (ruleset exige PR) nem abre PR via API (PR do
       # GITHUB_TOKEN não dispara `on: pull_request`, travando os checks).
-      # Empurra a branch e deixa link pro humano abrir o PR — aí o CI roda.
+      # Empurra a branch e deixa link pro humano abrir o PR, e aí o CI roda.
       # Ver [[repo-ci-constraints]].
       - name: Atualiza EAS_INSTALL_URL + latest-apk-version.json (branch + link de PR)
         env:
@@ -68,10 +68,10 @@ jobs:
           EAS_URL="https://expo.dev/accounts/matheushnascimento/projects/backOnTrack/builds/${BUILD_ID}"
           APP_VERSION=$(jq -r '.expo.version' app.json)
 
-          # constants/distribution.js — card "Obter o app"
+          # constants/distribution.js: card "Obter o app"
           sed -i -E "s#(projects/backOnTrack/builds/)[a-f0-9-]+#\1${BUILD_ID}#" constants/distribution.js
 
-          # assets/latest-apk-version.json — banner NATIVE_OUTDATED (dispara
+          # assets/latest-apk-version.json: banner NATIVE_OUTDATED (dispara
           # nos testers em versão anterior). Reescreve o arquivo inteiro pra
           # garantir schema estável (jq -n em vez de sed).
           jq -n --arg v "$APP_VERSION" --arg u "$EAS_URL" \
@@ -79,7 +79,7 @@ jobs:
             > assets/latest-apk-version.json
 
           if git diff --quiet constants/distribution.js assets/latest-apk-version.json; then
-            echo "Distribuição já aponta pro build atual — nada a fazer." >> "$GITHUB_STEP_SUMMARY"
+            echo "Distribuição já aponta pro build atual, nada a fazer." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
 

--- a/.github/workflows/test-pr-on-staging.yaml
+++ b/.github/workflows/test-pr-on-staging.yaml
@@ -1,12 +1,12 @@
 name: Test PR on Staging
 
-# TODO PR publica na branch `staging` — é o que o BoT staging consome. Serve
+# TODO PR publica na branch `staging`, que é o que o BoT staging consome. Serve
 # pra validar no aparelho ANTES do merge.
 #
 # ## Por que sem label
 #
 # O #269 exigia a label `staging` no PR. Como a regra virou "toda feature
-# branch vai pro staging", a label passaria a estar em todo PR — e uma marca
+# branch vai pro staging", a label passaria a estar em todo PR, e uma marca
 # que está em tudo não marca nada. Pior: dava a impressão de escolher qual PR
 # está carregado, o que ela nunca fez. Existe UM canal `staging` e UM app no
 # aparelho, então é sempre um PR por vez: **o staging mostra o push mais
@@ -15,9 +15,9 @@ name: Test PR on Staging
 #
 # ## Quem NÃO publica
 #
-# - **Draft** — trabalho em andamento não precisa ocupar a bancada.
-# - **Label `skip-staging`** — escape hatch manual.
-# - **PR de fork** — não recebe `EXPO_TOKEN`, falharia com erro confuso.
+# - **Draft**: trabalho em andamento não precisa ocupar a bancada.
+# - **Label `skip-staging`**: escape hatch manual.
+# - **PR de fork**: não recebe `EXPO_TOKEN`, falharia com erro confuso.
 # - **Mudança só de doc ou de workflow**, pelo filtro `paths` abaixo. Não
 #   altera o bundle, e publicar seria gasto de update à toa.
 #
@@ -34,7 +34,7 @@ name: Test PR on Staging
 #
 # ## O que garante que isto não vaze pros testers
 #
-# A promoção (`promote-update.yaml`) NÃO sai de `staging` — sai de `release`,
+# A promoção (`promote-update.yaml`) NÃO sai de `staging`. Sai de `release`,
 # que só a main alimenta. Código não-mergeado não tem caminho até o canal
 # `preview`. Ver docs/10-canais-e-promocao.md.
 
@@ -73,7 +73,7 @@ jobs:
           NUM: ${{ github.event_name == 'workflow_dispatch' && inputs.pr || github.event.pull_request.number }}
         run: echo "num=$NUM" >> "$GITHUB_OUTPUT"
 
-      # `refs/pull/N/merge` é o PR JÁ MESCLADO com a main — é o que a main vai
+      # `refs/pull/N/merge` é o PR JÁ MESCLADO com a main, que é o que a main vai
       # virar depois do merge. Testar o head puro esconderia conflito
       # semântico com o que entrou na main enquanto o PR estava aberto.
       - uses: actions/checkout@v4
@@ -109,7 +109,7 @@ jobs:
             echo ""
             echo "Abra o **BoT staging** no aparelho pra validar (pode precisar fechar e reabrir)."
             echo ""
-            echo "Se você tinha outro PR carregado, ele foi substituído — a bancada é um slot só, sempre com o push mais recente."
+            echo "Se você tinha outro PR carregado, ele foi substituído: a bancada é um slot só, sempre com o push mais recente."
             echo ""
             echo "Isto **não** chega nos testers: a promoção sai da branch \`release\`, que só a main alimenta."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,7 @@ yarn-error.*
 # typescript
 *.tsbuildinfo
 
-# Lista de testers exportada do app (PII) — nunca versionar.
+# Lista de testers exportada do app (PII). Nunca versionar.
 scripts/testers.json
 
 # Rascunho local da mensagem do sender (notify-testers.mjs --text-file).
@@ -50,7 +50,7 @@ convite.txt
 server/data/
 
 # Fonte visual do design v2 (Claude Design bundle, M5-B). ~600KB, referência
-# local — os tokens extraídos vivem em docs/09-design-v2.md.
+# local, e os tokens extraídos vivem em docs/09-design-v2.md.
 Back on Track - Icon Directions.html
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contribuindo — Back on Track
+# Contribuindo com o Back on Track
 
 Guia curto pra manter consistência entre contribuidores (humanos e agentes).
 
@@ -12,7 +12,7 @@ O repositório usa **dois idiomas** de forma deliberada. A regra de qual vai ond
   - Exemplos: `feat/80-metric-screen-base`, `fix/72-water-history-crash`, `refactor/154-tokens-radius`, `docs/187-contributing-conventions`
 - **Mensagem de commit:** conventional commits em inglês.
   - Exemplos: `fix(ui): shorten dark border`, `refactor(ui): canonical radius scale`, `docs(readme): fix typo`
-  - `commitlint` valida o formato (`.commitlintrc.*` / husky). O `subject` deve começar em **minúsculo** — evite começar com nome de componente (`MyButton`, `MetricScreen`); parafraseie (`disabled state on MyButton` em vez de `MyButton disabled`).
+  - `commitlint` valida o formato (`.commitlintrc.*` / husky). O `subject` deve começar em **minúsculo**, então evite começar com nome de componente (`MyButton`, `MetricScreen`); parafraseie (`disabled state on MyButton` em vez de `MyButton disabled`).
 - **Identificadores de código novos:** inglês como API exportada (`get`, `add`, `getToday`, `useRegistrosPersistencia`). Se um arquivo legado usa PT (`hidratar`, `linhas`), respeite o estilo local até que ele seja refatorado.
 
 ### Português
@@ -25,19 +25,19 @@ O repositório usa **dois idiomas** de forma deliberada. A regra de qual vai ond
 
 ### Rationale
 
-Branch e commit são a **interface técnica do repo** — aparecem em qualquer plataforma (GitHub UI, `git log`, notificações, releases) e ficam expostos a qualquer contribuidor futuro, incluindo ferramentas automatizadas. O restante (issue, PR, comentário, UI, doc) é conteúdo do **produto** ou da **discussão**, e mantém a voz PT-BR do projeto.
+Branch e commit são a **interface técnica do repo**, e aparecem em qualquer plataforma (GitHub UI, `git log`, notificações, releases) e ficam expostos a qualquer contribuidor futuro, incluindo ferramentas automatizadas. O restante (issue, PR, comentário, UI, doc) é conteúdo do **produto** ou da **discussão**, e mantém a voz PT-BR do projeto.
 
 ## Fluxo de trabalho
 
 Cada mudança deveria passar pelo ciclo:
 
-1. **Issue** — registrar o trabalho antes de codar (título/corpo em português)
-2. **Branch** — criar a partir de `main` atualizada; nome em inglês
-3. **Implementar** — código, testes, doc
-4. **Commit** — conventional commits em inglês
-5. **PR** — abrir contra `main` (título/corpo em português); aguardar CI verde
-6. **Merge** — squash + delete branch depois que o CI passar (e revisão visual, quando aplicável)
-7. **Fechar issue** — com um comentário do que foi entregue
+1. **Issue**: registrar o trabalho antes de codar (título/corpo em português)
+2. **Branch**: criar a partir de `main` atualizada; nome em inglês
+3. **Implementar**: código, testes, doc
+4. **Commit**: conventional commits em inglês
+5. **PR**: abrir contra `main` (título/corpo em português); aguardar CI verde
+6. **Merge**: squash + delete branch depois que o CI passar (e revisão visual, quando aplicável)
+7. **Fechar issue**: com um comentário do que foi entregue
 
 `main` tem proteção: sem push direto, exige PR e CI verde. Não use `--force` sem alinhar antes.
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Aplicação React Native para registro de métricas pessoais mínimas. O MVP cob
 
 ## Documentos
 
-1. [Project Charter](docs/01-project-charter.md) — visão, objetivo, justificativa, critérios de sucesso
-2. [Escopo & MVP](docs/02-escopo-mvp.md) — modelo de domínio, o que entra na v1, non-goals
-3. [Decisões Técnicas (ADR)](docs/03-decisoes-tecnicas.md) — stack escolhida e o porquê de cada decisão
-4. [Roadmap de Milestones](docs/04-roadmap-milestones.md) — sequência de desenvolvimento (projeto em adaptação)
-5. [Guia de Migração de Estilo](docs/05-guia-migracao-estilo.md) — mapa de → para CSS-web → NativeWind
+1. [Project Charter](docs/01-project-charter.md): visão, objetivo, justificativa, critérios de sucesso
+2. [Escopo & MVP](docs/02-escopo-mvp.md): modelo de domínio, o que entra na v1, non-goals
+3. [Decisões Técnicas (ADR)](docs/03-decisoes-tecnicas.md): stack escolhida e o porquê de cada decisão
+4. [Roadmap de Milestones](docs/04-roadmap-milestones.md): sequência de desenvolvimento (projeto em adaptação)
+5. [Guia de Migração de Estilo](docs/05-guia-migracao-estilo.md): mapa de → para CSS-web → NativeWind
 
 ## Como usar esta documentação
 

--- a/api/feedback.js
+++ b/api/feedback.js
@@ -1,6 +1,6 @@
 // @ts-nocheck -- handler serverless (req/res do Vercel não tipados); ADR-002
 // Função serverless (Vercel) que cria uma issue de feedback no GitHub em nome do
-// tester — assim quem não tem conta ou familiaridade com o GitHub reporta direto
+// tester, então quem não tem conta ou familiaridade com o GitHub reporta direto
 // do app. O PAT fica SÓ aqui (env GITHUB_ISSUE_TOKEN), nunca no cliente.
 //
 // Env necessárias na Vercel:

--- a/app.config.js
+++ b/app.config.js
@@ -1,19 +1,19 @@
 // Variante de app por ambiente.
 //
-// O `app.json` continua sendo a fonte de verdade da config — o Expo o carrega
+// O `app.json` continua sendo a fonte de verdade da config, e o Expo o carrega
 // primeiro e entrega o resultado aqui como `config`. Este arquivo só BIFURCA
 // a identidade quando `APP_VARIANT=staging` (setado pelo profile `staging` do
 // eas.json).
 //
 // ## Por que uma identidade separada
 //
-// O APK de staging precisa conviver com o de produção NO MESMO aparelho — é
+// O APK de staging precisa conviver com o de produção NO MESMO aparelho, e é
 // isso que permite validar uma mudança nativa antes dela chegar nos testers.
 // Dois apps só coexistem no Android se tiverem `applicationId` diferente.
 //
 // O `scheme` também bifurca, e não é detalhe: com os dois instalados sob o
 // mesmo `backontrack://`, o Android não sabe qual abrir no callback do magic
-// link — o login cairia no app errado (ou num seletor). Ver
+// link, e o login cairia no app errado (ou num seletor). Ver
 // docs/10-canais-e-promocao.md § Supabase.
 //
 // O que NÃO muda: `slug`, `extra.eas.projectId` e `updates.url`. Os dois

--- a/app/_layout.jsx
+++ b/app/_layout.jsx
@@ -26,7 +26,7 @@ import UpdateBanner from "@/components/UpdateBanner";
 // Segura o splash nativo até as fontes carregarem. Fora do componente porque
 // precisa rodar UMA vez, antes do primeiro render.
 SplashScreen.preventAutoHideAsync().catch(() => {
-  // Já escondido ou indisponível (web/dev) — seguir sem travar o boot.
+  // Já escondido ou indisponível (web/dev): seguir sem travar o boot.
 });
 
 export default function RootLayout() {
@@ -41,7 +41,7 @@ export default function RootLayout() {
   // apareceu como bug de renderização recorrente no Android: a UI montava com
   // a fonte de fallback do sistema, o Android MEDIA o texto com ela, e quando
   // a Inter terminava de carregar o glifo real vinha mais largo que a caixa já
-  // dimensionada — a última letra cortava ("Depois" virava "Depoi").
+  // dimensionada, e a última letra cortava ("Depois" virava "Depoi").
   //
   // Foi diagnosticado errado três vezes (#239 fontWeight+letterSpacing, #249
   // underline, #268 flex): cada patch mexia num sintoma diferente da mesma
@@ -54,7 +54,7 @@ export default function RootLayout() {
     JetBrainsMono_500Medium,
   });
 
-  // Erro de fonte não pode deixar o app preso no splash pra sempre — nesse
+  // Erro de fonte não pode deixar o app preso no splash pra sempre. Nesse
   // caso segue com o fallback do sistema, que é degradação aceitável.
   const pronto = fontsLoaded || !!fontError;
 
@@ -68,10 +68,10 @@ export default function RootLayout() {
 
   return (
     <SafeAreaProvider>
-      {/* SessionProvider envolve tudo (M6 auth fatia A, #207) — expõe a
+      {/* SessionProvider envolve tudo (M6 auth fatia A, #207): expõe a
           sessão do Supabase pros filhos via useSession. O SyncStatusProvider
           precisa vir por DENTRO dele: roda useRegistrosSync, que chama
-          useSession por baixo — acima do provider receberia o default do
+          useSession por baixo, porque acima do provider receberia o default do
           contexto (user: null) e o sync nunca sairia da sala anônima após
           login (bug do #217). */}
       <SessionProvider>
@@ -95,7 +95,7 @@ function AppTree() {
         <Stack.Screen name="export" options={{ title: "Exportação" }} />
         <Stack.Screen name="history" options={{ title: "Histórico" }} />
         <Stack.Screen name="semana" options={{ title: "Semana" }} />
-        {/* Aberta pelo hamburger (canto esquerdo) — entra da esquerda pra
+        {/* Aberta pelo hamburger (canto esquerdo): entra da esquerda pra
             casar com o ícone, em vez do slide-from-right padrão de "avançar
             no conteúdo" que as outras telas usam. */}
         <Stack.Screen
@@ -103,10 +103,10 @@ function AppTree() {
           options={{ title: "Ajustes", animation: "slide_from_left" }}
         />
         <Stack.Screen name="feedback" options={{ title: "Feedback" }} />
-        {/* Rota de admin (testers) — acesso só por deep link backontrack://admin */}
+        {/* Rota de admin (testers): acesso só por deep link backontrack://admin */}
         <Stack.Screen name="admin" options={{ title: "Admin" }} />
         <Stack.Screen name="login" options={{ title: "Entrar" }} />
-        {/* Callback do magic link — headless, autopropulsão pra /. */}
+        {/* Callback do magic link: headless, autopropulsão pra /. */}
         <Stack.Screen
           name="auth/callback"
           options={{ title: "Autenticando", headerShown: false }}

--- a/app/admin.jsx
+++ b/app/admin.jsx
@@ -1,7 +1,7 @@
 // @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
 //
 // Tela de administração de testers (Track A do M3-5, #109). Acesso só por deep
-// link `backontrack://admin` — de propósito NÃO fica linkada nos Utilitários.
+// link `backontrack://admin`, e de propósito NÃO fica linkada nos Utilitários.
 // A lista vive em TinyBase local (por-device), então numa instalação de tester
 // esta tela aparece vazia; só o aparelho do admin popula.
 //#region imports
@@ -31,7 +31,7 @@ export default function Admin() {
   const [name, setName] = useState("");
   const [phone, setPhone] = useState("");
 
-  // Assina a tabela: re-renderiza a cada mudança — inclusive quando o
+  // Assina a tabela: re-renderiza a cada mudança, inclusive quando o
   // `startAutoLoad()` da persistência termina. Ler só no foco fazia a lista
   // nascer vazia no primeiro load (mesma causa do #108).
   const testersTable = useTable("testers", store);
@@ -71,7 +71,7 @@ export default function Admin() {
     );
     try {
       // No web o destino é a máquina de dev (colar no scripts/testers.json), e
-      // a Web Share API nem existe em boa parte do desktop — clipboard é o
+      // a Web Share API nem existe em boa parte do desktop, então clipboard é o
       // certo. No native, o share sheet é o caminho natural pra tirar o JSON
       // do device.
       if (Platform.OS === "web") {
@@ -81,7 +81,7 @@ export default function Admin() {
       }
       await Share.share({ message: json });
     } catch (e) {
-      // Erro de share/clipboard não vaza pro usuário — só console.
+      // Erro de share/clipboard não vaza pro usuário, só console.
       console.error("[admin] export falhou:", e);
       notify("Não deu pra exportar", "Tenta de novo em instantes.");
     }

--- a/app/ajustes.jsx
+++ b/app/ajustes.jsx
@@ -67,15 +67,15 @@ const DEV_SURFACE = isDevSurface();
 // full-height + rolagem lê pior que uma tela dedicada.
 //
 // Seções:
-//   - METAS DO DIA  — display-only por ora (valor por-usuário é feature futura).
-//   - NAVEGAÇÃO     — Semana / Histórico.
-//   - APP           — Tema switch inline, Feedback, Roadmap, Exportar, Sobre.
-//   - CONTA         — só se logado (Logado como… + Sair).
-//   - AVANÇADO      — Limpar todos os dados (destrutivo, confirm modal).
+//   - METAS DO DIA  = display-only por ora (valor por-usuário é feature futura).
+//   - NAVEGAÇÃO     = Semana / Histórico.
+//   - APP           = Tema switch inline, Feedback, Roadmap, Exportar, Sobre.
+//   - CONTA         = só se logado (Logado como… + Sair).
+//   - AVANÇADO      = Limpar todos os dados (destrutivo, confirm modal).
 //
 // Lembretes da mockup ficaram fora (dependem de expo-notifications, escopo M7).
 
-// Rótulos das metas. Os VALORES vêm do store desde a #285 — antes eram texto
+// Rótulos das metas. Os VALORES vêm do store desde a #285. Antes eram texto
 // fixo aqui, e o modelo de níveis não fecha sem meta como dado. Edição pelo
 // usuário é fatia própria; por ora o store guarda os mesmos defaults.
 const METAS_LABEL = {
@@ -86,7 +86,7 @@ const METAS_LABEL = {
   study: "Estudo",
 };
 
-// Rótulo humano dos status da jornada. Descritivo, nunca elogioso — é
+// Rótulo humano dos status da jornada. Descritivo, nunca elogioso, porque é
 // diagnóstico, não reforço (docs/11-modelo-de-niveis.md §1.5).
 const STATUS_LABEL = {
   [BUILDING]: "construindo",
@@ -114,7 +114,7 @@ export default function Ajustes() {
   const goals = useMemo(() => getGoals(), [goalsTable]);
 
   // Pular nível (#295): a pessoa declara que já tem o hábito, o app confere o
-  // histórico com o MESMO critério do portão e concede — ou diz que observa.
+  // histórico com o MESMO critério do portão e concede, ou diz que observa.
   const [skipMetric, setSkipMetric] = useState(null);
   const recordsTable = useTable("records", store);
   const grantedValue = useValue("journeyGranted", store);
@@ -282,7 +282,7 @@ export default function Ajustes() {
         </Section>
 
         {/* Conta: sempre visível quando auth tá configurada. Concentra o
-            fluxo de entrar/sair — a Home não tem mais botão Entrar isolado
+            fluxo de entrar/sair, e a Home não tem mais botão Entrar isolado
             (era redundante e piscava durante o auto-load da sessão). */}
         {AUTH_ENABLED && (
           <Section title="Conta">
@@ -301,7 +301,7 @@ export default function Ajustes() {
           </Section>
         )}
 
-        {/* Já tenho esse hábito — pular nível com conferência (#295). */}
+        {/* Já tenho esse hábito: pular nível com conferência (#295). */}
         <Section title="Já tenho esse hábito">
           {JOURNEY_ORDER.map((metric) => (
             <Row
@@ -504,12 +504,12 @@ function NameEditModal({ current, onClose }) {
 /** @param {{ title: string, children: any }} props */
 // Estado do sync, em linguagem de gente. Fecha o item "UI de status de sync"
 // do M6: o auto-reconnect (#263) resolveu a queda silenciosa, mas o usuário
-// ainda não tinha ONDE conferir se estava sincronizando — e a quebra do ES256
+// ainda não tinha ONDE conferir se estava sincronizando, e a quebra do ES256
 // mostrou que "não aparece no outro aparelho" pode passar semanas invisível.
 //
 // Estar offline NÃO é erro aqui: o app é local-first, os registros ficam
 // salvos no aparelho e sobem quando a conexão volta. Por isso nada de
-// vermelho — o `danger` fica reservado pro destrutivo (regra 2 do Turno 3).
+// vermelho: o `danger` fica reservado pro destrutivo (regra 2 do Turno 3).
 // Offline usa cinza de label e a copy tranquiliza em vez de cobrar.
 const SYNC_UI = {
   [SYNC_ONLINE]: {
@@ -535,7 +535,7 @@ const SYNC_UI = {
   // Recusado por falta de login (#278). Antes isto caía em `offline`, e as
   // três coisas ficavam falsas ao mesmo tempo: não era falta de conexão, nada
   // ia "subir quando voltar", e o "Tentar de novo" nunca funcionaria. Copy
-  // sem cobrança, como o resto — o registro local segue intacto.
+  // sem cobrança, como o resto, porque o registro local segue intacto.
   [SYNC_NEEDS_AUTH]: {
     dot: "bg-border-strong dark:bg-border-strong-dark",
     text: "precisa entrar",
@@ -548,7 +548,7 @@ function SyncRow() {
   const ui = SYNC_UI[status] ?? SYNC_UI[SYNC_OFF];
   // Só oferece "tentar de novo" quando há o que retentar. Em `off` não há
   // servidor configurado; em `connecting`/`online` já está acontecendo; em
-  // `needs-auth` retentar é justamente o que não resolve — a ação é entrar.
+  // `needs-auth` retentar é justamente o que não resolve, porque a ação é entrar.
   const canRetry = status === SYNC_OFFLINE;
   const precisaEntrar = status === SYNC_NEEDS_AUTH;
 
@@ -617,7 +617,7 @@ function SyncRow() {
  * Sinais de automaticidade por métrica (#285, fatia 0).
  *
  * Medição silenciosa: nada aqui decide nada. Nenhum limiar, nenhum nível,
- * nenhum "bom/ruim" — só os números crus, pra calibrar os limiares do modelo
+ * nenhum "bom/ruim", só os números crus, pra calibrar os limiares do modelo
  * com dado real antes de pendurar consequência neles
  * (docs/11-modelo-de-niveis.md §12).
  *
@@ -715,12 +715,12 @@ function SignalsBlock({ goals }) {
         ))}
       </View>
 
-      {/* Controles de desenvolvimento — NÃO aparecem no app dos testers.
+      {/* Controles de desenvolvimento. NÃO aparecem no app dos testers.
           Ver `isDevSurface`: só em dev e no canal `staging`. */}
       {DEV_SURFACE ? (
         <>
           {/* Previsualização de nível: força o nível pra ver as telas que o
-          histórico curto não alcança. Afrouxar limiar não resolveria — com
+          histórico curto não alcança. Afrouxar limiar não resolveria, porque com
           21% de consistência o portão teria que cair tão fundo que deixaria
           de ser o mesmo portão. Isto testa a TELA; o modelo continua coberto
           por tests/journey.test.js com dado sintético. */}
@@ -768,7 +768,7 @@ function SignalsBlock({ goals }) {
 
           {/* Forçar estabilidade (#297): a tela do hábito estável é inalcançável
           sem um hábito estável, e nenhum passa o portão com histórico curto.
-          Reusa o mesmo caminho da conferência (#295) — a tela de detalhe não
+          Reusa o mesmo caminho da conferência (#295), e a tela de detalhe não
           sabe se a estabilidade veio de mérito ou daqui. */}
           <View className="mt-2 flex-row flex-wrap items-center gap-1.5">
             <Text
@@ -804,8 +804,8 @@ function SignalsBlock({ goals }) {
 
           {/* Controles de simulação (#293).
           Os dois momentos são inobserváveis com histórico curto: nada sobe,
-          nada cai. Estes botões só mexem no `journeyAckLevel` — o nível que a
-          pessoa "já viu" — pra forçar a comparação a dar subida ou queda.
+          nada cai. Estes botões só mexem no `journeyAckLevel`, o nível que a
+          pessoa "já viu", pra forçar a comparação a dar subida ou queda.
           Nenhum registro é tocado, e dispensar o momento devolve o ack ao
           nível real. É o equivalente ao server em `required` que usamos pra
           ver o estado de "precisa entrar". */}
@@ -913,7 +913,7 @@ function Row({
       }`}
     >
       {/* Sem flex/shrink explícito, RN não encolhe ninguém por padrão (ao
-          contrário do CSS web) — label + value longos (ex: "Logado como" +
+          contrário do CSS web), porque label + value longos (ex: "Logado como" +
           email, ou o nome customizado do usuário) podiam somar mais que a
           largura da row e cortar sem reticências no Android. `label` fica no
           tamanho natural (são strings curtas e fixas do app); `value` é o

--- a/app/auth/callback.jsx
+++ b/app/auth/callback.jsx
@@ -16,7 +16,7 @@ import { useThemeTokens } from "@/constants/themeTokens";
 
 // Callback do magic link do Supabase (M6 auth fatia A, #207, ADR-010).
 // Deep link `backontrack://auth/callback?code=...` (native) OU
-// `https://<host>/auth/callback?code=...` (web) cai aqui — troca o code por
+// `https://<host>/auth/callback?code=...` (web) cai aqui e troca o code por
 // sessão via PKCE, redireciona pra /.
 
 export default function AuthCallback() {
@@ -26,7 +26,7 @@ export default function AuthCallback() {
 
   useEffect(() => {
     // Supabase pode redirecionar com `?error=...` em vez de `?code=...`
-    // (ex: link expirado, config errada) — vira status error; detalhe fica
+    // (ex: link expirado, config errada): vira status error; detalhe fica
     // no console pra debug sem vazar shape do backend pro usuário.
     if (error) {
       console.error("[callback] supabase error:", error, error_description);
@@ -38,7 +38,7 @@ export default function AuthCallback() {
       setStatus("error");
       return;
     }
-    // Caminho A (PKCE): magic link veio com `?code=` — troca por sessão.
+    // Caminho A (PKCE): magic link veio com `?code=`, então troca por sessão.
     if (code) {
       supabase.auth
         .exchangeCodeForSession(String(code))

--- a/app/feedback.jsx
+++ b/app/feedback.jsx
@@ -58,7 +58,7 @@ export default function Feedback() {
       setResult(data);
       setStatus("ok");
     } catch (e) {
-      // Detalhe técnico só no console (mesma regra do login #216) — evita
+      // Detalhe técnico só no console (mesma regra do login #216), o que evita
       // vazar shape do backend pro usuário e não ajuda quem tá vendo.
       console.error("feedback send failed:", e);
       setStatus("error");
@@ -126,7 +126,7 @@ export default function Feedback() {
                 className="text-sm text-body-secondary dark:text-body-secondary-dark"
                 style={{ fontFamily: "Inter_400Regular", marginTop: 2 }}
               >
-                Achou um problema ou tem uma sugestão? Conta aqui — abrimos o
+                Achou um problema ou tem uma sugestão? Conta aqui, e abrimos o
                 chamado pra você automaticamente.
               </Text>
             </View>

--- a/app/habito/[metric].jsx
+++ b/app/habito/[metric].jsx
@@ -25,7 +25,7 @@ import {
 // Detalhe do hábito estável (#297, tela 4a·5 do Turno 4).
 //
 // Onde mora o hábito que virou automático. Chegou aqui porque a linha
-// compacta dele na Home deixou de ir direto pro registro — é um toque a mais
+// compacta dele na Home deixou de ir direto pro registro, porque é um toque a mais
 // pra registrar algo que já não precisa de atenção diária, e é o ponto: a
 // tela existe pra dar lugar ao que saiu do foco sem sumir.
 //
@@ -101,7 +101,7 @@ export default function HabitoEstavel() {
         </Pressable>
 
         {/* Cabeçalho: nome + chip de status. O chip usa cinza de label, NUNCA
-            verde — é status, não medalha. */}
+            verde, porque é status e não medalha. */}
         <View className="flex-row items-center gap-3">
           <View
             className={`items-center justify-center rounded-xl ${METRIC_TINT[metric] ?? ""}`}
@@ -142,7 +142,7 @@ export default function HabitoEstavel() {
         </View>
 
         {/* Últimos 14 dias. Cada dia é um traço: preenchido quando houve
-            registro no alvo. Sem números — a forma já conta a história. */}
+            registro no alvo. Sem números, porque a forma já conta a história. */}
         <View className="gap-2">
           <Text
             className="text-xs uppercase tracking-wider text-label dark:text-label-dark"

--- a/app/history.jsx
+++ b/app/history.jsx
@@ -17,7 +17,7 @@ import { useThemeTokens } from "@/constants/themeTokens";
 // Ordem canônica das métricas (mesma da tela "hoje").
 const METRICS = Object.keys(CATEGORY_MAP);
 
-// Zera a hora pra comparar/derivar dias sem ruído de fuso — getByDate compara
+// Zera a hora pra comparar/derivar dias sem ruído de fuso. O getByDate compara
 // ano/mês/dia local, então o dia "cheio" é o suficiente.
 function startOfDay(input) {
   const d = new Date(input);
@@ -35,7 +35,7 @@ function isSameDay(a, b) {
   return startOfDay(a).getTime() === startOfDay(b).getTime();
 }
 
-// "SEG · 04 AGO 2026" — label mono do card de navegação.
+// "SEG · 04 AGO 2026": label mono do card de navegação.
 function formatMonoDate(d) {
   const weekday = d
     .toLocaleDateString("pt-BR", { weekday: "short" })
@@ -54,7 +54,7 @@ export default function History() {
 
   // Assina a tabela: re-renderiza a cada mudança nos registros (edição, exclusão
   // e também o fim do `startAutoLoad()` da persistência). Ler só no foco perdia
-  // a carga inicial assíncrona — ver #108.
+  // a carga inicial assíncrona. Ver #108.
   const records = useTable("records", store);
 
   // Registros do dia agrupados por type (uma passada só, via getByDate).

--- a/app/index.jsx
+++ b/app/index.jsx
@@ -70,7 +70,7 @@ function computeDaysSinceLast(records) {
   if (maxCreatedAt === 0) return null;
   const now = new Date();
   const last = new Date(maxCreatedAt);
-  // Compara dias-de-calendário local, não 24h corridas — pra "faz 1 dia" só
+  // Compara dias-de-calendário local, não 24h corridas, pra "faz 1 dia" só
   // acontecer na virada do dia, não 24h depois do registro.
   const todayMid = new Date(
     now.getFullYear(),
@@ -101,7 +101,7 @@ export default function Home() {
   const { user } = useSession();
   const t = useThemeTokens();
   // Dismissal in-memory do estado de retomada (M5-B fatia 5). Persistir viraria
-  // sub-tarefa; hoje "Depois" dura só a sessão — próximo launch com o critério
+  // sub-tarefa; hoje "Depois" dura só a sessão, e o próximo launch com o critério
   // ainda válido volta a mostrar, que é o objetivo (convidar até registrar).
   const [retomadaDismissed, setRetomadaDismissed] = useState(false);
 
@@ -114,7 +114,7 @@ export default function Home() {
   const displayName = useValue("displayName", store);
   // `records` é gatilho de propósito: muda quando a tabela muda (inclui o fim do
   // autoLoad) e força o getToday a reler. O exhaustive-deps não vê que os dois
-  // olham os mesmos dados e sugere remover — o que reintroduziria o #108.
+  // olham os mesmos dados e sugere remover, o que reintroduziria o #108.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const today = useMemo(() => getToday(), [records]);
   const daysSinceLast = useMemo(() => computeDaysSinceLast(records), [records]);
@@ -122,11 +122,11 @@ export default function Home() {
   const totalRecords = METRICS.reduce((s, m) => s + (today[m]?.length ?? 0), 0);
 
   // Origem única da derivação (#297). Antes cada tela montava os argumentos
-  // por conta própria, e a Home esquecia `granted` — a conferência da #295 e
+  // por conta própria, e a Home esquecia `granted`, e a conferência da #295 e
   // a previsualização não tinham efeito aqui, com os testes todos verdes.
   const journeyReal = useJourney();
 
-  // Previsualização de nível (#293). Substitui só o nível e o foco — o resto
+  // Previsualização de nível (#293). Substitui só o nível e o foco, e o resto
   // do estado segue real. Testa a TELA, não o modelo.
   const demoLevel = useValue("journeyDemoLevel", store);
   const emDemo = Number(demoLevel ?? -1) >= 0;
@@ -146,7 +146,7 @@ export default function Home() {
 
   // Data de estabilidade (#297). A graduação é derivada, então sem registrar
   // a data o app não saberia dizer "estável há N dias". Some quando o hábito
-  // deixa de estar estável — reconquistar recomeça a contagem.
+  // deixa de estar estável, e reconquistar recomeça a contagem.
   const estaveis = JOURNEY_ORDER.filter(
     (m) => journey.habits[m]?.status === GRADUATED,
   );
@@ -248,7 +248,7 @@ export default function Home() {
         contentContainerStyle={{ padding: 20, gap: 20 }}
         showsVerticalScrollIndicator={false}
       >
-        {/* Trigger de Ajustes — hamburger à esquerda navega pra tela dedicada
+        {/* Trigger de Ajustes: hamburger à esquerda navega pra tela dedicada
             (M5-B fatia 4). Substituiu o MenuModal antigo. */}
         <View className="w-full flex-row justify-start">
           <Pressable
@@ -266,7 +266,7 @@ export default function Home() {
         {/* Header: data · greeting · mini-ícone 1c · subtitle. Padrão da mockup
             2a·1 do design v2. */}
         <View className="gap-1 px-1">
-          {/* Data + chip de nível. O nível é CONTEXTO, não pontuação — por
+          {/* Data + chip de nível. O nível é CONTEXTO, não pontuação, e por
               isso vive num chip discreto ao lado da data, e nunca como número
               grande (docs/11-modelo-de-niveis.md §1.5). */}
           <View className="flex-row items-center justify-between gap-2">
@@ -286,7 +286,7 @@ export default function Home() {
             </View>
           </View>
           <View className="flex-row items-center justify-between gap-3">
-            {/* `flex-1` dá largura limitada pro Text — sem isso ele não tem
+            {/* `flex-1` dá largura limitada pro Text, e sem isso ele não tem
                 onde quebrar e o nome longo vaza. Com a largura definida, a
                 quebra natural cai no espaço depois da vírgula: "Bom dia," na
                 primeira linha, nome na segunda. `numberOfLines={2}` fecha o
@@ -326,7 +326,7 @@ export default function Home() {
         </View>
 
         {/* Aviso de regressão: no topo, acima de tudo. Não é modal de
-            propósito — não bloqueia, e a pessoa pode ignorar e registrar. */}
+            propósito: não bloqueia, e a pessoa pode ignorar e registrar. */}
         {moment === MOMENT_REGRESSION ? (
           <RegressionNotice
             copy={regressionCopy({ focus: focus ?? "sleep", paused: pausados })}
@@ -336,7 +336,7 @@ export default function Home() {
         ) : null}
 
         {/* Zona de foco: o hábito do nível, com número grande e ação rápida.
-            É o único com essa altura — a hierarquia mora aqui. */}
+            É o único com essa altura, e a hierarquia mora aqui. */}
         {focus ? (
           <FocusCard
             metric={focus}
@@ -371,7 +371,7 @@ export default function Home() {
               value={porMetrica[metric].value}
               badge={restBadge(journey.habits[metric]?.status)}
               // Hábito estável abre o DETALHE, não o registro (#297). É um
-              // toque a mais pra registrar algo que já é automático — e é o
+              // toque a mais pra registrar algo que já é automático, e é o
               // ponto: a tela existe pra dar lugar ao que saiu do foco sem
               // sumir. Registrar continua a um toque de lá.
               onPress={() =>
@@ -396,7 +396,7 @@ export default function Home() {
 
         {/* Login/logout ficam TODOS em Ajustes → Conta (Entrar quando !user,
             Sair quando user). Ter um botão Entrar aqui na Home também era
-            redundante — e como useSession pode devolver `user: null` durante
+            redundante, e como useSession pode devolver `user: null` durante
             o auto-load da sessão, o gate `!user` piscava o botão logo depois
             de logar. Concentrar em Ajustes elimina o flicker e centraliza. */}
       </ScrollView>

--- a/app/login.jsx
+++ b/app/login.jsx
@@ -13,7 +13,7 @@ import { AUTH_ENABLED, supabase } from "@/infra/supabase";
 import { useThemeTokens } from "@/constants/themeTokens";
 
 // Login por magic link (M6 auth fatia A, #207, ADR-010).
-// Sync continua anônimo por baixo — só a fatia B passa a usar o JWT.
+// Sync continua anônimo por baixo, e só a fatia B passa a usar o JWT.
 
 export default function Login() {
   const t = useThemeTokens();
@@ -37,7 +37,7 @@ export default function Login() {
       if (error) throw error;
       setStatus("sent");
     } catch (e) {
-      // Detalhes técnicos ficam no console — UI mostra só mensagem genérica.
+      // Detalhes técnicos ficam no console, e a UI mostra só mensagem genérica.
       // "Invalid API key", HTTP status, stack trace: infra interna que só
       // atrapalha usuário final e pode vazar shape do backend.
       console.error("[login] signInWithOtp falhou:", e);

--- a/assets/source/adaptive-icon.svg
+++ b/assets/source/adaptive-icon.svg
@@ -1,6 +1,6 @@
 <!--
   Back on Track · adaptive-icon.png source (M5-B, #228).
-  Foreground do adaptive Android — símbolo com transparência ao redor.
+  Foreground do adaptive Android: símbolo com transparência ao redor.
   Android compõe com `adaptiveIcon.backgroundColor` (definido no app.json).
   Símbolo dentro da safe zone central de 66% (círculo de raio ~336 no centro).
   Cor do símbolo: navy pra contrastar sobre o `#F8F9FA` de fundo do adaptive.

--- a/assets/source/favicon.svg
+++ b/assets/source/favicon.svg
@@ -1,6 +1,6 @@
 <!--
   Back on Track · favicon.png source (M5-B, #228).
-  Browser tab (48-96px) — fundo navy + curva branca pra contraste alto em
+  Browser tab (48-96px): fundo navy + curva branca pra contraste alto em
   tamanhos pequenos. Ponto verde mantém o ancoramento visual, mas em stroke
   mais grosso pra sobreviver ao downscale.
 -->

--- a/assets/source/splash-icon.svg
+++ b/assets/source/splash-icon.svg
@@ -1,6 +1,6 @@
 <!--
   Back on Track · splash-icon.png source (M5-B, #228).
-  Símbolo isolado com transparência ao redor — Expo centraliza sobre o
+  Símbolo isolado com transparência ao redor. O Expo centraliza sobre o
   splash backgroundColor (`#F8F9FA` no app.json). Cor navy pra contrastar
   sobre esse fundo claro.
 -->

--- a/components/Card.jsx
+++ b/components/Card.jsx
@@ -1,6 +1,6 @@
 // @ts-nocheck -- legado grandfatherizado por ADR-002 (#48); remover ao tipar este arquivo
 //
-// Componente-base "card" — outer container das telas topo-nível.
+// Componente-base "card": outer container das telas topo-nível.
 // Encapsula os tokens do M5: raio lg (papel "card"), bg surface por tema,
 // max-w 640 (o único breakpoint do app), padding p-4 canônico e a sombra
 // padrão (regra "top-level card → shadow"). Ver docs/08-design-tokens.md.

--- a/components/Icon1c.jsx
+++ b/components/Icon1c.jsx
@@ -1,7 +1,7 @@
 // @ts-nocheck -- SVG inline, sem tipos exportados
 import Svg, { Circle, Path } from "react-native-svg";
 
-// Símbolo "1c · Linha que sobe" — a marca escolhida pra identidade visual v2.
+// Símbolo "1c · Linha que sobe", a marca escolhida pra identidade visual v2.
 // Curva ascendente + círculo verde no ponto de partida. Reusável pra header,
 // splash e (fatia 6) os 4 assets de app.json (icon/adaptive/splash/favicon).
 //
@@ -9,9 +9,9 @@ import Svg, { Circle, Path } from "react-native-svg";
 // nos assets nativos.
 //
 // Props:
-//   size          — largura/altura em px (default 32)
-//   strokeColor   — cor da curva (default #F8F9FA — over blue bg)
-//   dotColor      — cor do ponto de partida (default #4CAF50)
+//   size          = largura/altura em px (default 32)
+//   strokeColor   = cor da curva (default #F8F9FA, over blue bg)
+//   dotColor      = cor do ponto de partida (default #4CAF50)
 export default function Icon1c({
   size = 32,
   strokeColor = "#F8F9FA",

--- a/components/InstallApp.jsx
+++ b/components/InstallApp.jsx
@@ -1,8 +1,8 @@
-// Card "Obter o app" — versão nativa (no-op).
+// Card "Obter o app": versão nativa (no-op).
 //
 // A obtenção do APK só faz sentido na web: quem já está no app nativo não
 // precisa baixá-lo. O Metro resolve InstallApp.web.jsx no bundle web e este
-// arquivo no nativo, então o card simplesmente não existe fora da web — sem
+// arquivo no nativo, então o card simplesmente não existe fora da web, sem
 // espalhar checagens de Platform.OS pela árvore. Mesmo padrão de
 // infra/persistence.js vs infra/persistence.web.js.
 

--- a/components/InstallApp.web.jsx
+++ b/components/InstallApp.web.jsx
@@ -1,4 +1,4 @@
-// Card "Obter o app" — versão web (Ciclo 3, #74; distribuição via EAS #90).
+// Card "Obter o app": versão web (Ciclo 3, #74; distribuição via EAS #90).
 //
 // Só existe no bundle web (o Metro resolve este .web.jsx na web e o
 // InstallApp.jsx no nativo). Detecta o navegador:

--- a/components/MetricIcon.jsx
+++ b/components/MetricIcon.jsx
@@ -2,7 +2,7 @@
 import Svg, { Path } from "react-native-svg";
 
 // SVGs por métrica extraídos das mockups do Turno 2 (Claude Design).
-// 24x24 viewBox, stroke 2, round caps — pattern do design.
+// 24x24 viewBox, stroke 2, round caps, pattern do design.
 // Cor do stroke é controlada pela cor passada (default = brand-blue).
 const PATHS = {
   water: ["M12 2.5c-3 4-6 7-6 11a6 6 0 0 0 12 0c0-4-3-7-6-11z"],

--- a/components/MetricRegisterHeader.jsx
+++ b/components/MetricRegisterHeader.jsx
@@ -18,10 +18,10 @@ import { useThemeTokens } from "@/constants/themeTokens";
 // vêm em fatias 2a-2c e usam este cabeçalho por cima.
 //
 // Props:
-//   metric    — key da métrica ("water" | ...) — usada pro SVG.
-//   title     — displayName capitalizado ("Água").
-//   subtitle  — string curta. Se omitida, some.
-//   label     — mono uppercase à direita. Default: "HOJE".
+//   metric    = key da métrica ("water" | ...), usada pro SVG.
+//   title     = displayName capitalizado ("Água").
+//   subtitle  = string curta. Se omitida, some.
+//   label     = mono uppercase à direita. Default: "HOJE".
 export default function MetricRegisterHeader({
   metric,
   title,

--- a/components/MyHistory.jsx
+++ b/components/MyHistory.jsx
@@ -23,7 +23,7 @@ function formatDate(date) {
 
 // Valor principal do registro. Registros novos guardam `quantity` como
 // número (minutos, quando unit === "min"); registros antigos podem trazer
-// `quantity`/`duration` já como "HH:MM" string — daí o fallback.
+// `quantity`/`duration` já como "HH:MM" string, daí o fallback.
 function formatQuantity(obj, unit) {
   const raw = obj.quantity ?? obj.duration;
   if (raw == null || raw === "") return "";
@@ -40,7 +40,7 @@ function formatQuantity(obj, unit) {
  *
  * Props preservadas do formato antigo pra continuar plug-and-play na tela de
  * registro (`MetricScreen`, via `MyHistory`) e no `/history`. `cardStyle`
- * aceito mas não usado — mantido pra compat visual.
+ * aceito mas não usado, mantido pra compat visual.
  */
 export function HistoryCard({
   obj,

--- a/components/RetomadaState.jsx
+++ b/components/RetomadaState.jsx
@@ -9,12 +9,12 @@ import { useThemeTokens } from "@/constants/themeTokens";
 // Estado "retomada" da Home (M5-B fatia 5, mockup 2a·9).
 //
 // Aparece quando a Home ia mostrar 5 cards vazios: usuário sem registro há N
-// dias (ou nunca). Substitui a Home inteira por um convite calmo — símbolo
+// dias (ou nunca). Substitui a Home inteira por um convite calmo: símbolo
 // grande, copy sem cobrança, 3 atalhos pra métricas mais fáceis. Tom canônico
 // do design v2: "Sem pressa", "quando puder", "que bom te ver de volta".
 //
 // Dismissal é in-memory (via prop `onDismiss`): sessão atual passa a mostrar a
-// Home normal. Próximo launch volta pra cá se o critério persistir — é o
+// Home normal. Próximo launch volta pra cá se o critério persistir, e é o
 // desejado (o objetivo é convidar até a pessoa registrar, não esconder pra
 // sempre).
 
@@ -35,7 +35,7 @@ export default function RetomadaState({ daysSinceLast, onDismiss }) {
 
   return (
     <View className="flex-1 gap-6 p-6">
-      {/* Símbolo grande — mesmo brand-blue tinted container do resto do app */}
+      {/* Símbolo grande, mesmo brand-blue tinted container do resto do app */}
       <View
         className="items-center justify-center rounded-2xl bg-primary dark:bg-primary-dark"
         style={{ width: 84, height: 84 }}
@@ -98,7 +98,7 @@ export default function RetomadaState({ daysSinceLast, onDismiss }) {
           O texto centraliza por `text-center`, NÃO por `items-center` no
           container. Parece a mesma coisa e não é: `alignItems: center` faz o
           filho encolher pra própria largura, e aí quem decide o tamanho da
-          caixa é a medição de texto do Android — que erra com a Inter e come
+          caixa é a medição de texto do Android, que erra com a Inter e come
           a última letra ("Depoi"). Com o Text ocupando a largura do pai, a
           caixa vem do layout e a medição não decide nada. */}
       <Pressable
@@ -142,7 +142,7 @@ function ShortcutButton({ metric, label, dim, onPress }) {
       )}
       {/* flex-1 força o Text a preencher o espaço restante do Pressable
           (flex-row) em vez de depender da intrinsic width medida do
-          NativeText — Android + Inter custom estava truncando labels no
+          NativeText: Android + Inter custom estava truncando labels no
           meio ("Um copo" em vez de "Um copo d'água"). */}
       <Text
         className={`flex-1 text-sm ${dim ? "text-body-secondary dark:text-body-secondary-dark" : "text-ink dark:text-ink-dark"}`}

--- a/components/SectionLabel.jsx
+++ b/components/SectionLabel.jsx
@@ -2,7 +2,7 @@
 //
 // Rótulo de seção (SECTION LABEL). Aparece como cabeçalho de bloco dentro
 // dos cards ("MÉTRICAS DE HOJE", "UTILITÁRIOS", "HISTÓRICO"…). Papel
-// tipográfico diferente do FieldLabel — ver docs/08-design-tokens.md.
+// tipográfico diferente do FieldLabel. Ver docs/08-design-tokens.md.
 
 import { Text } from "react-native";
 

--- a/components/UpdateBanner.jsx
+++ b/components/UpdateBanner.jsx
@@ -4,21 +4,21 @@
 //
 // Quatro estados, em ordem de prioridade (só um aparece):
 //
-//   1. NATIVE_OUTDATED  — versão do APK em execução é MENOR que a última
+//   1. NATIVE_OUTDATED  = versão do APK em execução é MENOR que a última
 //      publicada. Nesses casos o OTA não cobre (`runtimeVersion.policy:
-//      "appVersion"` — publicação nova sai em runtime N+1, o device em N
+//      "appVersion"`: publicação nova sai em runtime N+1, o device em N
 //      ignora silenciosamente). Único jeito é reinstalar o APK. Banner
 //      prioritário porque tudo mais é sintoma disso.
 //
-//   2. DOWNLOADING      — expo-updates tá baixando bundle novo em background.
+//   2. DOWNLOADING      = expo-updates tá baixando bundle novo em background.
 //      Sem progresso real (a API pública não expõe bytes), então usamos uma
-//      ProgressBar indeterminada — sinaliza "atividade em andamento" sem
+//      ProgressBar indeterminada, que sinaliza "atividade em andamento" sem
 //      mentir sobre percentual.
 //
-//   3. UPDATE_PENDING   — bundle baixado, esperando reload. Toque aplica.
+//   3. UPDATE_PENDING   = bundle baixado, esperando reload. Toque aplica.
 //      Comportamento original do #131.
 //
-//   4. NEEDS_AUTH       — o sync foi recusado por falta de login (#281). Vem
+//   4. NEEDS_AUTH       = o sync foi recusado por falta de login (#281). Vem
 //      por último de propósito: os três de cima são transitórios e se
 //      resolvem sozinhos, este persiste até a pessoa entrar. Se disputassem,
 //      o permanente esconderia os passageiros.
@@ -28,7 +28,7 @@
 //      vale só pra sessão (mesmo critério do `RetomadaState` da Home) —
 //      próxima abertura convida de novo, que é o objetivo.
 //
-// Em dev/web/native sem update mecanismo os hooks retornam false — banner
+// Em dev/web/native sem update mecanismo os hooks retornam false, e o banner
 // não aparece. Fetch da última APK version só tenta em native com rede;
 // falha silenciosa mantém o banner desligado.
 
@@ -47,14 +47,14 @@ import { useThemeTokens } from "@/constants/themeTokens";
 // Fonte remota da última versão do APK cortada, atualizada manualmente no repo
 // quando um build novo é distribuído. Preferi raw.githubusercontent.com em vez
 // de embed no bundle porque o cliente numa versão VELHA precisa saber de uma
-// versão MAIS NOVA que ele — o bundle dele nunca vai ter esse valor por
+// versão MAIS NOVA que ele, porque o bundle dele nunca vai ter esse valor por
 // definição. Cache do GitHub CDN é ~5min, suficiente pro caso de uso.
 const LATEST_APK_URL =
   "https://raw.githubusercontent.com/matheushnascimento/backOnTrack/main/assets/latest-apk-version.json";
 
 /**
  * "1.1.1" vs "1.2.0" → true se `current < latest`. Assume semver simples
- * (major.minor.patch numérico) — o que app.json.version segue.
+ * (major.minor.patch numérico), que é o que app.json.version segue.
  */
 function isBehind(current, latest) {
   if (!current || !latest) return false;
@@ -74,10 +74,10 @@ export default function UpdateBanner() {
   const insets = useSafeAreaInsets();
   const t = useThemeTokens();
   const { status: syncStatus } = useSyncStatus();
-  // Dispensa só a sessão atual — ver a nota de prioridade no topo do arquivo.
+  // Dispensa só a sessão atual. Ver a nota de prioridade no topo do arquivo.
   const [authDismissed, setAuthDismissed] = useState(false);
 
-  // Última APK conhecida — carrega em background, sem bloquear render.
+  // Última APK conhecida: carrega em background, sem bloquear render.
   const [latestApk, setLatestApk] = useState(
     /** @type {{version: string, installUrl?: string} | null} */ (null),
   );
@@ -92,7 +92,7 @@ export default function UpdateBanner() {
         if (d?.version) setLatestApk(d);
       })
       .catch(() => {
-        /* falha silenciosa — banner de native update só aparece se der certo */
+        /* falha silenciosa: banner de native update só aparece se der certo */
       });
     return () => ctrl.abort();
   }, []);
@@ -165,7 +165,7 @@ export default function UpdateBanner() {
           className="text-center text-white"
           style={{ fontFamily: "Inter_600SemiBold", fontSize: 14 }}
         >
-          Atualização pronta — toque para reiniciar
+          Atualização pronta. Toque para reiniciar
         </Text>
       </BannerBase>
     );
@@ -207,7 +207,7 @@ export default function UpdateBanner() {
  * cada tela já monta o próprio safe-area (MyView safe) e o app é edge-to-edge;
  * absoluto flutua sem mexer no layout de ninguém.
  *
- * `onDismiss` é opcional e só o banner de login usa (#281) — os de
+ * `onDismiss` é opcional e só o banner de login usa (#281), e os de
  * atualização não fecham porque somem sozinhos quando a causa passa.
  *
  * @param {{
@@ -231,7 +231,7 @@ function BannerBase({
   //
   // Aninhar quebra no web: o `accessibilityRole="button"` faz o
   // react-native-web renderizar um `<button>` de verdade, e `<button>` dentro
-  // de `<button>` é aninhamento inválido — o React DOM recusa e derruba a
+  // de `<button>` é aninhamento inválido, e o React DOM recusa e derruba a
   // árvore. Só apareceu quando o banner de login passou `onPress` e
   // `onDismiss` juntos; os três de atualização nunca tiveram botão de fechar.
   //

--- a/components/journey/CompactRow.jsx
+++ b/components/journey/CompactRow.jsx
@@ -7,7 +7,7 @@ import { METRIC_TINT } from "@/constants/journeyHome";
 
 // Linha da zona "resto do dia" (#291, tela 4a·1 do Turno 4).
 //
-// Metade da altura do card de foco, sem número grande e sem botões — mas
+// Metade da altura do card de foco, sem número grande e sem botões, mas
 // **tapável**, abrindo o registro completo. É o que sustenta a promessa do
 // rodapé ("Tudo continua registrável"): a hierarquia organiza a atenção, não
 // restringe o acesso.
@@ -40,7 +40,7 @@ export default function CompactRow({ metric, name, value, badge, onPress }) {
 
       {/* `flex-1` dá largura ao Text pelo layout. Sem isso ele encolhe ao
           conteúdo e a caixa passa a vir da medição do Android, que erra com a
-          Inter e come a última letra — ver docs e o histórico do #274. */}
+          Inter e come a última letra. Ver docs e o histórico do #274. */}
       <Text
         className="flex-1 text-sm text-ink dark:text-ink-dark"
         style={{ fontFamily: "Inter_400Regular" }}

--- a/components/journey/FocusCard.jsx
+++ b/components/journey/FocusCard.jsx
@@ -12,7 +12,7 @@ import {
 
 // Card do hábito em construção (#291, tela 4a·1 do Turno 4).
 //
-// É o único card com número grande e botões visíveis — é isso que cria a
+// É o único card com número grande e botões visíveis, e é isso que cria a
 // hierarquia sem esconder nada. As demais métricas viram linhas compactas de
 // metade da altura, mas seguem tapáveis (`CompactRow`).
 //
@@ -66,7 +66,7 @@ export default function FocusCard({
             {count === 1 ? "1 registro hoje" : `${count} registros hoje`}
           </Text>
         </View>
-        {/* Número grande — o único da tela. Alinhado à direita pra não
+        {/* Número grande, o único da tela. Alinhado à direita pra não
             competir com o nome. */}
         <View className="flex-row items-baseline gap-1">
           <Text
@@ -87,7 +87,7 @@ export default function FocusCard({
       </View>
 
       {/* Ação rápida. Métrica sem incremento natural (sono) cai num botão
-          único que abre a tela — ver QUICK_ADD. */}
+          único que abre a tela. Ver QUICK_ADD. */}
       <View className="mt-3.5 flex-row gap-2">
         {hasQuickAdd(metric) ? (
           <>

--- a/components/journey/LevelUpSheet.jsx
+++ b/components/journey/LevelUpSheet.jsx
@@ -11,13 +11,13 @@ import { METRIC_TINT } from "@/constants/journeyHome";
 // a subida como interrupção solene; sheet trata como recado. É reconhecimento,
 // não cerimônia.
 //
-// Sem confete, sem verde de vitória, sem "🎉" — reforço sóbrio
+// Sem confete, sem verde de vitória, sem "🎉": reforço sóbrio
 // (docs/11-modelo-de-niveis.md §1.5). O reconhecimento vem em prosa: "Sono
 // virou seu".
 //
 // A peça mais importante é a última: `reassurance` antecipa a queda ("sem
 // drama") antes que ela aconteça. Reconhecimento que não antecipa a queda
-// vira dívida — a pessoa passa a ter algo a perder.
+// vira dívida, porque a pessoa passa a ter algo a perder.
 
 /**
  * @param {{

--- a/components/journey/RegressionNotice.jsx
+++ b/components/journey/RegressionNotice.jsx
@@ -4,16 +4,16 @@ import { Pressable, Text, View } from "react-native";
 // Aviso de regressão (#293, tela 4a·2 do Turno 4).
 //
 // **A tela mais difícil do modelo.** Se ela der vontade de fechar o app, o
-// resto desmorona — foi assim que o briefing a descreveu, e o designer a
+// resto desmorona. Foi assim que o briefing a descreveu, e o designer a
 // tratou como prioridade.
 //
 // Três escolhas que sustentam isso:
 //
 // 1. **Aviso no topo, não modal.** Não bloqueia. A pessoa pode ignorar e
-//    registrar — o app não sequestra a tela pra falar de queda.
+//    registrar, porque o app não sequestra a tela pra falar de queda.
 // 2. **Zero vermelho.** Fundo neutro (`surface-subtle`). O `danger` segue
 //    reservado pro destrutivo, como manda o design v2.
-// 3. **"Ver histórico" ao lado de "Entendi"** — a promessa de que nada sumiu
+// 3. **"Ver histórico" ao lado de "Entendi"**: a promessa de que nada sumiu
 //    vem com um caminho pra conferir. Provar, não afirmar.
 
 /**

--- a/components/journey/SkipLevelSheet.jsx
+++ b/components/journey/SkipLevelSheet.jsx
@@ -11,7 +11,7 @@ import { METRIC_TINT } from "@/constants/journeyHome";
 // resolve com dois movimentos, e os dois estão aqui:
 //
 // 1. **Números concretos, não veredito.** O bloco do meio lista o que o app
-//    viu — dias com registro, dispersão do horário — sem dar nota.
+//    viu: dias com registro e dispersão do horário, sem dar nota.
 // 2. **O caso oposto vem antecipado.** Dizer de antemão o que aconteceria se
 //    não batesse deixa claro que o app não confia cego, mas também não
 //    desconfia hostil.

--- a/components/metrics/ExerciseBespoke.jsx
+++ b/components/metrics/ExerciseBespoke.jsx
@@ -14,7 +14,7 @@ import TimePickerField from "./TimePickerField";
 // opcional → intensidade (leve/ok/forte/puxado) mapeando pra score 2/3/4/5.
 //
 // Fatia do exercício do #256: quando `recordId` chega (edição pelo HistoryCard),
-// o componente troca pra <ExerciseEdit> — hidrata modalidade, duração,
+// o componente troca pra <ExerciseEdit>: hidrata modalidade, duração,
 // trainingTime, intensidade e OBS do registro; salva via `update`. Score fora
 // do range v2 (registros antigos com estrelas 0/1) fica sem pill selecionada e
 // é preservado no save via `intensityTouched=false`.

--- a/components/metrics/FeedingBespoke.jsx
+++ b/components/metrics/FeedingBespoke.jsx
@@ -19,7 +19,7 @@ import { useThemeTokens } from "@/constants/themeTokens";
 //
 // Diferente do modelo antigo (uma linha por dia com quantity=count), o bespoke
 // segue o padrão da água: cada [+] cria um registro com quantity=1 e [−]
-// deleta o mais recente do dia. O total exibido é o `sum(quantity)` — a agrega-
+// deleta o mais recente do dia. O total exibido é o `sum(quantity)`, e a agrega-
 // ção Home usa o mesmo reduce, então registros antigos (quantity=N) continuam
 // somando corretamente.
 //
@@ -29,7 +29,7 @@ import { useThemeTokens } from "@/constants/themeTokens";
 // Notas + score ficam intencionalmente fora do create (mockup não tem).
 //
 // Fatia da alimentação do #256: quando `recordId` chega (edição pelo History-
-// Card), o componente troca pra <FeedingEdit> — Quantidade + OBS. Score do
+// Card), o componente troca pra <FeedingEdit>: Quantidade + OBS. Score do
 // registro antigo é preservado no save (o create v2 não define, mas o v1 sim).
 
 function mealLabel(hourNumber) {
@@ -195,7 +195,7 @@ function FeedingCreate({ onAfterAdd }) {
         </Text>
       </View>
 
-      {/* Concluir — só volta pra Home. Cada +/- já persistiu. */}
+      {/* Concluir: só volta pra Home. Cada +/- já persistiu. */}
       <Pressable
         accessibilityRole="button"
         accessibilityLabel="Concluir e voltar"

--- a/components/metrics/SleepBespoke.jsx
+++ b/components/metrics/SleepBespoke.jsx
@@ -10,7 +10,7 @@ import { useThemeTokens } from "@/constants/themeTokens";
 import TimePickerField from "./TimePickerField";
 
 // Limita string de dígitos ao intervalo [0, max]. Usado nos inputs separados
-// de hora/minuto do SleepEdit — vazio permanece vazio, valor acima do teto é
+// de hora/minuto do SleepEdit: vazio permanece vazio, valor acima do teto é
 // truncado pro teto (usuário tenta digitar "99" na hora, vira "23").
 function clampNumString(s, max) {
   const digits = String(s ?? "").replace(/\D/g, "");
@@ -37,7 +37,7 @@ function clampNumString(s, max) {
 // Qualidade mapeia pra `score` (2/3/4/5) pra reusar a infra do histórico.
 //
 // Fatia do sono do #256: quando `recordId` chega (edição pelo HistoryCard), o
-// componente troca pra <SleepEdit> — o registro só guarda duração + score, não
+// componente troca pra <SleepEdit>: o registro só guarda duração + score, não
 // bed/wake times, então a edição mostra duração (h/min) + qualidade + OBS.
 // Score fora do range QUALITY (registros antigos com estrelas 0-5) fica sem
 // pill selecionada e o valor original é preservado no save se o usuário não

--- a/components/metrics/StudyBespoke.jsx
+++ b/components/metrics/StudyBespoke.jsx
@@ -15,11 +15,11 @@ import TimePickerField from "./TimePickerField";
 // pill de foco single-select (leitura/curso/prática/revisão/outro, opcional) →
 // info card sereno → Registrar.
 //
-// `focus` é campo novo no modelo (opcional, string) — não quebra registros
+// `focus` é campo novo no modelo (opcional, string), e não quebra registros
 // antigos porque o bespoke lê direto e o path legado sumiu com o #256.
 //
 // Fatia do estudo do #256: quando `recordId` chega (edição pelo HistoryCard), o
-// componente troca pra <StudyEdit> — hidrata Feito/duração/foco/OBS do
+// componente troca pra <StudyEdit>: hidrata Feito/duração/foco/OBS do
 // registro; salva via `update`. Score do registro é preservado (v2 create não
 // define, v1 shell definia).
 

--- a/components/metrics/TimePickerField.jsx
+++ b/components/metrics/TimePickerField.jsx
@@ -9,7 +9,7 @@ import { useThemeTokens } from "@/constants/themeTokens";
 // (bed/wake, duração, hora de início). Toque no display abre um modal com o
 // relógio: anel externo é 1-12, interno é 13-00; minutos aparecem em 5-em-5
 // depois que o usuário escolhe a hora. Fallback textual embaixo cobre entrada
-// precisa (minuto 07, por exemplo) — texto aceito mas não é a primeira opção.
+// precisa (minuto 07, por exemplo): texto aceito mas não é a primeira opção.
 //
 // Sem dep nativa nova: puro SVG + Pressable. Continua chegando via OTA.
 
@@ -29,7 +29,7 @@ function pad2(n) {
   return String(n).padStart(2, "0");
 }
 
-// Máscara HH:MM suave pro fallback textual — mesmo comportamento do fatia
+// Máscara HH:MM suave pro fallback textual, mesmo comportamento do fatia
 // anterior: digits only, colon automático, clamp 23/59.
 function maskHHMM(text) {
   const digits = String(text ?? "")

--- a/components/metrics/WaterQuickAdd.jsx
+++ b/components/metrics/WaterQuickAdd.jsx
@@ -195,7 +195,7 @@ function WaterEdit({ recordId, onAfterSave }) {
   const [quantity, setQuantity] = useState("");
   const [note, setNote] = useState("");
   // Guarda o registro original pra preservar campos legados no update
-  // (score/min/max/ideal). Hidrata uma vez — sem reagir a mudanças pra não
+  // (score/min/max/ideal). Hidrata uma vez, sem reagir a mudanças pra não
   // sobrescrever o que o usuário está editando.
   const [loaded, setLoaded] = useState(/** @type {any} */ (null));
 

--- a/components/metrics/registry.jsx
+++ b/components/metrics/registry.jsx
@@ -1,7 +1,7 @@
 // Registro de config por métrica.
 //
 // Após o #256 fatia 5 (faxina), cada métrica só declara o componente de
-// histórico, o cardClass opcional e o `renderCustom` — o bespoke assume o
+// histórico, o cardClass opcional e o `renderCustom`: o bespoke assume o
 // fluxo inteiro (criação + edição). Adicionar uma métrica = adicionar um
 // bespoke + entrada aqui.
 
@@ -60,7 +60,7 @@ const REGISTRY = {
   },
 };
 
-/** Config benigna pra métrica desconhecida — nunca quebra a tela. */
+/** Config benigna pra métrica desconhecida, que nunca quebra a tela. */
 const FALLBACK = /** @type {MetricConfig} */ ({
   History: MyHistory,
 });

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,7 +17,7 @@ export default defineConfig([
   {
     // O código do app é .jsx (as telas/componentes) + .js (constants/infra).
     // Antes o eslint só cobria **/*.js, e como o app é todo .jsx ele não lintava
-    // NADA — foi por isso que um `setTick` inexistente foi parar em produção
+    // NADA, e foi por isso que um `setTick` inexistente foi parar em produção
     // (#126). Cobrir .jsx com no-undef como erro fecha essa cegueira (#128).
     files: ["**/*.{js,jsx}"],
     plugins: { js, "react-hooks": reactHooks },
@@ -35,7 +35,7 @@ export default defineConfig([
       // Erro (não warn): é o que faz um no-undef como o do #126 quebrar o CI.
       "no-undef": "error",
       // O código já trazia um disable de exhaustive-deps sem o plugin instalado
-      // — a intenção sempre foi ter o react-hooks ligado.
+      // A intenção sempre foi ter o react-hooks ligado.
       "react-hooks/rules-of-hooks": "error",
       "react-hooks/exhaustive-deps": "warn",
     },
@@ -67,7 +67,7 @@ export default defineConfig([
     },
   },
   {
-    // Server WS de sync do M6 (server/) — Node ESM, fora do bundle do app.
+    // Server WS de sync do M6 (server/): Node ESM, fora do bundle do app.
     files: ["server/**/*.js"],
     languageOptions: {
       sourceType: "module",

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,7 @@
 // tinybase só publica build ESM, e o jest precisa transpilá-lo. Em vez de
 // reescrever o transformIgnorePatterns do jest-expo (e arriscar deixar de fora
 // algo como expo-modules-core), pegamos o default dele e injetamos `tinybase`
-// como 1ª exceção — robusto a mudanças futuras na lista.
+// como 1ª exceção, robusto a mudanças futuras na lista.
 const expoPreset = require("jest-expo/jest-preset");
 
 const transformIgnorePatterns = expoPreset.transformIgnorePatterns.map((p) =>

--- a/plugins/withArm64Only.js
+++ b/plugins/withArm64Only.js
@@ -2,7 +2,7 @@
 //
 // O APK do perfil `preview` era "universal": empacotava libs nativas de 4
 // arquiteturas (arm64-v8a + armeabi-v7a + x86 + x86_64 = 114 MB). x86/x86_64 só
-// servem emulador e armeabi-v7a só celular 32-bit antigo — peso morto que fazia
+// servem emulador e armeabi-v7a só celular 32-bit antigo, peso morto que fazia
 // o download travar no celular dos testers.
 //
 // Fixar `reactNativeArchitectures=arm64-v8a` no gradle.properties faz o

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,7 +14,7 @@ module.exports = {
         light: Colors.light,
         dark: Colors.dark,
         // Tokens semânticos do design v2 (M5-B). Ver docs/09-design-v2.md.
-        // Adicionados sem remover nada do M5 — telas antigas seguem com o
+        // Adicionados sem remover nada do M5, e telas antigas seguem com o
         // baseline; telas novas nascem consumindo estes.
         ink: "#0F1419",
         label: "#6B7280",
@@ -51,10 +51,10 @@ module.exports = {
         "on-primary-dark": "#0F1419",
         "secondary-dark": "#5FC463",
       },
-      // Escala de tipografia canônica do M5 — px direto (não rem) pra não
+      // Escala de tipografia canônica do M5: px direto (não rem) pra não
       // depender de font-size base do html, que no bundle web tinha um truque
       // 62.5% inconsistente (§4 da auditoria) já removido. Valores mercado
-      // (iOS body: 17pt) — ver docs/08-design-tokens.md.
+      // (iOS body: 17pt). Ver docs/08-design-tokens.md.
       fontSize: {
         xs: "13px",
         sm: "15px",

--- a/tests/database.test.js
+++ b/tests/database.test.js
@@ -1,5 +1,5 @@
 // @ts-nocheck -- teste; globals do jest não são tipados (ADR-002)
-// Testes das funções de domínio da store (M4, #134). Puros — sem React.
+// Testes das funções de domínio da store (M4, #134). Puros, sem React.
 // A store é um singleton de módulo; zeramos entre os testes.
 import {
   store,

--- a/tests/feedback-api.test.js
+++ b/tests/feedback-api.test.js
@@ -1,5 +1,5 @@
 // @ts-nocheck -- teste; globals do jest não são tipados (ADR-002)
-// Testes da função serverless api/feedback.js (M4, #137). Mocka o fetch — nada
+// Testes da função serverless api/feedback.js (M4, #137). Mocka o fetch, então nada
 // de GitHub real nem rede. Exercita validações, montagem do corpo da issue e a
 // compat do #116 (payload legado com `device` vs novo com `environment`).
 import handler from "../api/feedback.js";
@@ -126,7 +126,7 @@ describe("montagem da issue", () => {
     expect(p.body).not.toContain("- Dispositivo:");
   });
 
-  test("payload LEGADO (device) segue renderizando — compat #116", async () => {
+  test("payload LEGADO (device) segue renderizando, compat #116", async () => {
     await call({
       body: {
         title: "antigo",

--- a/tests/greeting.test.js
+++ b/tests/greeting.test.js
@@ -11,7 +11,7 @@ describe("firstName", () => {
     expect(firstName("Matheus Henrique Nascimento")).toBe("Matheus");
   });
 
-  it("preserva acento — a regra é letra Unicode, não [a-z]", () => {
+  it("preserva acento: a regra é letra Unicode, não [a-z]", () => {
     expect(firstName("João da Silva")).toBe("João");
     expect(firstName("Ângela Souza")).toBe("Ângela");
   });
@@ -50,7 +50,7 @@ describe("pickName", () => {
     expect(pickName({ email: "outro@x.com" }, "Ana")).toBe("Ana");
   });
 
-  it("aplica primeiro-nome no displayName — era o bug do #268", () => {
+  it("aplica primeiro-nome no displayName, era o bug do #268", () => {
     expect(pickName(null, "Matheus Henrique Nascimento")).toBe("Matheus");
   });
 

--- a/tests/habit-signals.test.js
+++ b/tests/habit-signals.test.js
@@ -17,7 +17,7 @@ const DIA = 86_400_000;
 // Base de tempo FIXA, passada explicitamente como `now` em toda chamada.
 //
 // Sem isso os testes ficam dependentes da hora em que a suíte roda: `em(0, 20)`
-// é "hoje às 20:00", que às 15h ainda está no FUTURO — e as funções descartam
+// é "hoje às 20:00", que às 15h ainda está no FUTURO, e as funções descartam
 // timestamp futuro, então a amostra encolhe e a asserção quebra. Aconteceu de
 // verdade: o mesmo teste passou de manhã e falhou à tarde.
 //
@@ -43,7 +43,7 @@ describe("goalFor", () => {
     expect(goalFor(null, "sleep")).toBe(DEFAULT_GOALS.sleep);
   });
 
-  // Meta zero ou negativa é dado corrompido, não escolha — cair no default é
+  // Meta zero ou negativa é dado corrompido, não escolha, então cair no default é
   // mais seguro que dizer que todo dia bateu a meta.
   it("ignora meta inválida", () => {
     expect(goalFor({ water: 0 }, "water")).toBe(DEFAULT_GOALS.water);
@@ -99,7 +99,7 @@ describe("dailyVerdicts", () => {
   });
 
   // Sono é `presence`: o portão é comportamento, não desfecho (§4). Dormir
-  // pouco não pode contar como falha de hábito — registrar é o hábito.
+  // pouco não pode contar como falha de hábito, porque registrar é o hábito.
   it("sono conta presença, não quantidade", () => {
     const v = dailyVerdicts(
       [reg("sleep", em(0, 23), 60)],
@@ -142,7 +142,7 @@ describe("consistency", () => {
 describe("regularity", () => {
   // ESTE é o teste que justifica a estatística circular. 23h50 e 00h10 distam
   // 20 minutos. Um desvio-padrão sobre "minutos desde a meia-noite" daria
-  // ~700 minutos e diria que a pessoa é caótica — quando ela é quase perfeita.
+  // ~700 minutos e diria que a pessoa é caótica, quando ela é quase perfeita.
   // E é exatamente o caso do horário de deitar, o hábito do lvl 1.
   it("horários em volta da meia-noite são regulares, não caóticos", () => {
     const recs = [
@@ -185,7 +185,7 @@ describe("regularity", () => {
     );
   });
 
-  // Sem amostra não se afirma nada — null é resposta, 0 seria mentira
+  // Sem amostra não se afirma nada: null é resposta, 0 seria mentira
   // ("perfeitamente regular").
   it("menos de 2 registros não produz desvio", () => {
     expect(regularity([], "water", 7, AGORA).sdMinutes).toBeNull();
@@ -231,10 +231,10 @@ describe("resilience", () => {
   });
 
   // Só a falha ISOLADA conta como oportunidade. Nesta sequência:
-  //   idx 0 falha — primeira da janela, sem dia anterior: não conta
-  //   idx 2 falha após alvo — oportunidade, e o dia seguinte falha: não recuperou
-  //   idx 3 falha após falha — não é isolada: não conta
-  //   idx 5 falha após alvo — oportunidade, e o dia seguinte acerta: recuperou
+  //   idx 0 falha: primeira da janela, sem dia anterior: não conta
+  //   idx 2 falha após alvo: oportunidade, e o dia seguinte falha: não recuperou
+  //   idx 3 falha após falha, então não é isolada: não conta
+  //   idx 5 falha após alvo: oportunidade, e o dia seguinte acerta: recuperou
   it("mistura de recuperações e recaídas", () => {
     const r = resilience(v(false, true, false, false, true, false, true));
     expect(r.opportunities).toBe(2);
@@ -243,7 +243,7 @@ describe("resilience", () => {
   });
 
   // Sem esta distinção, uma recaída longa pontuaria como recuperação assim
-  // que acabasse — que é o oposto do que o sinal deve dizer.
+  // que acabasse, que é o oposto do que o sinal deve dizer.
   it("recaída longa não vira recuperação quando enfim acaba", () => {
     const r = resilience(v(true, false, false, false, true));
     expect(r.opportunities).toBe(1);

--- a/tests/journey-home.test.js
+++ b/tests/journey-home.test.js
@@ -13,8 +13,8 @@ import { JOURNEY_ORDER } from "@/constants/goals";
 import { BUILDING, GRADUATED, LOCKED, PAUSED } from "@/constants/journey";
 
 // Partes puras da Home da jornada (#291). O que se verifica aqui é o que tem
-// risco de bug: qual ação rápida aparece, qual copy sai, e — o mais
-// importante — que NADA some da tela.
+// risco de bug: qual ação rápida aparece, qual copy sai, e, o mais
+// importante, que NADA some da tela.
 
 const jornada = ({
   level = 2,
@@ -110,7 +110,7 @@ describe("headerCopy", () => {
     expect(c.subtitle).toBe("Sem pressa. Um de cada vez.");
   });
 
-  // Zero culpa, zero vermelho — e o esforço de volta dimensionado como curto.
+  // Zero culpa, zero vermelho, e o esforço de volta dimensionado como curto.
   it("na regressão, a copy é de recomeço e não de falha", () => {
     const c = headerCopy(jornada({ focus: "water", regressed: true }));
     expect(c.title).toBe("Recomeço curto.");
@@ -121,7 +121,7 @@ describe("headerCopy", () => {
 
 describe("splitZones", () => {
   // A decisão central do design: hierarquia, não exclusão.
-  it("NADA some — todas as métricas aparecem em alguma zona", () => {
+  it("NADA some: todas as métricas aparecem em alguma zona", () => {
     const { focus, rest } = splitZones(jornada({ focus: "water" }));
     expect([focus, ...rest].sort()).toEqual([...JOURNEY_ORDER].sort());
   });
@@ -131,7 +131,7 @@ describe("splitZones", () => {
     expect(rest).not.toContain(focus);
   });
 
-  // Sem foco (lvl 0), tudo vai pro resto — nenhuma métrica é escondida.
+  // Sem foco (lvl 0), tudo vai pro resto, e nenhuma métrica é escondida.
   it("sem foco, todas ficam no resto", () => {
     const { focus, rest } = splitZones(jornada({ level: 0, focus: null }));
     expect(focus).toBeNull();
@@ -151,7 +151,7 @@ describe("restBadge", () => {
     expect(restBadge(GRADUATED)).toBe("estável");
   });
 
-  // "em pausa", nunca "perdido" — a palavra importa (tela 4a·2).
+  // "em pausa", nunca "perdido", porque a palavra importa (tela 4a·2).
   it("em pausa para pausado", () => {
     expect(restBadge(PAUSED)).toBe("em pausa");
   });

--- a/tests/journey-moments.test.js
+++ b/tests/journey-moments.test.js
@@ -10,7 +10,7 @@ import {
 
 // Momentos da jornada (#293). Duas coisas com risco de bug aqui: um momento
 // aparecer mais de uma vez (ou nunca), e a copy escorregar pro vocabulário
-// que o projeto rejeita — culpa na regressão, jogo na subida.
+// que o projeto rejeita: culpa na regressão, jogo na subida.
 
 describe("pendingMoment", () => {
   it("nível acima do reconhecido = subiu", () => {
@@ -41,7 +41,7 @@ describe("pendingMoment", () => {
     expect(pendingMoment(undefined, 1)).toBeNull();
   });
 
-  // Reconhecer o lvl 0 é diferente de nunca ter reconhecido nada — por isso o
+  // Reconhecer o lvl 0 é diferente de nunca ter reconhecido nada, e por isso o
   // default é -1 e não 0.
   it("reconhecer o lvl 0 e subir dispara momento", () => {
     expect(pendingMoment(1, 0)).toBe(MOMENT_LEVEL_UP);
@@ -123,7 +123,7 @@ describe("regressionCopy", () => {
     expect(c.body).toMatch(/retoma/);
   });
 
-  // A dúvida que a regressão levanta, respondida em voz alta — e com um botão
+  // A dúvida que a regressão levanta, respondida em voz alta, e com um botão
   // pro histórico, pra provar em vez de afirmar.
   it("diz que nada foi perdido e oferece o histórico", () => {
     expect(c.preserved).toMatch(/nada.*foi perdido/i);
@@ -138,7 +138,7 @@ describe("regressionCopy", () => {
     );
   });
 
-  // "em pausa", nunca "perdido" — e o texto não pode contradizer o badge.
+  // "em pausa", nunca "perdido", e o texto não pode contradizer o badge.
   it("não chama o hábito de perdido", () => {
     expect(c.body).not.toMatch(/perdid/i);
   });

--- a/tests/journey-skip.test.js
+++ b/tests/journey-skip.test.js
@@ -104,7 +104,7 @@ describe("concessão no deriveJourney", () => {
     expect(comGrant.level).toBeGreaterThan(semGrant.level);
   });
 
-  // Graduado não derruba ninguém — e concedido é graduado.
+  // Graduado não derruba ninguém, e concedido é graduado.
   it("hábito concedido não é reportado como quebrado", () => {
     const j = deriveJourney({ ...base, granted: ["sleep"] });
     expect(j.habits.sleep.broken).toBe(false);

--- a/tests/journey.test.js
+++ b/tests/journey.test.js
@@ -14,7 +14,7 @@ import { JOURNEY_ORDER } from "@/constants/goals";
 
 // Estado da jornada (#289). Os testes usam dado SINTÉTICO de propósito: os
 // limiares são provisórios e sem calibração, então o que se verifica aqui é o
-// mecanismo — transições, ordem, semântica de pausa — não os valores.
+// mecanismo (transições, ordem, semântica de pausa), e não os valores.
 
 const DIA = 86_400_000;
 // Base fixa: sem isso os testes dependem da hora em que a suíte roda (lição
@@ -61,7 +61,7 @@ describe("passesGate", () => {
     expect(passesGate(sinais({ sd: 400 }))).toBe(false);
   });
 
-  // Duas faltas seguidas é o laço quebrado (§6) — não é "perto de automático".
+  // Duas faltas seguidas é o laço quebrado (§6), e não "perto de automático".
   it("falta dupla na janela não passa", () => {
     expect(passesGate(sinais({ doubleMisses: 1 }))).toBe(false);
   });
@@ -164,7 +164,7 @@ describe("deriveJourney", () => {
   });
 
   // Quem nunca começou não está quebrado. Sem isto, um usuário novo abriria o
-  // app já "regredido" — 28 dias de janela vazia viram 28 faltas.
+  // app já "regredido": 28 dias de janela vazia viram 28 faltas.
   it("hábito sem nenhum acerto não é reportado como quebrado", () => {
     const j = deriveJourney({ records: [], ...base });
     expect(j.habits.sleep.broken).toBe(false);
@@ -214,7 +214,7 @@ describe("deriveJourney", () => {
   });
 
   // A decisão da #289: quem pausa é o TOPO, não quem quebrou.
-  it("na regressão, pausa o topo — os hábitos entre o nível atual e o antigo", () => {
+  it("na regressão, pausa o topo, os hábitos entre o nível atual e o antigo", () => {
     const j = deriveJourney({
       records: serieCheia("sleep", 480),
       previousLevel: 4,

--- a/tests/persistence-reactivity.test.jsx
+++ b/tests/persistence-reactivity.test.jsx
@@ -1,14 +1,14 @@
 // @ts-nocheck -- teste; globals do jest não são tipados (ADR-002)
-// Teste da corrida da persistência (#108) — a razão de existir do M4.
+// Teste da corrida da persistência (#108), a razão de existir do M4.
 //
 // O bug: a persistência carrega de forma assíncrona (`await startAutoLoad()`),
 // mas a tela lia a store UMA vez (no foco). No primeiro load lia a store vazia e
-// nunca era avisada quando os dados chegavam — a Home aparecia sem dados até
+// nunca era avisada quando os dados chegavam, e a Home aparecia sem dados até
 // navegar e voltar. O #126 (crash ao excluir) nasceu justamente ao corrigir isso.
 //
 // O fix: `useTable` ASSINA a store e re-renderiza quando ela muda. Este teste
-// reproduz a forma temporal do bug — monta VAZIO e só depois a store ganha dados
-// — e exige que o consumidor atualize sozinho. Rodado contra o padrão antigo
+// reproduz a forma temporal do bug: monta VAZIO e só depois a store ganha dados
+// e exige que o consumidor atualize sozinho. Rodado contra o padrão antigo
 // (leitura única, sem assinatura), ele FALHA; contra o atual, passa.
 import { renderHook, act, waitFor } from "@testing-library/react-native";
 import { useTable } from "tinybase/ui-react";
@@ -20,7 +20,7 @@ beforeEach(() => {
 });
 
 test("o consumidor atualiza quando a store ganha dados depois do mount (#108)", async () => {
-  // renderHook da RNTL 14 é async. Monta com a store vazia — como no primeiro
+  // renderHook da RNTL 14 é async. Monta com a store vazia, como no primeiro
   // load, antes do autoLoad terminar.
   const { result } = await renderHook(() => {
     useTable("records", store); // assina a tabela

--- a/tests/roadmap.test.js
+++ b/tests/roadmap.test.js
@@ -1,8 +1,13 @@
 // @ts-nocheck -- teste; globals do jest não são tipados (ADR-002)
 // Parser do roadmap (M4, #140). É ele que alimenta a tela /roadmap a partir do
-// docs/04-roadmap-milestones.md — se quebrar, a tela mente ou some.
+// docs/04-roadmap-milestones.md. Se quebrar, a tela mente ou some.
 import { parseRoadmap, cleanText, getDigest } from "../constants/roadmap";
 
+// ⚠️ O M0 usa dois-pontos e o M1 usa travessão, de propósito. O MILESTONE_RE
+// aceita os dois na classe `[:\s—–-]`, e o doc real migrou pra dois-pontos na
+// #307. Este fixture é o que garante que o ramo do travessão continua
+// funcionando, então a varredura da #302 deixou essa linha intacta. Trocar
+// aqui apagaria a cobertura em silêncio.
 const MD = `
 ## M0: Fundamentos ✅ concluído
 

--- a/tests/stable-habit.test.js
+++ b/tests/stable-habit.test.js
@@ -53,7 +53,7 @@ describe("stableChip", () => {
     expect(stableChip(null)).toBe("estável");
   });
 
-  // Status, não medalha — a palavra escolhida importa.
+  // Status, não medalha, e a palavra escolhida importa.
   it("não usa vocabulário de prêmio", () => {
     for (const d of [null, 0, 1, 24]) {
       expect(stableChip(d)).not.toMatch(
@@ -73,7 +73,7 @@ describe("stableExplanation", () => {
     expect(e.body).toMatch(/não precisa mais do seu esforço ativo/);
   });
 
-  // Sem um motivo, registrar vira permissão sem propósito — e a pessoa para.
+  // Sem um motivo, registrar vira permissão sem propósito, e a pessoa para.
   it("dá um motivo pra continuar registrando", () => {
     expect(e.body).toMatch(/manter os dados apurados/);
   });

--- a/tests/sync-retry.test.js
+++ b/tests/sync-retry.test.js
@@ -1,6 +1,6 @@
 // @ts-nocheck -- teste; globals do jest não são tipados (ADR-002)
 // Testa o backoff do reconnect do sync WS. É o pedaço puro da correção do
-// auto-reconnect — a parte onde bug moraria (crescimento errado, teto que
+// auto-reconnect, a parte onde bug moraria (crescimento errado, teto que
 // não segura, jitter que sincroniza todo mundo, entrada negativa/absurda).
 //
 // Contexto: sem reconexão, uma queda de WS deixava o app sem sync até o
@@ -27,7 +27,7 @@ describe("retryDelay", () => {
     expect(d(3)).toBe(BASE_RETRY_DELAY_MS * 8); // 8s
   });
 
-  test("respeita o teto — queda longa não vira espera de minutos", () => {
+  test("respeita o teto: queda longa não vira espera de minutos", () => {
     const d = (n) => retryDelay(n, { random: noJitter });
     expect(d(10)).toBe(MAX_RETRY_DELAY_MS);
     expect(d(50)).toBe(MAX_RETRY_DELAY_MS);
@@ -36,7 +36,7 @@ describe("retryDelay", () => {
     expect(d(1000)).toBe(MAX_RETRY_DELAY_MS);
   });
 
-  test("jitter mantém o delay em [metade, cheio] — nunca zero", () => {
+  test("jitter mantém o delay em [metade, cheio], nunca zero", () => {
     for (const n of [0, 1, 5, 99]) {
       const cheio = retryDelay(n, { random: noJitter });
       const piso = retryDelay(n, { random: minJitter });
@@ -51,7 +51,7 @@ describe("retryDelay", () => {
     }
   });
 
-  test("jitter de fato espalha — clientes não voltam todos juntos", () => {
+  test("jitter de fato espalha: clientes não voltam todos juntos", () => {
     // 200 "clientes" caindo na mesma tentativa devem produzir delays variados.
     // Sem jitter, todos retornariam o mesmo valor e derrubariam o server de novo.
     const amostras = new Set();

--- a/tests/sync-server-auth.test.js
+++ b/tests/sync-server-auth.test.js
@@ -151,7 +151,7 @@ async function stopServer({ child, dataDir }) {
  * Tenta abrir a conexão WS. Resolve com:
  *   { open: true }               → handshake aceito
  *   { open: false, code: <n> }   → server rejeitou (unexpected-response)
- * Não faz TinyBase sync — só checa o handshake, que é onde a auth vive.
+ * Não faz TinyBase sync: só checa o handshake, que é onde a auth vive.
  */
 function tryConnect(port, room, token, timeoutMs = 3000) {
   return new Promise((resolveResult) => {
@@ -177,7 +177,7 @@ function tryConnect(port, room, token, timeoutMs = 3000) {
       resolveResult({ open: false, code: res.statusCode });
     });
     ws.once("error", () => {
-      // Silenciar — o close/unexpected-response já resolve o resultado.
+      // Silenciar, porque o close/unexpected-response já resolve o resultado.
     });
     ws.once("close", (code) => {
       clearTimeout(timer);
@@ -196,7 +196,7 @@ function tryConnect(port, room, token, timeoutMs = 3000) {
 // "sem conexão" pra quem na verdade precisa entrar.
 
 // `fetch` global aqui é o do ambiente jest-expo (React Native), não o do
-// Node — `res.status` vem undefined. Usa http.request direto, como o resto
+// Node: `res.status` vem undefined. Usa http.request direto, como o resto
 // deste arquivo já faz com o cliente `ws`.
 function httpGet(port, path) {
   return new Promise((resolveGet, rejectGet) => {
@@ -249,7 +249,7 @@ describe("GET /healthz", () => {
 
   // Regressão: o WS precisa continuar funcionando com o http.createServer na
   // frente. Trocar `port:` por `server:` no WebSocketServer faz ele parar de
-  // bindar sozinho — sem o listen explícito, nada escuta.
+  // bindar sozinho, e sem o listen explícito nada escuta.
   test("o WebSocket continua de pé com o HTTP na frente", async () => {
     const server = await startServer({
       AUTH_MODE: "optional",
@@ -365,7 +365,7 @@ describe("AUTH_MODE=required (fase final, após migração)", () => {
 //
 // Regressão do bug real: o Supabase migrou pra chaves assimétricas e passou a
 // assinar com ES256+kid. O server só aceitava HS256, então rejeitava TODO
-// cliente logado com 401 — sync silenciosamente morto em web e mobile.
+// cliente logado com 401, com sync silenciosamente morto em web e mobile.
 
 describe("ES256 via JWKS", () => {
   let server;
@@ -411,7 +411,7 @@ describe("ES256 via JWKS", () => {
   });
 
   test("ES256 assinado por chave fora do JWKS: rejeita com 401", async () => {
-    // kid conhecido, chave privada errada — assinatura não confere.
+    // kid conhecido, chave privada errada, então a assinatura não confere.
     const token = signEs256({
       payload: { sub: "alice", exp: futureExp() },
       kid: key.kid,

--- a/tests/sync-server.test.js
+++ b/tests/sync-server.test.js
@@ -1,6 +1,6 @@
 // @ts-nocheck -- teste; globals do jest não são tipados (ADR-002)
 // Testes do server WS de sync (M6, fatia 2, #198). Sobe o server em subprocess
-// com porta aleatória + tmpdir isolado — testa o CÓDIGO do server (não a infra
+// com porta aleatória + tmpdir isolado: testa o CÓDIGO do server (não a infra
 // do túnel Cloudflare, que é outra classe de coisa). Roda in-process no CI,
 // sem depender de rede externa nem gerar lixo no server público.
 
@@ -14,7 +14,7 @@ import { WebSocket } from "ws";
 
 const SERVER_JS = resolve(__dirname, "..", "server", "server.js");
 
-// Porta alta aleatória — evita colisão com serviços conhecidos. 1-em-milhares
+// Porta alta aleatória, o que evita colisão com serviços conhecidos. 1-em-milhares
 // de chance de conflito com outro processo local; se acontecer, re-roda.
 const PORT = 40000 + Math.floor(Math.random() * 10000);
 
@@ -29,7 +29,7 @@ beforeAll(async () => {
     stdio: ["ignore", "pipe", "pipe"],
   });
 
-  // Espera o log "listening on ..." — indica que o WebSocketServer já bindou.
+  // Espera o log "listening on ...", que indica que o WebSocketServer já bindou.
   await new Promise((resolveReady, rejectReady) => {
     const timer = setTimeout(
       () => rejectReady(new Error("server didn't come up in 5s")),
@@ -84,7 +84,7 @@ test("round-trip: valor escrito volta em nova conexão (fatia 2 do M6)", async (
   await new Promise((r) => setTimeout(r, 1500));
   await sync1.destroy();
 
-  // Round 2: reconecta com store limpa — valor deve voltar do server.
+  // Round 2: reconecta com store limpa: valor deve voltar do server.
   const [s2, sync2] = await connect("round-trip");
   await new Promise((r) => setTimeout(r, 1500));
   const got = s2.getCell("ping", "row1", "value");
@@ -108,7 +108,7 @@ test("persistência: arquivo JSON por sala é criado no DATA_DIR", async () => {
 test("path traversal: pathId malicioso não escapa do DATA_DIR", async () => {
   // safeFilename troca qualquer coisa fora de [A-Za-z0-9_-] por hífen. Se
   // alguém tentar `../../etc/passwd`, deve virar algo tipo `etc-passwd.json`
-  // dentro do DATA_DIR — não escrever fora.
+  // dentro do DATA_DIR, sem escrever fora.
   const [store, sync] = await connect("..%2F..%2Fetc%2Fpasswd");
   store.setCell("x", "y", "z", "1");
   await new Promise((r) => setTimeout(r, 1500));

--- a/tests/sync-session.test.js
+++ b/tests/sync-session.test.js
@@ -6,7 +6,7 @@ import {
 } from "@/infra/sync-session";
 
 // Cobre os dois defeitos da #275. Os dois eram "tratar 'ainda não sei' como se
-// fosse resposta" — os testes abaixo travam justamente esse instante.
+// fosse resposta". Os testes abaixo travam justamente esse instante.
 
 describe("resolveRoomId", () => {
   const USER = { id: "00c5fe3b-9dc7-4428-a4e8-1c9f5e426b33" };
@@ -32,7 +32,7 @@ describe("resolveRoomId", () => {
   });
 
   // syncRoomId vem do disco pelo persister, também async. Sem ele não há sala
-  // — o caller trata null como "não abre WebSocket".
+  // O caller trata null como "não abre WebSocket".
   it("devolve null quando resolveu, sem login e sem anon carregado", () => {
     expect(resolveRoomId(true, null, undefined)).toBeNull();
   });
@@ -60,7 +60,7 @@ describe("isTokenExpired", () => {
   });
 
   // O round-trip até o server leva tempo: um token que vence em 2s chega lá
-  // vencido. Por isso a margem — evita a rejeição por milissegundos.
+  // vencido. Por isso a margem, que evita a rejeição por milissegundos.
   it("token prestes a vencer conta como vencido (margem de 5s)", () => {
     expect(isTokenExpired(sessao(AGORA + 2_000), AGORA)).toBe(true);
   });
@@ -74,7 +74,7 @@ describe("isTokenExpired", () => {
     expect(isTokenExpired(s, AGORA, 30_000)).toBe(true);
   });
 
-  // Anônimo não tem o que renovar — dizer "vencido" bloquearia o reconnect
+  // Anônimo não tem o que renovar, e dizer "vencido" bloquearia o reconnect
   // de quem nem usa auth.
   it("sessão ausente nunca está vencida", () => {
     expect(isTokenExpired(null, AGORA)).toBe(false);
@@ -100,7 +100,7 @@ describe("isTokenExpired", () => {
   });
 
   // Regressão específica: `expires_at` do Supabase é em SEGUNDOS. Tratar como
-  // ms daria uma data em 1970 e todo token pareceria vencido — o sync nunca
+  // ms daria uma data em 1970 e todo token pareceria vencido, e o sync nunca
   // reconectaria depois de voltar do background.
   it("interpreta expires_at em segundos, não milissegundos", () => {
     const daquiUmaHora = sessao(AGORA + 3_600_000);
@@ -122,7 +122,7 @@ describe("needsLogin", () => {
   });
 
   // Server inalcançável: o /healthz não respondeu, então o modo é null. Isso
-  // É problema de rede — cair em "sem conexão" está certo.
+  // É problema de rede, e cair em "sem conexão" está certo.
   it("modo desconhecido nunca vira 'precisa entrar'", () => {
     expect(needsLogin(false, null)).toBe(false);
     expect(needsLogin(false, undefined)).toBe(false);

--- a/tests/sync-url.test.js
+++ b/tests/sync-url.test.js
@@ -1,6 +1,6 @@
 // @ts-nocheck -- teste; globals do jest não são tipados (ADR-002)
 // Testa o helper buildSyncUrl (M6 auth fatia C). É o único pedaço puro de
-// infra/sync.js — a lógica de montagem/encoding da URL onde bug moraria
+// infra/sync.js: a lógica de montagem/encoding da URL onde bug moraria
 // (roomId com espaço, JWT com `+`/`=`, mistura de logado/deslogado).
 
 import { buildHealthzUrl, buildSyncUrl } from "../infra/sync-url";
@@ -35,7 +35,7 @@ describe("buildSyncUrl", () => {
   });
 
   test("encoding: caracteres URL-unsafe no roomId viram %XX", () => {
-    // roomId hipotético com espaço + slash — não deve vazar pra URL.
+    // roomId hipotético com espaço + slash, que não deve vazar pra URL.
     const url = buildSyncUrl(BASE, "a b/c", null);
     // encodeURIComponent transforma " " em "%20" e "/" em "%2F".
     expect(url).toBe(`${BASE}/a%20b%2Fc`);
@@ -51,7 +51,7 @@ describe("buildSyncUrl", () => {
   });
 
   test("roomId numérico é aceito (String() coerção)", () => {
-    // useValue pode retornar tipos diferentes conforme a store — proteja o
+    // useValue pode retornar tipos diferentes conforme a store, então proteja o
     // template string de virar `[object Object]` ou `undefined`.
     expect(buildSyncUrl(BASE, 42, null)).toBe(`${BASE}/42`);
   });
@@ -61,7 +61,7 @@ describe("buildSyncUrl", () => {
 
 // O client consulta o /healthz pra saber se a recusa do WS foi política
 // (AUTH_MODE=required) ou rede. Errar o esquema aqui faz a sondagem falhar
-// sempre, e falha de sondagem é lida como "offline" — ou seja, o app voltaria
+// sempre, e falha de sondagem é lida como "offline", ou seja o app voltaria
 // silenciosamente a mentir pro tester sem login.
 describe("buildHealthzUrl", () => {
   it("converte wss:// em https://", () => {


### PR DESCRIPTION
Closes #318, e com ele a #302 inteira.

65 arquivos. A fatia era `components`, `app` e `tests`, e cresceu por um motivo que vale contar.

## Achei uma cauda que nunca tinha sido contada

Ao conferir o repo inteiro no fim, apareceram **62 ocorrências em 18 arquivos de raiz e configuração**: os quatro workflows, `CONTRIBUTING.md`, `README.md`, `eslint.config.mjs`, `tailwind.config.js`, `app.config.js`, `jest.config.js`, `.gitignore`, `.env.example`, os SVG de origem dos ícones, e o próprio hook que barra commit em português.

Nenhum levantamento por área tinha alcançado esses arquivos, porque todos os meus contadores olhavam `docs/`, `constants/`, `infra/`, `components/`, `app/`, `server/`, `scripts/` e `tests/`. Incluí aqui em vez de abrir uma fatia órfã.

## Duas strings visíveis escaparam da fatia 1

Este é um erro meu que vale explicar, porque a fatia 1 se declarava completa:

- **`components/UpdateBanner.jsx`**: "Atualização pronta — toque para reiniciar"
- **`app/feedback.jsx`**: "Conta aqui — abrimos o chamado pra você automaticamente"

As duas são **nó de texto JSX**, e o grep que usei na fatia 1 exigia o caractere dentro de aspas. Texto JSX não tem aspas, então passaram batido, mesmo eu tendo corrigido o `accessibilityLabel` do banner que fica três linhas acima.

A barreira da #310 pega esse caso, porque olha a linha inteira sem depender de contexto sintático. Ou seja, a barreira já era mais rigorosa que a varredura que a motivou.

## Dois casos ficam, de propósito

**`tests/roadmap.test.js`** mantém `## M1 — Trabalho real` no fixture. O `MILESTONE_RE` aceita `[:\s—–-]`, e o doc real migrou pra dois-pontos na #307. Este fixture é o que mantém o ramo do travessão coberto, e trocar ali apagaria a cobertura em silêncio. Deixei uma nota no arquivo explicando, pra ninguém "consertar" depois.

**O glifo de célula vazia** em `docs/02-escopo-mvp.md` e no `server/README.md`.

## Onde a #302 termina

Sobram **19 ocorrências** no repo, todas intencionais:

| | |
|---|---|
| glifo de tabela | 2 |
| fixture do parser | 1 |
| arquivos da própria barreira | 16 |

De 892 para 19, e o que entra a partir de agora passa pelo job `Texto`.

## Verificação

292 testes verdes, eslint, prettier e tsc limpos, e a barreira passa no próprio diff.

## Como validar

Duas strings mudaram na tela:

1. **Banner de atualização**: forçar um OTA e ver "Atualização pronta. Toque para reiniciar"
2. **Tela de feedback**: o subtítulo abaixo de "Enviar feedback"

O resto é comentário e configuração.